### PR TITLE
Retrieving a TOC from HTML files

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,23 +427,24 @@
 			<section id="table-of-contents">
 				<h3>Table of Contents</h3>
 
-				<p>If the table of contents is not specified in the <a href="#manifest">manifest</a>, the user agent MUST make an attempt to retrive one as follows:</p>
 
-				<ol>
-					<li>
-						Check, among the <a>primary resources</a> of the publication, an HTML resource with basename <code>index.html</code> if it exists, and extract a <a>TOC navigation element</a> from the resource if present;
-					</li>
-					<li>
-						otherwise, locate the first HTML resource among the <a>primary resources</a> in the order provided by the <a>default reading order</a> that also includes a <a>TOC navigation element</a>, and extract it.
-					</li>
-				</ol>
-
-				<p>If such <a>TOC navigation element</a> is found, its content provides the table of contents information for the Web Publication infoset. If several of those are found, only the first one is considered.</p>
-
+				<p>The table of contents is recommended in the infoset.</p>
+				
 				<p>
-					A <dfn>TOC navigation element</dfn> is an HTML <code>nav</code> element with the <code>role</code> attribute set to <code>doc-toc</code>&nbsp;[[!dpub-aria-1.0]].</p>
+					An author MAY omit the table of contents from the <a href="#manifest">manifest</a> if it is included in an HTML <code>nav</code> element identified by the role <code>doc-toc</code>&nbsp;[[!dpub-aria-1.0]]. 
+					This <code>nav</code> element MUST be in a file named <code>index.html</code> or in the first HTML resource in the <a>default reading order</a> (if applicable). In this case, the user agent MUST use this navigation element as the table of contents for the Web Publication.
+				</p>
+				
+				<p>
+					If a user agent requires a table of contents and one is not specified, it MAY provide one of its own making. This specification does not mandate how such a table of contents is created. The user agent might:
 				</p>
 
+				<ol>
+					<li>attempt to locate table of contents nav element in a subsequent primary resource in the default reading order;</li>
+					<li>use the titles of the primary resources in the default reading order;</li>
+					<li>calculate a table of contents using its own algorithms.</li>
+				</ol>
+				
 				<p class=note>
 					This process may not yield a table of contents, which is in line with the fact that a table of contents is not a required information in the <a href="#infoset-req">WP infoset</a>.
 				</p>

--- a/index.html
+++ b/index.html
@@ -421,12 +421,47 @@
 				<h3>Default Reading Order</h3>
 
 				<p>The default reading order MUST include at least one <a>primary resource</a>.</p>
+				
 			</section>
 
 			<section id="table-of-contents">
 				<h3>Table of Contents</h3>
 
-				<div class="ednote">Placeholder for identifying table of contents - whether embedded or by reference.</div>
+				<p>If the table of contents is not specified in the <a href="#manifest">manifest</a>, the user agent MUST make an attempt to retrive one as follows:</p>
+
+				<ol>
+					<li>
+						Check, among the <a>primary resources</a> of the publication, an HTML resource with basename <code>index.html</code> if it exists, and extract a <a>TOC navigation element</a> from the resource if present;
+					</li>
+					<li>
+						otherwise, locate the first HTML resource among the <a>primary resources</a> in the order provided by the <a>default reading order</a> that also includes a <a>TOC navigation element</a>, and extract it.
+					</li>
+				</ol>
+
+				<p>If such <a>TOC navigation element</a> is found, its content provides the table of contents information for the Web Publication infoset. If several of those are found, only the first one is considered.</p>
+
+				<p>
+					A <dfn>TOC navigation element</dfn> is an HTML <code>nav</code> element with the <code>role</code> attribute set to <code>doc-toc</code>&nbsp;[[!dpub-aria-1.0]].</p>
+				</p>
+
+				<p class=note>
+					This process may not yield a table of contents, which is in line with the fact that a table of contents is not a required information in the <a href="#infoset-req">WP infoset</a>.
+				</p>
+
+				<p class="issue">
+					This question arises only if this mechanism is accepted: the question is whether a <a>TOC navigation element</a> can refer, via links, to any resource that is <em>not</em> listed as a <a>primary resource</a>.
+				</p>
+
+				<p class=ednote>
+					The issue of using the HTML <code>nav</code> element as a possible encoding of the table of contents is mentioned or explicitly addressed in a number of issues listed below.
+				</p>
+
+				<p class="issue" data-number=26></p>
+				<p class="issue" data-number=35>Define the primary resources of a WP to be the files referenced in the first</p>
+				<p class="issue" data-number=36></p>
+				<p class="issue" data-number=39>There is a consensus that a Web publication must have a reading order (a list of primary resources) and must/should have a table of contents (ToC) (the main navigation entry point).</p>
+				
+
 			</section>
 		</section>
 		<section id="manifest">


### PR DESCRIPTION
This is a spin-off from #46, containing the proposed changes on finding a TOC in HTML files if not explicit in the manifest.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/wpub/toc-from-html.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/wpub/9718f6a...b30529c.html)