### PR TITLE
Remove extra "a" in definition of identifier

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
 				<dl>
 					<dt><dfn>Identifier</dfn></dt>
 					<dd>
-						<p>An identifier is metadata that can be used to refer to a <a class="externalDFN"
+						<p>An identifier is metadata that can be used to refer to <a class="externalDFN"
 								href="https://www.w3.org/TR/publishing-linking/#dfn-web-content">Web Content</a> in a
 							persistent and unambiguous manner. URLs, URNs, DOIs, ISBNs, or PURLs are all examples of
 							persistent identifiers frequently used in publishing.</p>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/dauwhe/wpub/master.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/wpub/24cc654...dauwhe:96e37f9.html)