### PR TITLE
genericize resource naming

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,8 +189,8 @@
 					<dt><dfn data-lt="Manifests">Manifest</dfn></dt>
 					<dd>
 						<p>A manifest represents structured information about a <a>Web Publication</a>, such as informative
-							metadata, a list of all <a data-lt="primary resource">primary</a> and <a>secondary resources</a>,
-							and a <a>default reading order</a>.</p>
+							metadata, a <a href="#wp-resources">list of all resources</a>, and a <a>default reading
+							order</a>.</p>
 					</dd>
 
 					<dt><dfn>Non-empty</dfn></dt>
@@ -198,17 +198,6 @@
 						<p>For the purposes of this specification, non-empty is used to refer to an element, attribute or
 							property whose text content or value consists of one or more characters after whitespace
 							normalization, where whitespace normalization rules are defined per the host format.</p>
-					</dd>
-
-					<dt><dfn data-lt="Primary Resources">Primary Resource</dfn></dt>
-					<dd>
-						<p>A primary resource is one that is listed in the <a>default reading order</a>.</p>
-					</dd>
-
-					<dt><dfn data-lt="Secondary Resources">Secondary Resource</dfn></dt>
-					<dd>
-						<p>A secondary resource is one that is required for the processing or rendering of a <a>Web
-								Publication</a>.</p>
 					</dd>
 
 					<dt><dfn>URL</dfn></dt>
@@ -222,8 +211,8 @@
 
 					<dt><dfn data-lt="Web Publications|Web Publication's">Web Publication</dfn></dt>
 					<dd>
-						<p>A Web Publication is a collection of one or more <a>primary resources</a>, organized together
-							through a <a>manifest</a> into a single logical work with a <a>default reading order</a>. The Web
+						<p>A Web Publication is a collection of one or more resources, organized together through a
+								<a>manifest</a> into a single logical work with a <a>default reading order</a>. The Web
 							Publication is uniquely identifiable and presentable using Open Web Platform technologies.</p>
 					</dd>
 				</dl>
@@ -323,7 +312,7 @@
 
 				<ul>
 					<li>use the first <a>non-empty</a>
-						<code>title</code> element found in a primary resource in the default reading order;</li>
+						<code>title</code> element found in the <a>default reading order</a>;</li>
 					<li>provide a language-specific placeholder title (e.g., 'Untitled Publication');</li>
 					<li>use the URL of the manifest;</li>
 					<li>calculate a title using its own algorithm.</li>
@@ -360,7 +349,7 @@
 
 				<ul>
 					<li>use the <a>non-empty</a> language declaration of the manifest;</li>
-					<li>use the first non-empty language declaration for a <a>primary resource</a>;</li>
+					<li>use the first non-empty language declaration found in the <a>default reading order</a>;</li>
 					<li>calculate the language using its own algorithm.</li>
 				</ul>
 
@@ -417,27 +406,27 @@
 			<section id="wp-resources">
 				<h3>Resources</h3>
 
-				<p>The infoset MUST include a list of the <a>primary resources</a> of the Web Publication.</p>
-
-				<p>The infoset also SHOULD list secondary resources, although the list is not required to be exhaustive.</p>
+				<p>The infoset MUST include a list of the Web Publication's resources, although the list is not required to
+					be exhaustive. Resources in the <a>default reading order</a> MUST be included in this list.</p>
 
 				<p class="issue" data-number="22">The discussion led to the question whether the manifest/infoset MUST list
-					all <a>Secondary resources</a> or not. In this sense, this became a duplicate of <a
+					all resources or not. In this sense, this became a duplicate of <a
 						href="https://github.com/w3c/wpub/issues/23">issue #23</a> ended up at the same question.</p>
 
-				<p class="issue" data-number="23">The question is whether the manifest/infoset MUST list all <a>Secondary
-						resources</a> or not.</p>
+				<p class="issue" data-number="23">The question is whether the manifest/infoset MUST list all resources or
+					not.</p>
 			</section>
 
 			<section id="wp-default-reading-order">
 				<h3>Default Reading Order</h3>
 
-				<p>The <dfn>default reading order</dfn> is a specific progression through the <a>primary resources</a>.</p>
+				<p>The <dfn>default reading order</dfn> is a specific progression through a set of Web Publication
+					resources.</p>
 
 				<p>A user might follow alternative pathways through the content, but in the absence of such interaction the
-					default reading order defines the expected progression from one primary resource to the next.</p>
+					default reading order defines the expected progression from one resource to the next.</p>
 
