### PR TITLE
add construction section

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,8 +278,8 @@
 					<dt><dfn data-lt="Manifests">Manifest</dfn></dt>
 					<dd>
 						<p>A manifest represents structured information about a <a>Web Publication</a>, such as informative
-							metadata, a <a href="#wp-resources">list of all resources</a>, and a <a>default reading
-							order</a>.</p>
+							metadata, a <a href="#wp-resource-list">list of all resources</a>, and a <a>default reading
+								order</a>.</p>
 					</dd>
 
 					<dt><dfn>Non-empty</dfn></dt>
@@ -369,7 +369,7 @@
 
 				<ul>
 					<li>The <a href="#wp-address">address</a> of the Web Publication.</li>
-					<li>The <a href="#wp-resources">Web Publication resources</a>.</li>
+					<li>A <a href="#wp-resource-list">list of resources</a>.</li>
 					<li>The <a href="#wp-default-reading-order">default reading order</a> of the Web Publication.</li>
 				</ul>
 
@@ -503,8 +503,8 @@
 					[[link-relation]].</div>
 			</section>
 
-			<section id="wp-resources">
-				<h3>Resources</h3>
+			<section id="wp-resource-list">
+				<h3>Resource List</h3>
 
 				<p>The <a>infoset</a> MUST include a list of the Web Publication's resources, although the list is not
 					required to be exhaustive. Resources in the <a>default reading order</a> MUST be included in this
@@ -583,7 +583,7 @@
 					<li>calculate a table of contents using its own algorithms.</li>
 				</ol>
 
-				<p class=ednote>This section should be brought in sync with the section on <a>landing page</a>.</p>
+				<p class="ednote">This section should be brought in sync with the section on <a>landing page</a>.</p>
 
 				<p class="issue" data-number="9">The question is whether the manifest/infoset needs to provide navigation, or
 					whether such mechanisms belong in the content.</p>
@@ -705,43 +705,6 @@
 				<p class="issue" data-number="32"></p>
 			</section>
 
-			<section id="manifest-linking">
-				<h2>Linking to a Manifest</h2>
-
-				<p>Providing a link from a resource to its manifest allows a user agent to discover that a Web Publication is
-					available. Links MUST take one or both of the following forms:</p>
-
-				<ul>
-					<li><p>An HTTP Link header field&#160;[[!rfc5988]] with its <code>rel</code> parameter set to the value
-								"<code>publication</code>".</p>
-						<pre class="example">Link: &lt;https://example.com/webpub/>; rel=publication</pre>
-					</li>
-					<li><p>An [[!html]] <code>link</code> element with its <code>rel</code> attribute set to the value
-								"<code>publication</code>".</p>
-						<pre class="example">&lt;link href="https://example.com/webpub/" rel="publication"/></pre>
-					</li>
-				</ul>
-
-				<p>A resource SHOULD link to one or more Web Publications to which it belongs.</p>
-				
-				<p class="ednote">A resource may link to multiple parent manifests. User agents may
-                                   choose to present one or more alternatives to an end user, or choose a single
-                                   alternative on its own. A user agent may choose to present whichever manifest it
-                                   wishes based upon information that it possesses, even one that is not explicitly
-                                   listed as a parent, e.g. based upon information it calculates or acquires out of
-                                   band. In the absence of a preference by user agent implementors, selection of the
-                                   first manifest listed is suggested as a default.</p>
-
-				<p class="issue" data-number="13">If we have a collection of information about a web publication as a whole
-					("manifest") that exists separately from most of the publication's resources, we need to find a way to
-					associate the manifest with the other publication resources.</p>
-
-				<p class="issue" data-number="32">How linking to a manifest is done may change depending on whether
-					integration with [[appmanifest]] is feasible and beneficial. For a list of differences in linking
-					approaches, refer to the <a href="https://github.com/w3c/wpub/wiki/Options-for-Processing-a-Manifest"
-						>wiki analysis</a>.</p>
-			</section>
-
 			<section id="manifest-linking-from">
 				<h3>Linking from a Manifest</h3>
 
@@ -783,11 +746,76 @@
 				<p class="issue" data-number="67"></p>
 			</section>
 		</section>
