### PR TITLE
clarify in scope the intent to facilitate different UA models

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,6 +201,15 @@
 
 				<p>Further, this specification does not attempt to constrain the nature of a Web Publication: any type of
 					work that can be represented on the Web constitutes a potential Web Publication.</p>
+
+				<p>The specification is also intended to facilitate different user agent architectures for the consumption of
+					Web Publications. While a primary goal is that traditional Web user agents (browsers) will be able to
+					consume Web Publications, this should not limit the capabilities of any other possible type of user agent
+					(e.g., applications, whether standalone or running within a user agent, or even Web Publications that
+					include their own user interface). As a result, the specification does not attempt to architect required
+					solutions for situations whose expected outcome will vary depending on the nature of the user agent and
+					the expectations of the user (e.g., how to prompt to initiate a Web Publication, or at what point or how
+					much of a Web Publication to cache for offline use).</p>
 			</section>
 
 			<section id="terminology">


### PR DESCRIPTION
Not asked for, but this seems to be a question we realize we're all struggling to resolve in our minds as we consider how initiation and consumption of web publications occurs.

I think it would be good to say something about staying open to different models, but won't shed any tears if it passes a short unloved life and disappears.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/wpub/target-ua.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/wpub/fe59e27...38bdbad.html)