### PR TITLE
media type registration for manifest file

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,6 +566,14 @@
 				<div class="ednote">Placeholder for how a manifest declares it describes a web publication.</div>
 			</section>
 
+			<section id="manifest-media-type">
+				<h3>Media Type</h3>
+				
+				<p>The media type for a Web Publication manifest is:</p>
+				
+				<pre><code>application/publication+json</code></pre>
+			</section>
+			
 			<section id="manifest-serialization">
 				<h3>Serialization</h3>
 
@@ -706,6 +714,57 @@
 			<h2>Privacy</h2>
 
 			<div class="ednote">Placeholder for privacy issues.</div>
+		</section>
+		<section id="app-manifest-media-type-registration" class="appendix">
+			<h2>Media Type Registration</h2>
+			
+			<p>This registration is for community review and will be submitted to the IESG for review, approval, and
+				registration with IANA.</p>
+			
+			<dl>
+				<dt>Type name:</dt>
+				<dd>application</dd>
+				<dt>Subtype name:</dt>
+				<dd>publication+json</dd>
+				<dt>Required parameters:</dt>
+				<dd>N/A</dd>
+				<dt>Optional parameters:</dt>
+				<dd>N/A</dd>
+				<dt>Encoding considerations:</dt>
+				<dd>Encoding considerations are identical to those specified for the "application/json" media type. See
+					[RFC7159].</dd>
+				<dt>Security and privacy considerations:</dt>
+				<dd>
+					<p>TBD</p>
+				</dd>
+				<dt>Applications that use this media type:</dt>
+				<dd>Web browsers</dd>
+				<dt>Additional information:</dt>
+				<dd>
+					<dl>
+						<dt>Magic number(s):</dt>
+						<dd>N/A</dd>
+						<dt>File extension(s):</dt>
+						<dd>.webpub</dd>
+						<dt>Macintosh file type code(s):</dt>
+						<dd>TEXT</dd>
+					</dl>
+				</dd>
+				<dt>Person &amp; email address to contact for further information:</dt>
+				<dd>The <a href="https://www.w3.org/Pubishing/WG/" rel="nofollow">Publishing Working Group</a> can be
+					contacted at <a href="https://lists.w3.org/Archives/Public/public-publ-wg/" rel="nofollow"
+						>public-publ-wg@w3.org</a>.</dd>
+				<dt>Intended usage:</dt>
+				<dd>COMMON</dd>
+				<dt>Restrictions on usage:</dt>
+				<dd>none</dd>
+				<dt>Author:</dt>
+				<dd>
+					<abbr title="World Wide Web Consortium">W3C</abbr>'s Publishing Working Group.</dd>
+				<dt>Change controller:</dt>
+				<dd>
+					<abbr title="World Wide Web Consortium">W3C</abbr>.</dd>
+			</dl>
 		</section>
 		<section id="ack" data-include="common/html/acknowledgements.html" data-include-replace="true"></section>
 	</body>


### PR DESCRIPTION
I'll say up front, feel free to nix this. It may be a bit premature.

In any case, in looking at section 5 this was another of the ancillary pieces that looks like it will be needed. It still needs work (agreement on media type and extension, plus security considerations), but didn't want to toss it without offering it first.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/wpub/media-reg.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/wpub/159950b...4e1f985.html)