-				<p>The default reading order MUST include at least one <a>primary resource</a>.</p>
+				<p>The default reading order MUST include at least one resource.</p>
 
 				<p>The default reading order is either specified directly in the manifest or a link is provided to an
 					[[!html]] <code>nav</code> element whose list of links are processed to create one.</p>
@@ -463,12 +452,11 @@
 				</ul>
 
 				<p class="issue" data-number="26"></p>
-				<p class="issue" data-number="35">Define the primary resources of a Web Publication to be the files
+				<p class="issue" data-number="35">Define the default reading order of a Web Publication to be the files
 					referenced in the first</p>
 				<p class="issue" data-number="36"></p>
-				<p class="issue" data-number="39">There is a consensus that a Web Publication must have a reading order (a
-					list of primary resources) and must/should have a table of contents (the main navigation entry
-					point).</p>
+				<p class="issue" data-number="39">There is a consensus that a Web Publication must have a reading order and
+					must/should have a table of contents (the main navigation entry point).</p>
 			</section>
 
 			<section id="wp-table-of-contents">
@@ -476,7 +464,7 @@
 
 				<p>The table of contents provides access to major sections of the Web Publication. There are no requirements
 					on the completeness of the table of contents, except that, when specified, it MUST link to at least one
-					primary resource.</p>
+					resource in the <a>default reading order</a>.</p>
 
 				<p>The table of contents is either specified directly in the manifest or a link is provided to an [[!html]]
 						<code>nav</code> element containing one.</p>
@@ -485,26 +473,26 @@
 					specification does not mandate how such a table of contents is created. The user agent might: </p>
 
 				<ol>
-					<li>attempt to locate a table of contents in a primary resource (e.g., that has the <code>role</code>
-						attribute value <code>doc-toc</code>);</li>
-					<li>use the titles of the primary resources in the default reading order;</li>
+					<li>attempt to locate a table of contents in the default reading order (e.g., an HTML document with a
+							<code>nav</code> element that has the <code>role</code> attribute value
+						<code>doc-toc</code>);</li>
+					<li>use the titles of resources in the default reading order;</li>
 					<li>calculate a table of contents using its own algorithms.</li>
 				</ol>
 
 				<p class="issue">This question arises only if this mechanism is accepted: the question is whether a table of
-					contents navigation element can refer, via links, to any resource that is <em>not</em> listed as a
-						<a>primary resource</a>.</p>
+					contents navigation element can refer, via links, to any resource that is <em>not</em> listed in the
+					default reading order.</p>
 
 				<p class="ednote">The issue of using the HTML <code>nav</code> element as a possible encoding of the table of
 					contents is mentioned or explicitly addressed in a number of issues listed below.</p>
 
 				<p class="issue" data-number="26"></p>
-				<p class="issue" data-number="35">Define the primary resources of a Web Publication to be the files
-					referenced in the first</p>
+				<p class="issue" data-number="35">Define the resources in the default reading order of a Web Publication to
+					be the files referenced in the first</p>
 				<p class="issue" data-number="36"></p>
-				<p class="issue" data-number="39">There is a consensus that a Web Publication must have a reading order (a
-					list of primary resources) and must/should have a table of contents (the main navigation entry
-					point).</p>
+				<p class="issue" data-number="39">There is a consensus that a Web Publication must have a reading order and
+					must/should have a table of contents (the main navigation entry point).</p>
 			</section>
 		</section>
 		<section id="manifest">
@@ -540,13 +528,13 @@
 				<p class="issue" data-number="7">Format of the Manifest (JSON, XML, embedded into HTML, etc.).</p>
 				<p class="issue" data-number="25"></p>
 				<p class="issue" data-number="26">Should the table of contents be a separate HTML file or is the listing of
-					primary resources in the manifest an implicit table of contents?</p>
+					resources in the default reading order an implicit table of contents?</p>
 				<p class="issue" data-number="32"></p>
 			</section>
 			<section id="manifest-linking">
 				<h2>Linking to a Manifest</h2>
 
-				<div class="ednote">Placeholder for how primary resources identify they belong to a publication.</div>
+				<div class="ednote">Placeholder for how resources identify they belong to a publication.</div>
 
 				<p class="issue" data-number="13">If we have a collection of information about a web publication as a whole
 					("manifest") that exists separately from most of the publication's resources, we need to find a way to


### PR DESCRIPTION
Here's a proposal to end #55 that removes the obvious contradictions of the current primary/secondary. It replaces them with nothing but "resources" and mention of the default reading order, when pertinent.

There's nothing yet that necessitates more complex naming, so let's leave the naming be until there is.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mattgarrish/wpub/master.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/wpub/ac65fdc...mattgarrish:07a349c.html)