### PR TITLE
Manifest linking

### DIFF
--- a/index.html
+++ b/index.html
@@ -578,15 +578,47 @@
 			<section id="manifest-linking">
 				<h2>Linking to a Manifest</h2>
 
-				<div class="ednote">Placeholder for how resources identify they belong to a publication.</div>
+				<p>Providing a link from a resource to its manifest allows a user agent to discover that a Web Publication is
+					available. The inclusion of links is not always possible, however. For example, when the resource is
+					hosted by a third party, or when access to modify HTTP headers is restricted.</p>
+
+				<p>The inclusion of links from resources to their manifests is therefore RECOMMENDED.</p>
+
+				<p>Links MUST take one or both of the following forms:</p>
+
+				<ul>
+					<li><p>An HTTP Link header field with its <code>rel</code> parameter set to the value
+						"<code>publication</code>".</p>
+						<pre class="example">Link: &lt;https://example.com/webpub/>; rel=publication</pre>
+					</li>
+					<li><p>An [[!HTML]] <code>link</code> element with its <code>rel</code> attribute set to the value
+						"<code>publication</code>".</p>
+						<pre class="example">&lt;link href="https://example.com/webpub/" rel="publication"/></pre>
+					</li>
+				</ul>
+
+				<p>A user agent is only required to process the first <code>publication</code> link encountered, so a
+					resource SHOULD NOT link to more than one Web Publication.</p>
+
+				<!--
+					<p>Each link SHOULD include a <code>title</code> field or attribute with a human-readable label, typically
+						the <a href="#wp-title">title</a> of the Web Publication.</p>
+					
+					<p>A resource MAY provide links to more than one manifest if it belongs to multiple Web Publications.</p>
+
+					<p class="note">The order of the links is not meaningful, but might be used by user agents to order a default
+						list of selections. Refer to <a href="#lifecycle-obtain-manifest"></a> for more information.</p>
+				-->
 
 				<p class="issue" data-number="13">If we have a collection of information about a web publication as a whole
 					("manifest") that exists separately from most of the publication's resources, we need to find a way to
 					associate the manifest with the other publication resources.</p>
+
+				<p class="issue" data-number="76"></p>
 			</section>
 
 			<section id="manifest-linking-from">
-				<h3>Linking <em>from</em> a Manifest</h3>
+				<h3>Linking from a Manifest</h3>
 
 				<p>The manifest serialization MUST provide a general linking mechanism for defining a relationship between
 					the Web Publication and other resources on the Web as well as the type of those relationships.</p>
@@ -624,36 +656,6 @@
 					coding and effort.</p>
 
 				<p class="issue" data-number="67"></p>
-			</section>
-		</section>
-		<section id="lifecycle">
-			<h2>Establishing a Web Publication</h2>
-
-			<p class="issue" data-number="32">Need to determine intersection between web pubs and the lifecycle of a web
-				app.</p>
-
-			<section id="lifecyle-obtain-manifest">
-				<h3>Obtaining the manifest</h3>
-
-				<p class="ednote">Placeholder for UA discovering and obtaining a manifest.</p>
-			</section>
-
-			<section id="lifecycle-process-manifest">
-				<h3>Processing the manifest</h3>
-
-				<p class="ednote">Placeholder for UA processing of manifest and creation of infoset.</p>
-			</section>
-
-			<section id="lifecycle-intiate-wp">
-				<h3>Intiating the Web Publication</h3>
-
-				<p class="ednote">Placeholder for UA initiating an enhanced reading experience.</p>
-			</section>
-
-			<section id="lifecycle-update-wp">
-				<h3>Updating the Web Publication</h3>
-
-				<p class="ednote">Placeholder for UA updating manifest and/or WP content.</p>
 			</section>
 		</section>
 		<section id="wp-enhancements">

--- a/index.html
+++ b/index.html
@@ -600,16 +600,6 @@
 				<p>A user agent is only required to process the first <code>publication</code> link encountered, so a
 					resource SHOULD NOT link to more than one Web Publication.</p>
 
-				<!--
-					<p>Each link SHOULD include a <code>title</code> field or attribute with a human-readable label, typically
-						the <a href="#wp-title">title</a> of the Web Publication.</p>
-					
-					<p>A resource MAY provide links to more than one manifest if it belongs to multiple Web Publications.</p>
-
-					<p class="note">The order of the links is not meaningful, but might be used by user agents to order a default
-						list of selections. Refer to <a href="#lifecycle-obtain-manifest"></a> for more information.</p>
-				-->
-
 				<p class="issue" data-number="13">If we have a collection of information about a web publication as a whole
 					("manifest") that exists separately from most of the publication's resources, we need to find a way to
 					associate the manifest with the other publication resources.</p>

--- a/index.html
+++ b/index.html
@@ -587,7 +587,7 @@
 				<p>Links MUST take one or both of the following forms:</p>
 
 				<ul>
-					<li><p>An HTTP Link header field with its <code>rel</code> parameter set to the value
+					<li><p>An HTTP Link header field&#160;[[!RFC5988]] with its <code>rel</code> parameter set to the value
 						"<code>publication</code>".</p>
 						<pre class="example">Link: &lt;https://example.com/webpub/>; rel=publication</pre>
 					</li>

--- a/index.html
+++ b/index.html
@@ -588,11 +588,11 @@
 
 				<ul>
 					<li><p>An HTTP Link header field&#160;[[!RFC5988]] with its <code>rel</code> parameter set to the value
-						"<code>publication</code>".</p>
+								"<code>publication</code>".</p>
 						<pre class="example">Link: &lt;https://example.com/webpub/>; rel=publication</pre>
 					</li>
 					<li><p>An [[!HTML]] <code>link</code> element with its <code>rel</code> attribute set to the value
-						"<code>publication</code>".</p>
+								"<code>publication</code>".</p>
 						<pre class="example">&lt;link href="https://example.com/webpub/" rel="publication"/></pre>
 					</li>
 				</ul>
@@ -603,6 +603,11 @@
 				<p class="issue" data-number="13">If we have a collection of information about a web publication as a whole
 					("manifest") that exists separately from most of the publication's resources, we need to find a way to
 					associate the manifest with the other publication resources.</p>
+
+				<p class="issue" data-number="32">How linking to a manifest is done may change depending on whether
+					integration with [[AppManifest]] is feasible and beneficial. For a list of differences in linking
+					approaches, refer to the <a href="https://github.com/w3c/wpub/wiki/Options-for-Processing-a-Manifest"
+						>wiki analysis</a>.</p>
 
 				<p class="issue" data-number="76"></p>
 			</section>


### PR DESCRIPTION
This PR removes section 5 on initiating, based on the discussions on the last call.

It retains a section on linking to a manifest that I wrote while working on 5.  There are issues that need further discussion, of course. It does not disallow linking to multiple manifests, for example, but does not require processing of more than the first link found. The relationship "publication" may also change depending on discussions. It is used to avoid comparisons with Web App Manifest until that issue is fully resolved.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/wpub/manifest-linking.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/wpub/159950b...f1450f0.html)