### PR TITLE
add link to privacy policy as an infoset item

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,13 +585,13 @@
 
 				<p>Users often have the legal right to know and control what information is collected about them, how such
 					information is stored and for how long, whether it is personally identifiable, and how it can be
-					expunged. Including a privacy policy statement that details all such privacy concerns is consequently a
-					necessary part of publishing any Web Publication. Even if no information is collected, such a declaration
-					increases the trust users have with the content.</p>
+					expunged. Including a statement that addresses all such privacy concerns is consequently an important
+					part of publishing Web Publications. Even if no information is collected, such a declaration increases
+					the trust users have with the content.</p>
 
-				<p>To address this important concern, the infoset allows a link to be provided to a privacy policy. The
-					privacy policy does not have to be a resource of the Web Publication, although including it as a resource
-					is RECOMMENDED.</p>
+				<p>To address this concern, the infoset allows a link to be provided to a privacy policy. The privacy policy
+					does not have to be a resource of the Web Publication, although including it as a resource is
+					RECOMMENDED.</p>
 
 				<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
 					Publications.</p>

--- a/index.html
+++ b/index.html
@@ -331,6 +331,7 @@
 					<li>The <a href="#wp-pub-date">publication date</a>.</li>
 					<li>The <a href="#wp-mod-date">modification date</a>.</li>
 					<li><a href="#wp-a11y-meta">Accessibility metadata</a>.</li>
+					<li>A link to a <a href="#wp-privacy">privacy policy</a></li>
 				</ul>
 
 				<p class="ednote">These requirements reflect the current minimum consensus, though a number of issues remain
@@ -577,6 +578,23 @@
 
 				<p>Accessibility metadata allows discovery of features and affordances of the Web Publication that enable its
 					usability by users with specific reading requirements and needs.</p>
+			</section>
+
+			<section id="wp-privacy">
+				<h3>Privacy Policy</h3>
+
+				<p>Users often have the legal right to know and control what information is collected about them, how such
+					information is stored and for how long, whether it is personally identifiable, and how it can be
+					expunged. Including a privacy policy statement that details all such privacy concerns is consequently a
+					necessary part of publishing any Web Publication. Even if no information is collected, such a declaration
+					increases the trust users have with the content.</p>
+
+				<p>To address this important concern, the infoset allows a link to be provided to a privacy policy. The
+					privacy policy does not have to be a resource of the Web Publication, although including it as a resource
+					is RECOMMENDED.</p>
+
+				<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
+					Publications.</p>
 			</section>
 
 			<section id="wp-extensibility">


### PR DESCRIPTION
Based on the discussions at TPAC, here's a first attempt at adding a link to a privacy policy as a recommended property in the infoset.

Comments welcome, as always.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/wpub/infoset-privacy.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/wpub/fe59e27...05a8a80.html)