+		<section id="wp-structure">
+			<h2>Web Publication Construction</h2>
+
+			<section id="wp-resources">
+				<h2>Resources</h2>
+
+				<p>Web Publications MAY reference resources of any media type, both in the default reading order and as
+					dependencies of other resources.</p>
+
+				<div class="note">
+					<p>When adding resources to a Web Publication, consideration needs to be paid to support in user agents.
+						The use of progressive enhancement techniques and the provision of fallback content, as appropriate,
+						will ensure a more consistent reading experience for users regardless of their preferred user agent.</p>
+				</div>
+			</section>
+
+			<section id="wp-linking">
+				<h2>Linking to a Manifest</h2>
+
+				<p>Providing a link from a resource to its manifest allows a user agent to discover that a Web Publication is
+					available. Links MUST take one or both of the following forms:</p>
+
+				<ul>
+					<li><p>An HTTP Link header field&#160;[[!rfc5988]] with its <code>rel</code> parameter set to the value
+								"<code>publication</code>".</p>
+						<pre class="example">Link: &lt;https://example.com/webpub/>; rel=publication</pre>
+					</li>
+					<li><p>An [[!html]] <code>link</code> element with its <code>rel</code> attribute set to the value
+								"<code>publication</code>".</p>
+						<pre class="example">&lt;link href="https://example.com/webpub/" rel="publication"/></pre>
+					</li>
+				</ul>
+
+				<p>A resource SHOULD link to one or more Web Publications to which it belongs.</p>
+
+				<p class="ednote">A resource may link to multiple parent manifests. User agents may choose to present one or
+					more alternatives to an end user, or choose a single alternative on its own. A user agent may choose to
+					present whichever manifest it wishes based upon information that it possesses, even one that is not
+					explicitly listed as a parent, e.g. based upon information it calculates or acquires out of band. In the
+					absence of a preference by user agent implementors, selection of the first manifest listed is suggested
+					as a default.</p>
+
+				<p class="issue" data-number="13">If we have a collection of information about a web publication as a whole
+					("manifest") that exists separately from most of the publication's resources, we need to find a way to
+					associate the manifest with the other publication resources.</p>
+
+				<p class="issue" data-number="32">How linking to a manifest is done may change depending on whether
+					integration with [[appmanifest]] is feasible and beneficial. For a list of differences in linking
+					approaches, refer to the <a href="https://github.com/w3c/wpub/wiki/Options-for-Processing-a-Manifest"
+						>wiki analysis</a>.</p>
+			</section>
+
+			<section id="wp-landing-page">
+				<h3>Landing Page</h3>
+
+				<p>As described in <a href="#wp-address"></a>, a Web Publication has an <a>address</a> that can be
+					dereferenced. That URL MUST resolve to an [[!HTML]] document that represents the primary entry point for
+					the Web Publication (referred to as the <dfn>landing page</dfn>).</p>
+
+				<p>Unlike other resources, the landing page MUST <a href="#wp-linking">link to the manifest</a> to ensure
+					that user agents can discover the Web Publication.</p>
+
+				<p>To ensure that the Web Publication is consumable in different types of user agents, including those that
+					do not support Web Publications, the landing page SHOULD include an [[!HTML]] serialization of the <a
+						href="#enh-toc">table of contents</a> (see <a href="#wp-table-of-contents"></a> for more
+					information).</p>
+			</section>
+		</section>
 		<section id="wp-lifecycle">
 			<h2>Web Publication Lifecycle</h2>
-
-			<p>As described in <a href="#wp-address"></a>, a Web Publication has an <a>address</a> that can be dereferenced. That URL MUST resolve to an HTML file (referred to as a <dfn>landing page</dfn>), and this HTML file MUST include a link to the <a>manifest</a> as described in <a href="#manifest-linking"></a>. The <a>landing page</a> SHOULD also include an HTML serialization of the <a href="#enh-toc">Table of Content</a>.
-			See <a href="#wp-table-of-contents"></a> for the details of the TOC.</p>
 
 			<div class="ednote">
 				<p>The publishing working group is currently evaluating the best approach for implementing web publications
@@ -904,7 +932,8 @@
 			<section id="enh-search">
 				<h3>Search</h3>
 
-				<p class="ednote">Detail on inter-publication search across multiple resources will be included in a future version.</p>
+				<p class="ednote">Detail on inter-publication search across multiple resources will be included in a future
+					version.</p>
 			</section>
 
 			<section id="Layout">


### PR DESCRIPTION
This is the thought I had after seeing the landing page section. The landing page is more of a content construction section than anything to do with the lifecycle. The section on linking to a manifest was similarly out of place, as it is about a content requirement not the manifest itself.

The one thing new I added was a resources section that says that there are no restrictions on the media types of web publication resources. We've been working under that assumption, but for understanding outside the working group I think we need to be more explicit about this point.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/wpub/construction-section.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/wpub/7806641...feea193.html)