### PR TITLE
rewrite abstract to be both narrower in scope and more descriptive

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,11 +88,11 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This specification defines a collection of information that describes the structure and metadata of web publications, 
-			so that user agents or developers may create user experiences well-suited to reading publications. 
-			This information includes the default reading order of the primary resources, a list of secondary resources, 
-			and metadata. This is necessary to enable such behaviors as 
-			sequential navigation and offline reading.</p>
+			<p>This specification defines a collection of information that describes the structure of web publications, 
+			so that user agents or developers may create user experiences well-suited to reading publications, 
+			such as sequential navigation and offline reading.
+			This information includes the default reading order, a list of resources, 
+			and publication-wide metadata.</p>
 		</section>
 		<section id="sotd">
 			<p>This first public working draft provides a preliminary outline of a Web Publication. Many details are under

--- a/index.html
+++ b/index.html
@@ -88,8 +88,15 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This specification defines digital publishing based on a fully native representation of publications within
-				the Open Web Platform.</p>
+			<p>This specification defines an infoset that describes the structure and metadata of web publications, 
+			so that user agents or developers may create user experiences well-suited to reading publications. 
+			This infoset includes the default reading order of the primary resources, a list of secondary resources, 
+			and metadata. This information is necessary to enable such behaviors as 
+			sequential navigation and offline reading.</p>
+
+			This specification also defines a serialization of this infoset in the form of a manifest, 
+			and defines rules for user agents to infer missing manifest information 
+			based on other publication resources.</p>
 		</section>
 		<section id="sotd">
 			<p>This first public working draft provides a preliminary outline of a Web Publication. Many details are under

--- a/index.html
+++ b/index.html
@@ -88,13 +88,13 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This specification defines an infoset that describes the structure and metadata of web publications, 
+			<p>This specification defines a collection of information that describes the structure and metadata of web publications, 
 			so that user agents or developers may create user experiences well-suited to reading publications. 
-			This infoset includes the default reading order of the primary resources, a list of secondary resources, 
-			and metadata. This information is necessary to enable such behaviors as 
+			This information includes the default reading order of the primary resources, a list of secondary resources, 
+			and metadata. This is necessary to enable such behaviors as 
 			sequential navigation and offline reading.</p>
 
-			This specification also defines a serialization of this infoset in the form of a manifest, 
+			This specification also defines a serialization of this information in the form of a manifest, 
 			and defines rules for user agents to infer missing manifest information 
 			based on other publication resources.</p>
 		</section>

--- a/index.html
+++ b/index.html
@@ -93,10 +93,6 @@
 			This information includes the default reading order of the primary resources, a list of secondary resources, 
 			and metadata. This is necessary to enable such behaviors as 
 			sequential navigation and offline reading.</p>
-
-			This specification also defines a serialization of this information in the form of a manifest, 
-			and defines rules for user agents to infer missing manifest information 
-			based on other publication resources.</p>
 		</section>
 		<section id="sotd">
 			<p>This first public working draft provides a preliminary outline of a Web Publication. Many details are under


### PR DESCRIPTION
The abstract is the first thing people might see when they read the WPUB spec. The current abstract is very general, and doesn’t quite state what we’re actually doing in the spec. I’ve written some new language which probably goes too far in the other direction. I’ve modeled this a bit on the [web app manifest](https://www.w3.org/TR/appmanifest/) abstract, which makes clear that the goal is to provide the information necessary for developers and/or user agents to enable new functionality. The hope is that this might assuage the fears of browser vendors, etc. who were worried about the scope of our charter. 

Feel free to brutally edit or reject the PR; I just think it’s useful for us to start discussing this language.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/dauwhe/wpub/master.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/wpub/96e37f9...dauwhe:dc3cbad.html)