### PR TITLE
various editorial and structural changes

### DIFF
--- a/common/js/biblio.js
+++ b/common/js/biblio.js
@@ -41,7 +41,7 @@ var biblio = {
        ],
        "rawDate": "2017-08",
        "publisher": "IETF",
-       "href": "https://tools.ietf.org/html/draft-vandesompel-identifier-00",
+       "href": "https://tools.ietf.org/html/draft-vandesompel-identifier-00"
     },
     "cfi": {
         "authors" : [
@@ -60,6 +60,15 @@ var biblio = {
         rawDate: "2017-01-05",
         status: "Recommended Specification"
     },   
+    "pub-loc": {
+      "title": "Locators for Web Publications",
+      "href": "https://w3.org/TR/pub-loc/",
+      "authors": [
+        "Timothy W. Cole",
+        "Ivan Herman"
+      ],
+      "date": "..."
+    },
     "pwpub": {
       "title": "Packaged Web Publications",
       "href": "https://w3.org/TR/pwpub/",
@@ -72,8 +81,8 @@ var biblio = {
       "title": "Web Publications",
       "href": "https://w3.org/TR/wpub/",
       "authors": [
-        "Dave Cramer",
-        "Matt Garrish"
+        "Matt Garrish",
+        "Ivan Herman"
       ],
       "date": "..."
     }

--- a/index.html
+++ b/index.html
@@ -107,9 +107,9 @@
 	<body>
 		<section id="abstract">
 			<p>This specification defines a collection of information that describes the structure of Web Publications, so
-				that user agents or developers may create user experiences well-suited to reading publications, such as
-				sequential navigation and offline reading. This information includes the default reading order, a list of
-				resources, and publication-wide metadata.</p>
+				that user agents can provide user experiences well-suited to reading publications, such as sequential
+				navigation and offline reading. This information includes the default reading order, a list of resources, and
+				publication-wide metadata.</p>
 		</section>
 		<section id="sotd">
 			<p>This first public working draft provides a preliminary outline of a Web Publication. Many details are under
@@ -132,9 +132,9 @@
 					is not all doom and gloom. Through the power of Web pages, these resources can be brought together to
 					create amazing experiences.</p>
 
-				<p>Web sites add another layer of relationship — this time between pages — but the relationship is a tenuous
-					one that typically depends on hyperlinks to add cohesion. Without a user that understands how to follow
-					the connections, a Web site is still no more than a loose coupling of information.</p>
+				<p>Web sites add another layer of relationship—this time between pages—but the relationship is a tenuous one
+					that typically depends on hyperlinks to add cohesion. Without a user that understands how to follow the
+					connections, a Web site is still no more than a loose coupling of information.</p>
 
 				<p>The preceding is not a critique of the Web, but meant to highlight that the modern Web is very much an
 					active, event-driven experience. Users follow the necessary paths to obtain the information they
@@ -169,15 +169,15 @@
 			<section id="what-is-wp" class="informative">
 				<h3>What is a Web Publication</h3>
 
-				<p>A Web Publication is a discoverable and identifiable collection of information about a publication and its
-					resources. This information is expressed in a machine-readable document called a <a>manifest</a>, which
-					is what enables user agents to understand the bounds of the Web Publication and connection between its
-					resources.</p>
+				<p>A <a>Web Publication</a> is a discoverable and identifiable collection of information about a publication
+					and its resources. This information is expressed in a machine-readable document called a <a>manifest</a>,
+					which is what enables user agents to understand the bounds of the Web Publication and the connection
+					between its resources.</p>
 
-				<p>The manifest includes metadata that describes the Web Publication, as it has an identity and nature beyond
-					its constituent resources. The manifest also provides a list of all the resources that belong to the Web
-					Publication and the default reading order, which is how it connects resources into a single contiguous
-					work.</p>
+				<p>The manifest includes metadata that describes the Web Publication, as a publication has an identity and
+					nature beyond its constituent resources. The manifest also provides a list of all the resources that
+					belong to the Web Publication and the default reading order, which is how it connects resources into a
+					single contiguous work.</p>
 
 				<p>A Web Publication is discoverable in one of two ways: resources either include a link to the manifest (via
 					an HTTP Link header or an [[!html]] <code>link</code> element), or the manifest can be loaded directly by
@@ -197,7 +197,7 @@
 
 				<p>Moreover, the specification is designed to adapt automatically to updates to Open Web Platform
 					technologies in order to ensure that Web Publications continue to interoperate seamlessly as the Web
-					evolves (e.g., by referencing the latest published versions instead of specific versions).</p>
+					evolves (e.g., by referencing the latest published versions instead of specific dated versions).</p>
 
 				<p>Further, this specification does not attempt to constrain the nature of a Web Publication: any type of
 					work that can be represented on the Web constitutes a potential Web Publication.</p>
@@ -226,7 +226,7 @@
 							web publications versus installation for applications).</p>
 
 						<p>The working assumption is that both applications and publications can use the same manifest and
-							serialization to express the information necessary to initiate both.</p>
+							serialization to express the information necessary to initiate themselves.</p>
 
 						<p>The initial stage of evaluating this assumption involves:</p>
 
@@ -236,13 +236,13 @@
 								in [[appmanifest]].</li>
 						</ul>
 
-						<p>The next stage will involve the serialization of the infoset in JSON, and see how this expression
-							of the manifest can be aligned with the expression of the [[appmanifest]]. Wherever semantically
-							possible, the terms used and defined for [[appmanifest]] should be reused, and, conversely, some
-							of the members defined for Web Publications may be generally useful for applications and may be
-							added to the [[appmanifest]] as a common pool of information. To avoid possible future conflicts,
-							care should be taken to use a naming schemes that clearly separates terms to be used for Web
-							Publications only.</p>
+						<p>The next stage will involve the serialization of the <a>infoset</a> in JSON to see how this
+							expression of the manifest can be aligned with the expression of the [[appmanifest]]. Wherever
+							semantically possible, the terms used and defined for [[appmanifest]] will be reused, and,
+							conversely, some of the members defined for Web Publications may be generally useful for
+							applications and may be added to the [[appmanifest]] as a common pool of information. To avoid
+							possible future conflicts, care will be taken to use a naming scheme that clearly separates terms
+							to be used for Web Publications only.</p>
 
 						<p>This specification consequently should be read and understood in this context of an ongoing
 							investigation, and that significant changes may occur in the future.</p>
@@ -267,7 +267,7 @@
 						class="externalDFN" href="https://www.w3.org/TR/publishing-linking/#dfn-address">address</a>.</p>
 
 				<dl>
-					<dt><dfn>Identifier</dfn></dt>
+					<dt><dfn data-lt="identifiers">Identifier</dfn></dt>
 					<dd>
 						<p>An identifier is metadata that can be used to refer to <a class="externalDFN"
 								href="https://www.w3.org/TR/publishing-linking/#dfn-web-content">Web Content</a> in a
@@ -289,11 +289,11 @@
 							normalization, where whitespace normalization rules are defined per the host format.</p>
 					</dd>
 
-					<dt><dfn>URL</dfn></dt>
+					<dt><dfn data-lt="URLs">URL</dfn></dt>
 					<dd>
-						<p>In this specification, the general term URL is used as in other W3C specifications like
-							HTML&#160;[[!html]], and is defined by URL Standard of the WhatWG&#160;[[!url]]. In particular,
-							such a URL allows for the usage of characters from Unicode following&#160;[[!rfc3987]]. See <a
+						<p>The general term URL is defined by the URL Standard&#160;[[!url]]. It is used as in other W3C
+							specifications, like HTML&#160;[[!html]]. In particular, a URL allows for the usage of characters
+							from Unicode following&#160;[[!rfc3987]]. See <a
 								href="https://www.w3.org/TR/html/references.html#biblio-url">the note in the HTML5
 								document</a> for further details.</p>
 					</dd>
@@ -318,15 +318,15 @@
 					criteria:</p>
 
 				<ul>
-					<li>It MUST have a <a>manifest</a> that conforms to <a href="#manifest-req"></a>.</li>
+					<li>it has a <a>manifest</a> that conforms to <a href="#manifest-req"></a>;</li>
+					<li>ot adheres to the construction requirements defined in <a href="#wp-construction"></a>.</li>
 				</ul>
 
 				<p id="ua-conformance">A user agent is conformant to this specification if it meets the following
 					criteria:</p>
 
 				<ul>
-					<li>It MUST be capable of generating a conforming <a href="#infoset">infoset</a> for a Web
-						Publication.</li>
+					<li>it is capable of generating a conforming <a href="#infoset">infoset</a> for a Web Publication.</li>
 				</ul>
 			</section>
 		</section>
@@ -335,57 +335,64 @@
 
 			<p class="ednote">The name "infoset" may change depending on feedback. Although this term has a different meaning
 				for individuals familiar with XML, alternatives such as "properties" and "metadata" do not fully capture the
-				nature or purpose. See <a href="https://github.com/w3c/wpub/issues/63">issue #63</a> for discussion.</p>
+				nature or purpose of the collected information. See <a href="https://github.com/w3c/wpub/issues/63">issue
+					#63</a> for discussion.</p>
 
 			<p class="ednote">As the serialization of the manifest remains an open issue, specifics about how properties are
 				compiled into the infoset remain unspecified. This includes, but is not limited to, what specific names the
 				properties will have in the infoset, whether the names in the manifest will be the same as those in the
 				infoset and/or whether mappings to properties from known vocabularies will be used.</p>
 
-			<section id="infoset-expl">
+			<section id="infoset-expl" class="informative">
 				<h3>Explanation</h3>
 
-				<p>A Web Publication is defined by a set of properties known as its <dfn data-lt="infoset">information
-						set</dfn> (infoset). The infoset is both abstract and concrete. It is abstract in the sense that it
-					represents a set of information that a user agent has to be able to compile about the Web Publication,
-					but it also becomes concrete when the user agent creates an internal representation of the
-					information.</p>
+				<p>A <a>Web Publication</a> is defined by a set of properties known as its <dfn data-lt="infoset">information
+						set</dfn> (infoset). The infoset is logically divided into two sets of properties: those that
+					describe the publication and those that express key structures. These classifications only exist for the
+					purposes of understanding the function of the properties, however.</p>
 
-				<p>The infoset does not require a specific serialization. It is primarily compiled from a Web Publication's
-						<a>manifest</a>, whose serialization requirements are defined in <a href="#manifest-serialization"
-					></a>. It is therefore possible to express the same infoset via different manifests, although a Web
-					Publication will only have one manifest.</p>
+				<p>The infoset is both abstract and concrete. It is abstract in the sense that it represents a set of
+					information that a user agent has to compile about the Web Publication, but it also becomes concrete when
+					the user agent creates an internal representation of that information.</p>
 
-				<p>Although the manifest is the primary source of the infoset, some information may be obtained independent
-					of it. For example, fallback rules for properties defined in the following subsections allow a user agent
-					to compile information that the author has not provided in the manifest, whether as an intentional
-					optimization or by accidental omission.</p>
+				<p>The infoset is primarily compiled from a Web Publication's <a>manifest</a>, whose serialization
+					requirements are defined in <a href="#manifest-serialization"></a>. Some information can be obtained in
+					outside the manifest, however. For example, fallback rules for properties defined in the following
+					subsections allow a user agent to compile information that the author has not provided in the manifest,
+					whether as an intentional optimization or by accidental omission.</p>
 			</section>
 
 			<section id="infoset-req">
 				<h3>Requirements</h3>
 
-				<p>The Web Publication <a>infoset</a> MUST include the following information:</p>
+				<p>The requirements for the expression of infoset properties are as follows:</p>
 
-				<ul>
-					<li>The <a href="#wp-address">address</a> of the Web Publication.</li>
-					<li>A <a href="#wp-resource-list">list of resources</a>.</li>
-					<li>The <a href="#wp-default-reading-order">default reading order</a> of the Web Publication.</li>
-				</ul>
-
-				<p>In addition, the infoset SHOULD include the following information:</p>
-
-				<ul>
-					<li>The <a href="#wp-title">title</a> (or "name") of the Web Publication.</li>
-					<li>The <a href="#wp-creators">creator(s)</a> of the Web Publication.</li>
-					<li>The <a href="#wp-language">default (natural) language</a> of the Web Publication.</li>
-					<li>A <a href="#wp-canonical-identifier">canonical identifier</a>.</li>
-					<li>The <a href="#wp-table-of-contents">table of contents</a>.</li>
-					<li>The <a href="#wp-pub-date">publication date</a>.</li>
-					<li>The <a href="#wp-mod-date">modification date</a>.</li>
-					<li><a href="#wp-a11y-meta">Accessibility metadata</a>.</li>
-					<li>A link to a <a href="#wp-privacy">privacy policy</a></li>
-				</ul>
+				<dl>
+					<dt>Descriptive Properties</dt>
+					<dd>
+						<p>REQUIRED: <a href="#wp-address">address</a></p>
+						<div>
+							<span>RECOMMENDED:</span>
+							<ul class="flat">
+								<li><a href="#wp-a11y">accessibility</a></li>
+								<li><a href="#wp-dir">base direction</a></li>
+								<li><a href="#wp-canonical-identifier">canonical identifier</a></li>
+								<li><a href="#wp-creators">creator</a></li>
+								<li><a href="#wp-language">language</a></li>
+								<li><a href="#wp-mod-date">modification date</a></li>
+								<li><a href="#wp-privacy">privacy policy</a></li>
+								<li><a href="#wp-pub-date">publication date</a></li>
+								<li><a href="#wp-title">title</a></li>
+							</ul>
+						</div>
+					</dd>
+					<dt>Structural Properties</dt>
+					<dd>
+						<p>REQUIRED: <a href="#wp-default-reading-order">default reading order</a> and <a
+								href="#wp-resource-list">resource list</a></p>
+						<p>RECOMMENDED: <a href="#wp-table-of-contents">table of contents</a></p>
+					</dd>
+				</dl>
 
 				<p class="ednote">These requirements reflect the current minimum consensus, though a number of issues remain
 					open that could change whether an item is required or recommended. See the following sections for more
@@ -395,261 +402,301 @@
 					to handle metadata. (Note: this is now more specifically related to the infoset.)</p>
 			</section>
 
-			<section id="wp-title">
-				<h3>Title</h3>
+			<section id="infoset-meta">
+				<h3>Descriptive Properties</h3>
 
-				<p>The title provides the human-readable name of the Web Publication.</p>
+				<section id="wp-a11y">
+					<h4>Accessibility</h4>
 
-				<p>When specified in the manifest, the title MUST be <a>non-empty</a>.</p>
+					<p>Accessibility metadata allows the discovery of features and affordances of the <a>Web Publication</a>
+						that enable its use by users with different reading requirements and needs.</p>
 
-				<p>If a user agent requires a title and one is not available in the <a>infoset</a>, it MAY create one. This
-					specification does not mandate how such a title is created. The user agent might:</p>
+					<p class="ednote">How to express accessibility metadata remains to be determined. This could be a
+						grouping of properties from schema.org, for example, or could be split out into a list of individual
+						properties.</p>
+				</section>
 
-				<ul>
-					<li>use the first <a>non-empty</a>
-						<code>title</code> element found in the <a>default reading order</a>;</li>
-					<li>provide a language-specific placeholder title (e.g., 'Untitled Publication');</li>
-					<li>use the URL of the manifest;</li>
-					<li>calculate a title using its own algorithm.</li>
-				</ul>
+				<section id="wp-address">
+					<h4>Address</h4>
 
-				<div class="note">
-					<p>A user agent is not expected to produce a <a
-							href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title">meaningful title</a> [[wcag20]]
-						for a Web Publication when one is not specified.</p>
-				</div>
-			</section>
+					<p>A <a>Web Publication's</a>
+						<dfn>address</dfn> is a <a>URL</a> that refers to the Web Publication. It dereferences to the <a
+							href="#wp-landing-page">landing page</a>, which enables the retrieval of a representation of the
+							<a>manifest</a>.</p>
 
-			<section id="wp-creators">
-				<h3>Creators</h3>
+					<p>The availability of this address does not preclude the creation and use of other identifiers and/or
+						addresses to retrieve a representation of a <a>Web Publication</a> in whole or part.</p>
 
-				<p>Creators are the individuals or entities responsible for the creation of the Web Publication.</p>
+					<div class="note">The Web Publication's address can also be used as value for an identifier link relation
+						[[link-relation]].</div>
+				</section>
 
-				<p>The role the creator played in the creation of the Web Publication SHOULD also be specified (e.g.,
-					'author', 'illustrator', 'translator').</p>
-			</section>
+				<section id="wp-dir">
+					<h4>Base Direction</h4>
 
-			<section id="wp-language">
-				<h3>Language</h3>
+					<p>The <dfn>base direction</dfn> identifies the display direction for <a>infoset</a> properties.</p>
 
-				<p>The language specified in the Web Publication's <a>infoset</a> identifies the natural language(s) of its
-					content.</p>
+					<p>The value of this property MUST be one of:</p>
 
-				<p>This language is not used in the processing or rendering of the Web Publication (including the manifest),
-					and is <strong>not</strong> a replacement for identifying the language of each resource as defined by its
-					format. It instead allows a user agent to ability to provide supplementary enhancements, such as the
-					ability to download a custom dictionary or the preload a language-specific text-to-speech module.</p>
+					<dl>
+						<dt><code>ltr</code></dt>
+						<dd>left-to-right</dd>
+						<dt><code>rtl</code></dt>
+						<dd>right-to-left</dd>
+						<dt><code>auto</code></dt>
+						<dd>direction is determined from the value of the property</dd>
+					</dl>
 
-				<p>When specified, the language MUST be a tag that conforms to [[!bcp47]].</p>
+					<p>If not specified, the value <code>ltr</code> SHOULD be assumed.</p>
 
-				<p>If a user agent requires the language and one is not available in the infoset, it MAY attempt to determine
-					the language. This specification does not mandate how such a language tag is created. The user agent
-					might:</p>
+					<p>If property values are harvested from another resource, such as the <a>table of contents</a>,
+						precedence SHOULD be given to the base direction specified in the resource, when provided.</p>
+				</section>
 
-				<ul>
-					<li>use the <a>non-empty</a> language declaration of the manifest;</li>
-					<li>use the first non-empty language declaration found in the <a>default reading order</a>;</li>
-					<li>calculate the language using its own algorithm.</li>
-				</ul>
+				<section id="wp-canonical-identifier">
+					<h4>Canonical Identifier</h4>
 
-				<p>If a language tag cannot be determined, the value "<code>und</code>" (undetermined) MUST be used.</p>
+					<p>A <a>Web Publication's</a>
+						<dfn>canonical identifier</dfn> is a unique identifier that resolves to the preferred version of the
+						Web Publication. The canonical identifier SHOULD be an <a>address</a>, but, if not, it MUST be
+						possible to make a one-to-one mapping to an address (e.g., a DOI can be resolved to a URL via a DOI
+						resolver).</p>
 
-				<div class="issue" data-number="53">
-					<p>The question is whether the language declared for the manifest content is the same as the language of
-						the publication, and how to deal with multilingual publications.</p>
-				</div>
-			</section>
+					<p>If a Web Publication is hosted at more than one address, this identifier allows a user agent to
+						identify the shared relationship between the versions and to determine which of the available
+						addresses is primary.</p>
 
-			<section id="wp-canonical-identifier">
-				<h3>Canonical Identifier</h3>
+					<p>The canonical identifier is also intended to provide a measure of permanence above and beyond the Web
+						Publication's address. Even if a Web Publication is permanently relocated to a new address, for
+						example, the canonical identifier will provide a way of locating the new location (e.g., a DOI
+						registry could be updated with the new URL, or a redirect could be added to the URL of the canonical
+						identifier).</p>
 
-				<p>A <a>Web Publication's</a>
-					<dfn>canonical identifier</dfn> is a unique identifier that resolves to the preferred version of the Web
-					Publication. The canonical identifier SHOULD be an <a>address</a>, but, if not, it MUST be possible to
-					make a one-to-one mapping to an address (e.g., a DOI can be resolved to a URL via a DOI resolver).</p>
+					<p>When assigned, the canonical identifier needs to be unique to one and only one Web Publication,
+						independent of its address(es). Ensuring uniqueness is outside the scope of this specification,
+						however. The actual uniqueness achievable depends on such factors as the conventions of the
+						identifier scheme used and the degree of control over assignment of identifiers.</p>
 
-				<p>If a Web Publication is hosted at more than one address, this identifier allows a user agent to identify
-					the shared relationship between the versions and to determine which of the available addresses is
-					primary.</p>
+					<p class="note">If the canonical identifier is a URL, it can be used as the target of a "canonical"
+						link&#160;[[rfc6596]] (e.g., an [[html]] <code>link</code> element whose <code>rel</code> attribute
+						has the value <code>canonical</code> or a Link HTTP header field [[rfc5988]] similarly
+						identified).</p>
 
-				<p>The canonical identifier is also intended to provide a measure of permanence above and beyond the Web
-					Publication's address. Even if a Web Publication is permanently relocated to a new address, for example,
-					the canonical identifier will provide a way of locating the new location (e.g., a DOI registry could be
-					updated with the new URL, or a redirect could be added to the URL of the canonical identifier).</p>
+					<p class="issue" data-number="58">The question is whether a canonical identifier is necessary to call out
+						explicitly in the infoset, or whether it is/can be handled by other metadata.</p>
+				</section>
 
-				<p>When assigned, the canonical identifier needs to be unique to one and only one Web Publication,
-					independent of its address(es). Ensuring uniqueness is outside the scope of this specification, however.
-					The actual uniqueness achievable depends on such factors as the conventions of the identifier scheme used
-					and the degree of control over assignment of identifiers.</p>
+				<section id="wp-creators">
+					<h4>Creators</h4>
 
-				<p class="note">If the canonical identifier is a URL, it can be used as the target of a "canonical"
-					link&#160;[[rfc6596]] (e.g., an [[html]] <code>link</code> element whose <code>rel</code> attribute has
-					the value <code>canonical</code> or a Link HTTP header field [[rfc5988]] similarly identified).</p>
+					<p>Creators are the individuals or entities responsible for the creation of the <a>Web
+						Publication</a>.</p>
 
-				<p class="issue" data-number="58">The question is whether a canonical identifier is necessary to call out
-					explicitly in the infoset, or whether it is/can be handled by other metadata.</p>
-			</section>
+					<p>The role the creator played in the creation of the Web Publication SHOULD also be specified (e.g.,
+						'author', 'illustrator', 'translator').</p>
+				</section>
 
-			<section id="wp-address">
-				<h3>Address</h3>
+				<section id="wp-language">
+					<h4>Language</h4>
 
-				<p>A Web Publication's <dfn>address</dfn> is a <a>URL</a> that refers to a <a>Web Publication</a> and enables
-					the retrieval of a representation of the <a>manifest</a> of the Web Publication.</p>
+					<p>The language specified in the <a>Web Publication's</a>
+						<a>infoset</a> identifies the natural language of its properties.</p>
 
-				<p>The availability of this address does not preclude the creation and use of other identifiers and/or
-					addresses to retrieve a representation of a <a>Web Publication</a> in whole or part.</p>
+					<p>When specified, the language MUST be a tag that conforms to [[!bcp47]].</p>
 
-				<div class="note">The Web Publication's address can also be used as value for an identifier link relation
-					[[link-relation]].</div>
-			</section>
+					<p class="note">This language is not used in the processing or rendering of the Web Publication, and is
+							<strong>not</strong> a replacement for identifying the language of each resource as defined by
+						its format.</p>
 
-			<section id="wp-resource-list">
-				<h3>Resource List</h3>
-
-				<p>The <a>infoset</a> MUST include a list of the Web Publication's resources, although the list is not
-					required to be exhaustive. Resources in the <a>default reading order</a> MUST be included in this
-					list.</p>
-
-				<p class="issue" data-number="22">The discussion led to the question whether the manifest/infoset MUST list
-					all resources or not. In this sense, this became a duplicate of <a
-						href="https://github.com/w3c/wpub/issues/23">issue #23</a> ended up at the same question.</p>
-
-				<p class="issue" data-number="23">The question is whether the manifest/infoset MUST list all resources or
-					not.</p>
-
-				<p class="issue" data-number="59">The question is whether the manifest MUST list resources in the default
-					reading order or whether this can be inferred.</p>
-			</section>
-
-			<section id="wp-default-reading-order">
-				<h3>Default Reading Order</h3>
-
-				<p>The <dfn>default reading order</dfn> is a specific progression through a set of Web Publication
-					resources.</p>
-
-				<p>A user might follow alternative pathways through the content, but in the absence of such interaction the
-					default reading order defines the expected progression from one resource to the next.</p>
-
-				<p>The default reading order MUST include at least one resource.</p>
-
-				<p>The default reading order is either specified directly in the manifest or a link is provided to an
-					[[!html]] <code>nav</code> element whose list of links are processed to create one.</p>
-
-				<p>The process for extracting a default reading order from a <code>nav</code> element are as follows:</p>
-
-				<ol>
-					<li>extract a list of resource paths referenced from the <code>href</code> attribute of all
-							<code>a</code> elements;</li>
-					<li>strip any fragment identifiers from the references;</li>
-					<li>resolve all relative paths to full URLs;</li>
-					<li>remove all consecutive references to the same resource, leaving only the first.</li>
-				</ol>
-
-				<p>If a user agent requires a default reading order and one is not provided in the <a>infoset</a>, it MAY
-					attempt to construct one. This specification does not mandate how such a default reading order is
-					created. The user agent might:</p>
-
-				<ul>
-					<li>use only the resource the user accessed to reach the manifest;</li>
-					<li>search the list of resources for a <code>nav</code> element to use;</li>
-					<li>calculate the default reading order using its own algorithm.</li>
-				</ul>
-
-				<p class="issue" data-number="35">Define the default reading order of a Web Publication to be the files
-					referenced in the first</p>
-				<p class="issue" data-number="39">There is a consensus that a Web Publication must have a reading order and
-					must/should have a table of contents (the main navigation entry point).</p>
-			</section>
-
-			<section id="wp-table-of-contents">
-				<h3>Table of Contents</h3>
-
-				<p>The <dfn>table of contents</dfn> is a hierarchical list of links that reflects the structural outline of
-					the major sections of the Web Publication. There are no requirements on the completeness of the table of
-					contents, except that, when specified, it MUST link to at least one <a href="#wp-resources"
-					>resource</a>.</p>
-
-				<p>The table of contents is either specified directly in the manifest or a link is provided to an [[!html]]
-						<code>nav</code> element containing one.</p>
-
-				<p>If a user agent requires a table of contents and one is not specified, it MAY construct one. This
-					specification does not mandate how such a table of contents is created. The user agent might: </p>
-
-				<ol>
-					<li>attempt to locate a table of contents in the default reading order (e.g., an HTML document with a
-							<code>nav</code> element that has the <code>role</code> attribute value
-						<code>doc-toc</code>);</li>
-					<li>use the titles of resources in the default reading order;</li>
-					<li>calculate a table of contents using its own algorithms.</li>
-				</ol>
-
-				<p class="ednote">This section should be brought in sync with the section on <a>landing page</a>.</p>
-
-				<p class="issue" data-number="9">The question is whether the manifest/infoset needs to provide navigation, or
-					whether such mechanisms belong in the content.</p>
-
-				<p class="issue">This question arises only if this mechanism is accepted: the question is whether a table of
-					contents navigation element can refer, via links, to any resource that is <em>not</em> listed in the
-					default reading order.</p>
-
-				<div class="issue">
-					<p>The issue of using the HTML <code>nav</code> element as a possible encoding of the table of contents
-						is mentioned or explicitly addressed in the following issues:</p>
+					<p>If a user agent requires the language and one is not available in the infoset, it MAY attempt to
+						determine the language. This specification does not mandate how such a language tag is created. The
+						user agent might:</p>
 
 					<ul>
-						<li><a href="https://github.com/w3c/wpub/issues/35">Issue #35</a>: Define the resources in the
-							default reading order of a Web Publication to be the files referenced in the first</li>
-						<li><a href="https://github.com/w3c/wpub/issues/39">Issue #39</a>: There is a consensus that a Web
-							Publication must have a reading order and must/should have a table of contents (the main
-							navigation entry point).</li>
+						<li>use the <a>non-empty</a> language declaration of the manifest;</li>
+						<li>use the first non-empty language declaration found in a resource in the <a>default reading
+								order</a>;</li>
+						<li>calculate the language using its own algorithm.</li>
 					</ul>
-				</div>
+
+					<p>If a language tag cannot be determined, the value "<code>und</code>" (undetermined) MUST be used.</p>
+
+					<div class="issue" data-number="53">
+						<p>The question is whether the language declared for the manifest content is the same as the language
+							of the publication, and how to deal with multilingual publications.</p>
+					</div>
+				</section>
+
+				<section id="wp-mod-date">
+					<h4>Last Modification Date</h4>
+
+					<p>The <dfn>last modification date</dfn> is the date when the <a>Web Publication</a> was last
+						updated.</p>
+
+					<p>The last modification date SHOULD be updated whenever changes are made to the resources of the Web
+						Publication, including the <a>manifest</a>. It does not necessarily reflect all changes to the Web
+						Publication, however, as, for example, it might not reflect changes to third-party content.</p>
+				</section>
+
+				<section id="wp-pub-date">
+					<h4>Publication Date</h4>
+
+					<p>The <dfn>publication date</dfn> is the date on which the <a>Web Publication</a> was originally
+						published. It represents a static event in the lifecycle of a Web Publication and allows subsequent
+						revisions to be identified and compared.</p>
+
+					<p>The exact moment of publication is intentionally left open to interpretation: it could be when the Web
+						Publication is first made available online or could be a point in time before publication when the
+						Web Publication is considered final.</p>
+				</section>
+
+				<section id="wp-privacy">
+					<h4>Privacy Policy</h4>
+
+					<p>Users often have the legal right to know and control what information is collected about them, how
+						such information is stored and for how long, whether it is personally identifiable, and how it can be
+						expunged. Including a statement that addresses all such privacy concerns is consequently an important
+						part of publishing <a>Web Publications</a>. Even if no information is collected, such a declaration
+						increases the trust users have with the content.</p>
+
+					<p>To address this concern, the infoset allows a link to be provided to a privacy policy. The privacy
+						policy does not have to be a resource of the Web Publication, although including it as a resource is
+						RECOMMENDED.</p>
+
+					<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
+						Publications.</p>
+				</section>
+
+				<section id="wp-title">
+					<h4>Title</h4>
+
+					<p>The title provides the human-readable name of the <a>Web Publication</a>.</p>
+
+					<p>When specified in the <a>manifest</a>, the title MUST be <a>non-empty</a>.</p>
+
+					<p>If a user agent requires a title and one is not available in the <a>infoset</a>, it MAY create one.
+						This specification does not mandate how such a title is created. The user agent might:</p>
+
+					<ul>
+						<li>use the first <a>non-empty</a>
+							<code>title</code> element found in a resource in the <a>default reading order</a>;</li>
+						<li>provide a language-specific placeholder title (e.g., 'Untitled Publication');</li>
+						<li>use the URL of the manifest;</li>
+						<li>calculate a title using its own algorithm.</li>
+					</ul>
+
+					<div class="note">
+						<p>A user agent is not expected to produce a <a
+								href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title">meaningful title</a>
+							[[wcag20]] for a Web Publication when one is not specified.</p>
+					</div>
+				</section>
 			</section>
 
-			<section id="wp-pub-date">
-				<h3>Publication Date</h3>
+			<section id="infoset-structure">
+				<h3>Structural Properties</h3>
 
-				<p>The <dfn>publication date</dfn> is the date on which the Web Publication was originally published. It
-					represents a static event in the lifecycle of a Web Publication and allows subsequent revisions to be
-					identified and compared.</p>
+				<section id="wp-default-reading-order">
+					<h4>Default Reading Order</h4>
 
-				<p>The exact moment of publication is intentionally left open to interpretation: it could be when the Web
-					Publication is first made available online, or could be a point in time before publication when the Web
-					Publication is considered final.</p>
-			</section>
+					<p>The <dfn>default reading order</dfn> is a specific progression through a set of <a>Web Publication</a>
+						resources.</p>
 
-			<section id="wp-mod-date">
-				<h3>Last Modification Date</h3>
+					<p>A user might follow alternative pathways through the content, but in the absence of such interaction
+						the default reading order defines the expected progression from one resource to the next.</p>
 
-				<p>The <dfn>last modification date</dfn> is the date when the Web Publication was last updated.</p>
+					<p>The default reading order MUST include at least one resource.</p>
 
-				<p>The last modification date SHOULD be updated whenever changes are made to the resources of the Web
-					Publication, including the manifest. It does not necessarily reflect all changes to the Web Publication,
-					however, as, for example, it might not reflect changes to third-party content.</p>
-			</section>
+					<p>The default reading order is either specified directly in the manifest or a link is provided to an
+						[[!html]] <code>nav</code> element whose list of links are processed to create one.</p>
 
-			<section id="wp-a11y-metadata">
-				<h3>Accessibility Metadata</h3>
+					<p>The process for extracting a default reading order from a <code>nav</code> element are as follows:</p>
 
-				<p>Accessibility metadata allows discovery of features and affordances of the Web Publication that enable its
-					usability by users with specific reading requirements and needs.</p>
-			</section>
+					<ol>
+						<li>extract a list of resource paths referenced from the <code>href</code> attribute of all
+								<code>a</code> elements;</li>
+						<li>strip any fragment identifiers from the references;</li>
+						<li>resolve all relative paths to full URLs;</li>
+						<li>remove all consecutive references to the same resource, leaving only the first.</li>
+					</ol>
 
-			<section id="wp-privacy">
-				<h3>Privacy Policy</h3>
+					<p>If a user agent requires a default reading order and one is not provided in the <a>infoset</a>, it MAY
+						attempt to construct one. This specification does not mandate how such a default reading order is
+						created. The user agent might:</p>
 
-				<p>Users often have the legal right to know and control what information is collected about them, how such
-					information is stored and for how long, whether it is personally identifiable, and how it can be
-					expunged. Including a statement that addresses all such privacy concerns is consequently an important
-					part of publishing Web Publications. Even if no information is collected, such a declaration increases
-					the trust users have with the content.</p>
+					<ul>
+						<li>use only the resource the user accessed to reach the manifest;</li>
+						<li>search the list of resources for a <code>nav</code> element to use;</li>
+						<li>calculate the default reading order using its own algorithm.</li>
+					</ul>
 
-				<p>To address this concern, the infoset allows a link to be provided to a privacy policy. The privacy policy
-					does not have to be a resource of the Web Publication, although including it as a resource is
-					RECOMMENDED.</p>
+					<p class="issue" data-number="35">Define the default reading order of a Web Publication to be the files
+						referenced in the first</p>
+					<p class="issue" data-number="39">There is a consensus that a Web Publication must have a reading order
+						and must/should have a table of contents (the main navigation entry point).</p>
+				</section>
 
-				<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
-					Publications.</p>
+				<section id="wp-resource-list">
+					<h4>Resource List</h4>
+
+					<p>The <a>infoset</a> MUST include a list of the Web Publication's resources, although the list is not
+						required to be exhaustive. Resources in the <a>default reading order</a> MUST be included in this
+						list.</p>
+
+					<p class="issue" data-number="22">The discussion led to the question whether the manifest/infoset MUST
+						list all resources or not. In this sense, this became a duplicate of <a
+							href="https://github.com/w3c/wpub/issues/23">issue #23</a> ended up at the same question.</p>
+
+					<p class="issue" data-number="23">The question is whether the manifest/infoset MUST list all resources or
+						not.</p>
+
+					<p class="issue" data-number="59">The question is whether the manifest MUST list resources in the default
+						reading order or whether this can be inferred.</p>
+				</section>
+
+				<section id="wp-table-of-contents">
+					<h4>Table of Contents</h4>
+
+					<p>The <dfn>table of contents</dfn> is a hierarchical list of links that reflects the structural outline
+						of the major sections of the Web Publication. There are no requirements on the completeness of the
+						table of contents, except that, when specified, it MUST link to at least one <a href="#wp-resources"
+							>resource</a>.</p>
+
+					<p>The table of contents is either specified directly in the manifest or a link is provided to an
+						[[!html]] <code>nav</code> element containing one.</p>
+
+					<p>If a user agent requires a table of contents and one is not specified, it MAY construct one. This
+						specification does not mandate how such a table of contents is created. The user agent might: </p>
+
+					<ol>
+						<li>attempt to locate a table of contents in the default reading order (e.g., an HTML document with a
+								<code>nav</code> element that has the <code>role</code> attribute value
+							<code>doc-toc</code>);</li>
+						<li>use the titles of resources in the default reading order;</li>
+						<li>calculate a table of contents using its own algorithms.</li>
+					</ol>
+
+					<p class="ednote">This section should be brought in sync with the section on <a>landing page</a>.</p>
+
+					<p class="issue" data-number="9">The question is whether the manifest/infoset needs to provide
+						navigation, or whether such mechanisms belong in the content.</p>
+
+					<p class="issue">This question arises only if this mechanism is accepted: the question is whether a table
+						of contents navigation element can refer, via links, to any resource that is <em>not</em> listed in
+						the default reading order.</p>
+
+					<div class="issue">
+						<p>The issue of using the HTML <code>nav</code> element as a possible encoding of the table of
+							contents is mentioned or explicitly addressed in the following issues:</p>
+						<ul>
+							<li><a href="https://github.com/w3c/wpub/issues/35">Issue #35</a>: Define the resources in the
+								default reading order of a Web Publication to be the files referenced in the first.</li>
+							<li><a href="https://github.com/w3c/wpub/issues/39">Issue #39</a>: There is a consensus that a
+								Web Publication must have a reading order and must/should have a table of contents (the main
+								navigation entry point).</li>
+						</ul>
+					</div>
+				</section>
 			</section>
 
 			<section id="wp-extensibility">
@@ -660,7 +707,7 @@
 
 				<ol>
 					<li>through the inclusion of additional properties in the manifest;</li>
-					<li>by the provision of <a href="#manifest-linking-from">linked</a> metadata records.</li>
+					<li>by the provision of linked metadata records.</li>
 				</ol>
 
 				<p>User Agents MAY support additional properties but MUST NOT include unrecognized properties in the infoset.
@@ -693,81 +740,45 @@
 				<h3>Declaration</h3>
 
 				<div class="ednote">A description of how a manifest declares it describes a web publication will be included
-					in a future version, as such a mechanism will depend on integration with [[appmanifest]].</div>
+					in a future draft, as such a mechanism will depend on integration with [[appmanifest]].</div>
 			</section>
 
 			<section id="manifest-serialization">
 				<h3>Serialization</h3>
+
+				<p>The manifest is serialized as a JSON document [[!ecma-404]].</p>
+
+				<div class="ednote">Additional serialization details will be included in a future draft, as these will depend
+					on integration with [[appmanifest]].</div>
 
 				<p class="issue" data-number="25"></p>
 				<p class="issue" data-number="26">Should the table of contents be a separate HTML file or is the listing of
 					resources in the default reading order an implicit table of contents?</p>
 				<p class="issue" data-number="32"></p>
 			</section>
-
-			<section id="manifest-linking-from">
-				<h3>Linking from a Manifest</h3>
-
-				<p>The manifest serialization MUST provide a general linking mechanism for defining a relationship between
-					the Web Publication and other resources on the Web as well as the type of those relationships.</p>
-
-				<p>This mechanism is used in to express many parts of the Web Publication's infoset, including but not
-					limited to:</p>
-
-				<ul>
-					<li><a href="#wp-canonical-identifier">Canonical identifier</a> using the <code>rel='canonical'</code>
-						link relation.&#160;[[rfc6596]]</li>
-					<li><a href="#wp-table-of-contents">Table of Contents</a> in the cases where the ToC is specified as a
-						link to an HTML nav element.</li>
-					<li><a href="#wp-metadata">External metadata</a> that may be expressed in established vocabularies such
-						as ONIX, MARC, schema.org, or Dublin Core.</li>
-				</ul>
-
-				<p class="ednote">There are some overlaps between this list and, e.g., the separate section on canonical
-					identifiers.</p>
-
-				<p>This linking mechanism may also be used to express other common link structures on the open Web. For
-					example:</p>
-
-				<ul>
-					<li>Distribution feeds such as <a href="http://opds-spec.org/specs/opds-catalog-1-1">OPDS</a> or <a
-							href="https://tools.ietf.org/html/rfc4287">Atom</a>&#160;[[rfc4287]]</li>
-
-					<li>Alternate versions of the publication</li>
-					<li><a href="https://www.w3.org/TR/webmention/">Web Mentions</a>&#160;[[webmention]]</li>
-				</ul>
-
-				<p class="note">Some of these link structures, such as dynamic search links, may require support for <a
-						href="https://tools.ietf.org/html/rfc6570">URI templates</a>&#160;[[rfc6570]] to be meaningfully
-					useful in the context of a Web Publications. User agents should(?) support URI templates in order to make
-					it easier for publishers to integrate dynamic server-side features into their publications with minimal
-					coding and effort.</p>
-
-				<p class="issue" data-number="67"></p>
-			</section>
 		</section>
-		<section id="wp-structure">
+		<section id="wp-construction">
 			<h2>Web Publication Construction</h2>
 
 			<section id="wp-resources">
 				<h2>Resources</h2>
 
-				<p>Web Publications MAY reference resources of any media type, both in the default reading order and as
-					dependencies of other resources.</p>
+				<p><a>Web Publications</a> MAY reference resources of any media type, both in the <a>default reading
+						order</a> and as dependencies of other resources.</p>
 
 				<div class="note">
-					<p>When adding resources to a Web Publication, consideration needs to be paid to support in user agents.
-						The use of progressive enhancement techniques and the provision of fallback content, as appropriate,
-						will ensure a more consistent reading experience for users regardless of their preferred user
-						agent.</p>
+					<p>When adding resources to a Web Publication, consider support in user agents. The use of progressive
+						enhancement techniques and the provision of fallback content, as appropriate, will ensure a more
+						consistent reading experience for users regardless of their preferred user agent.</p>
 				</div>
 			</section>
 
 			<section id="wp-linking">
 				<h2>Linking to a Manifest</h2>
 
-				<p>Providing a link from a resource to its manifest allows a user agent to discover that a Web Publication is
-					available. Links MUST take one or both of the following forms:</p>
+				<p>Providing a link from a resource to the <a>manifest</a> of the <a>Web Publication</a> it belongs to allows
+					a user agent to discover that a Web Publication is available. Links MUST take one or both of the
+					following forms:</p>
 
 				<ul>
 					<li><p>An HTTP Link header field&#160;[[!rfc5988]] with its <code>rel</code> parameter set to the value
@@ -780,14 +791,15 @@
 					</li>
 				</ul>
 
-				<p>A resource SHOULD link to one or more Web Publications to which it belongs.</p>
+				<p>A resource SHOULD link to the Web Publication(s) to which it belongs.</p>
 
-				<p class="ednote">A resource may link to multiple parent manifests. User agents may choose to present one or
-					more alternatives to an end user, or choose a single alternative on its own. A user agent may choose to
-					present whichever manifest it wishes based upon information that it possesses, even one that is not
-					explicitly listed as a parent, e.g. based upon information it calculates or acquires out of band. In the
-					absence of a preference by user agent implementers, selection of the first manifest listed is suggested
-					as a default.</p>
+				<p class="ednote">The following details might be moved to the lifecycle section in a future draft.</p>
+
+				<p>When a resource links to multiple manifests, a user agent MAY choose to present one or more alternatives
+					to the end user, or choose a single alternative on its own. The user agent MAY choose to present any
+					manifest based upon information that it possesses, even one that is not explicitly listed as a parent
+					(e.g., based upon information it calculates or acquires out of band). In the absence of a preference by
+					user agent implementers, selection of the first manifest listed is suggested as a default.</p>
 
 				<p class="issue" data-number="13">If there is a collection of information about a web publication as a whole
 					("manifest") that exists separately from most of the publication's resources, there needs to be a way to
@@ -802,24 +814,28 @@
 			<section id="wp-landing-page">
 				<h3>Landing Page</h3>
 
-				<p>As described in <a href="#wp-address"></a>, a Web Publication has an <a>address</a> that can be
-					dereferenced. That URL MUST resolve to an [[!HTML]] document that represents the primary entry point for
-					the Web Publication (referred to as the <dfn>landing page</dfn>).</p>
+				<p>As described in <a href="#wp-address"></a>, a <a>Web Publication</a> has an <a>address</a> that can be
+					dereferenced. The address URL MUST resolve to the <dfn>landing page</dfn>, an [[!html]] document that
+					represents the primary entry point for the Web Publication.</p>
 
 				<p>Unlike other resources, the landing page MUST <a href="#wp-linking">link to the manifest</a> to ensure
 					that user agents can discover the Web Publication.</p>
 
 				<p>To ensure that the Web Publication is consumable in different types of user agents, including those that
-					do not support Web Publications, the landing page SHOULD include an [[!HTML]] serialization of the <a
+					do not support Web Publications, the landing page SHOULD include an [[!html]] serialization of the <a
 						href="#enh-toc">table of contents</a> (see <a href="#wp-table-of-contents"></a> for more
 					information).</p>
+
+				<p class="issue" data-number="94">Additional questions about whether specifying HTML is necessary, whether
+					the resource has to be part of the web publication or not, and whether the table of contents is necessary
+					to specify at this location if provided in the content.</p>
 			</section>
 		</section>
 		<section id="wp-lifecycle">
 			<h2>Web Publication Lifecycle</h2>
 
 			<div class="ednote">
-				<p>The publishing working group is currently evaluating the best approach for implementing web publications
+				<p>The publishing working group is currently evaluating the best approach for implementing Web Publications
 					in user agents. This note is intended to provide an overview of where current thinking is and what issues
 					are under consideration.</p>
 
@@ -881,9 +897,116 @@
 		<section id="wp-enhancements">
 			<h2>Reading Enhancements</h2>
 
-			<p class="ednote">This section contains placeholders for possible reading enhancements the UA may/should/must
-				provide. The list is subject to addition, modification and removal as the enhancements get discussed in more
-				detail.</p>
+			<p class="ednote">This section contains placeholders for possible reading enhancements/affordances the user agent
+				may/should/must provide. The list is subject to addition, modification and removal as the enhancements get
+				discussed in more detail.</p>
+
+			<section id="layout">
+				<h3>Layout</h3>
+
+				<p>The layout and rendering of <a>Web Publications</a> is governed by the same rules that apply to all Web
+					content: [[!html]] documents are styled and laid out according to the rules of <a
+						href="https://www.w3.org/TR/CSS/">CSS</a>, [[!svg]] files are rendered as expected of that format,
+					and so on. This specification requires no particular profile or subset of CSS, HTML, or SVG to be
+					supported, other than the expectations set for these technologies by their respective specifications.</p>
+
+
+				<div class="note">
+					<p>This specification intentionally refrains from introducing any new layout features. Any shortcoming of
+						the Web platform in terms of layout needs to be addressed for the whole Web platform, which means via
+						CSS.</p>
+
+					<p>This working group will work with other relevant groups of the W3C to address platform-wide
+						limitations that negatively impact <a>Web Publications</a>.</p>
+				</div>
+
+				<p>For the purposes of layout, each resource of a Web Publication is treated as a separate document. User
+					agents MUST NOT mix content from multiple resources in the same rendering (e.g., <a
+						href="https://www.w3.org/TR/CSS21/visuren.html#floats">CSS floats</a> or <a
+						href="https://www.w3.org/TR/CSS21/visuren.html#absolutely-positioned">absolutely positioned
+						elements</a> from one resource cannot intrude or overlap with content from an other resource).</p>
+
+				<div class="issue">
+					<p>Despite this general requirement that each resource should be treated as a separate document for the
+						purpose of layout, there are some places where CSS specifications should be amended to be able to
+						deal more intelligently with collections of resources like Web Publications.</p>
+
+					<p>One instance is the definition of <a href="https://drafts.csswg.org/css-content/#cross-references"
+							>cross references</a>, which are currently restricted to work only within a single document. This
+						restriction should be relaxed to allow for cross references between separate resources of a single
+						Web Publication.</p>
+
+					<p>Another related one would be to allow <a
+							href="https://drafts.csswg.org/css-lists-3/#counter-properties">counters</a> to accumulate across
+						multiple resources of a single <a>Web Publication</a> (e.g., so that figures in multiple sections may
+						be numbered in a single sequence).</p>
+
+				</div>
+
+				<section id="scrolling-or-paginating" class="informative">
+					<h4>Scrolling or Paginating</h4>
+
+					<p>Publications have historically been presented via paged media, whereas Web pages almost always scroll.
+						As the preferences of individual readers vary, and as different types of publications are better
+						suited for one or the other, this specification encourages user agents to support both, and to offer
+						a choice to their users.</p>
+
+					<div class="issue">
+						<p>It may be useful for authors to be able to specify a preference between scrolling and pagination,
+							even if a strict requirement is not possible. This should most likely be addressed through an
+							extension of <a href="https://www.w3.org/TR/css-device-adapt-1/#atviewport-rule"
+									><code>@viewport</code></a> or of <a
+								href="https://drafts.csswg.org/css-device-adapt/#viewport-meta">the viewport meta tag</a>(see
+							[[css-device-adapt]]), or possibly through an extension of <a
+								href="https://drafts.csswg.org/css-page-3/#at-page-rule"><code>@page</code></a> (See
+							[[css-page-3]]). This should be discussed with the relevant working groups (<a
+								href="https://www.w3.org/Style/CSS/">CSSWG</a>, <a href="https://www.w3.org/WebPlatform/WG/"
+								>WebPlatformWG</a>, <a href="https://whatwg.org/">WHATWG</a>).</p>
+					</div>
+				</section>
+				<section id="enh-pagination">
+					<h4>Paginated Layout</h4>
+
+					<p>When a User Agent renders a <a>Web Publication</a> in a paginated layout, it MUST lay out each
+						document in the <a>default reading order</a> sequentially, with the last page of a resource being
+						followed by the first page of the subsequent one.</p>
+
+					<div class="issue">
+						<p>To avoid blank pages, if a resource ends on a left page (resp. right page), the subsequent one
+							should start on a right page (resp. left page) even if the <a
+								href="https://drafts.csswg.org/css-page-3/#progression">page progression</a> (see
+							[[!css-page-3]]) would otherwise lead to it starting on the opposite page. It should also be
+							possible to use the <a href="">break-before</a> property (See [[!css-break-3]]) to force the
+							content to resume on the opposite side if that was desired by the author.</p>
+
+						<p>[[css-page-3]] needs to be amended to describe this exception to the general behavior when dealing
+							with collections of documents instead of individual documents.</p>
+					</div>
+
+					<div class="issue">
+						<p>How is pagination supposed to work when subsequent resources have opposite <a
+								href="https://drafts.csswg.org/css-page-3/#progression">page progression</a> directions (see
+							[[css-page-3]]). For example, due to different a different writing mode? This is not necessarily
+							a problem from a layout point of view, as each page is independent, but from an UI point of view.
+							If swiping left means next page until the end of one chapter, and starts meaning previous page in
+							the next chapter because the language is switched from English to Hebrew, this is going to be
+							confusing.</p>
+					</div>
+
+					<div class="issue">
+						<p>Should any of the above be normative, or should this be up to User Agents to explore, and only
+							standardize if and when a clear winning approach emerges?</p>
+					</div>
+
+					<div class="issue">
+						<p>[[css-page-3]] needs to be amended so that <a
+								href="https://drafts.csswg.org/css-page-3/#page-based-counters">page counters</a> are not
+							automatically reset to at the beginning of each new resource belonging to the same Web
+							Publication.</p>
+					</div>
+
+				</section>
+			</section>
 
 			<section id="enh-nav">
 				<h3>Navigation</h3>
@@ -927,244 +1050,50 @@
 			<section id="enh-offline-reading">
 				<h3>Offline Reading</h3>
 
-				<p class="ednote">Detail on offline caching and reading will be included in a future version.</p>
+				<p class="ednote">Detail on offline caching and reading will be included in a future draft.</p>
 			</section>
 
 			<section id="enh-search">
 				<h3>Search</h3>
 
 				<p class="ednote">Detail on inter-publication search across multiple resources will be included in a future
-					version.</p>
+					draft.</p>
 			</section>
+		</section>
+		<section id="locators" class="informative">
+			<h3>Web Publication Locators</h3>
 
-			<section id="Layout">
-				<h3>Layout</h3>
+			<p>Locators are used to identify, locate, retrieve, and/or reference locations and content fragments within
+					<a>Web Publications</a> (e.g., for address(es), bookmarks, and annotations). Locators traditionally take
+				the form of fragment identifiers [[rfc3986]], where the portion of a URL preceded by a number sign character
+					(<code>#</code>) identifies a specific position within the referenced resource.</p>
 
-				<p>Since <a>web publications</a> may consist of many HTML documents considered as a logical whole, this does
-					have implications for layout, as discussed below.</p>
+			<p>For some use cases, it is essential to identify and reference a <a>Web Publication</a> resource—or a location
+				in or a segment of a resource—in the scope or context of the Web Publication to which it belongs. A
+				traditional fragment identifier cannot satisfy this requirement, since only the URL of the constituent
+				resource containing the location or content fragment of interest is expressed. Web Publication Locators
+				[[pub-loc]] address this issue by providing the means to express both the URL of the resource and the URL of
+				the Web Publication.</p>
 
+			<div class="ednote">
+				<p>Illustrate with example of simple, easy to understand Web Publication Locator such as might be used in
+					annotating a simple Web Publication.</p>
+			</div>
 
-				<p>The layout and rendering of <a>Web Publications</a> is governed by the usual rules that apply to all web
-					content. [[!html]] documents are styled and laid out according to the rules of <a
-						href="https://www.w3.org/TR/CSS/">CSS</a>, [[!svg]] files are rendered as normally expected of that
-					format, and so on. This specification requires no particular profile or subset of CSS, HTML, or SVG to be
-					supported, other than the expectations set for these technologies by their respective specifications.</p>
+			<p>The semantics of Web Publication Locators are a mapping and extension of the Web Annotation Data Model
+				[[annotation-model]] and Vocabulary [[annotation-vocab]] for describing and referencing a segment of a Web
+				resource. As a result, Web Publication Locators provide the expressiveness needed for a broad range of
+				annotation and bookmarking use cases. Additionally, Web Publication Locators provide a way to identify and
+				reference a location within a Web Publication (i.e., as distinct from identifying and referencing a content
+				fragment consisting of a span of characters or bytes). A Web Publication Locator can be used to identify,
+				retrieve and/or reference a fragment of a Web Publication that spans multiple resources. </p>
 
-
-				<div class="note">
-					<p>This specification intentionally refrains from introducing any new layout feature. Any shortcoming of
-						the web platform in terms of layout needs to be addressed for the whole web platform, which means via
-						CSS.</p>
-
-					<p>This working group will work with other relevant groups of the W3C to address platform-wide
-						limitations that negatively impacts <a>Web Publications</a>, and invites readers to do the same.</p>
-				</div>
-
-				<p>For the purposes of layout, each resource of a <a>Web Publication</a> is treated as a separate document.
-					User Agents must not mix content from multiple resources in the same rendering: For instance, <a
-						href="https://www.w3.org/TR/CSS21/visuren.html#floats">CSS floats</a> or <a
-						href="https://www.w3.org/TR/CSS21/visuren.html#absolutely-positioned">Absolutely positioned
-						elements</a> from one resource may not intrude or overlap with content from an other resource.</p>
-
-				<div class="issue">
-					<p>Despite this general requirement that each resource should be treated as a separate document for the
-						purpose of layout, there are some places where CSS specifications should be amended to be able to
-						deal more intelligently with collections of resources like <a>Web Publications</a>.</p>
-
-					<p>One instance is the definition of <a href="https://drafts.csswg.org/css-content/#cross-references"
-							>cross references</a> which are currently restricted to work only within a single document. This
-						restriction should be relaxed to allow for cross references between separate resources of a single
-							<a>Web Publication</a>.</p>
-
-					<p>Another related one would be to allow <a
-							href="https://drafts.csswg.org/css-lists-3/#counter-properties">counters</a> to accumulate across
-						multiple resources of a single <a>Web Publication</a>, for instance so that figures in multiple
-						sections may be numbered in a single sequence.</p>
-
-				</div>
-
-				<section id="scrolling-or-paginating" class="informative">
-					<h4>Scrolling or Paginating</h4>
-					<p>Publications have historically been presented via paged media. Web pages almost always scroll. As the
-						preferences of individual readers vary, and as different types of publications may be better suited
-						for one or the other, this specification encourages User Agents to support both, and to offer a
-						choice to their users.</p>
-
-					<div class="issue">
-						<p>It may nonetheless be useful for authors to be able to specify a preference between scrolling and
-							pagination, even if a strict requirement is not possible. This should most likely be addressed
-							through an extension of <a href="https://www.w3.org/TR/css-device-adapt-1/#atviewport-rule"
-									><code>@viewport</code></a> or of <a
-								href="https://drafts.csswg.org/css-device-adapt/#viewport-meta">the viewport meta tag</a>(see
-							[[css-device-adapt]]), or possibly through an extension of <a
-								href="https://drafts.csswg.org/css-page-3/#at-page-rule"><code>@page</code></a> (See
-							[[css-page-3]]). This should be discussed with the relevant working groups (<a
-								href="https://www.w3.org/Style/CSS/">CSSWG</a>, <a href="https://www.w3.org/WebPlatform/WG/"
-								>WebPlatformWG</a>, <a href="https://whatwg.org/">WHATWG</a>).</p>
-					</div>
-				</section>
-				<section id="enh-pagination">
-					<h4>Paginated Layout</h4>
-
-					<p>When a User Agent renders a <a>Web Publication</a> in a paginated layout, it must lay out each
-						document in the <a>default reading order</a> sequentially, with the last page of a resource being
-						followed by the first page of the subsequent one.</p>
-
-					<div class="issue">
-						<p>To avoid having unstyleable blank pages in the middle of the document, if the preceding resource
-							ended on a left page (resp. right page), the subsequent one should start on a right page (resp.
-							left page) even if the <a href="https://drafts.csswg.org/css-page-3/#progression">page
-								progression</a> (See [[!css-page-3]]) would otherwise lead to starting on the opposite page;
-							It should also be possible to use the <a href="">break-before</a> property (See [[!css-break-3]])
-							to force the content to resume on the opposite side if that was desired by the author.</p>
-
-						<p>[[css-page-3] needs to be amended to describe this exception to the general behavior when dealing
-							with collections of documents instead of individual documents.</p>
-					</div>
-
-					<div class="issue">
-						<p>How is that supposed to work when subsequent resources have opposite <a
-								href="https://drafts.csswg.org/css-page-3/#progression">page progression</a> (See
-							[[!css-page-3]]) direction, for instance due to different a different writing mode? This is not
-							necessarily a problem from a layout point of view, as each page is independent, but from an UI
-							point of view, if swiping left means next page until the end of one chapter, and starts meaning
-							previous page in the next chapter because we've switched from English to Hebrew, this is going to
-							be horribly confusing.</p>
-					</div>
-
-					<div class="issue">
-						<p>Should any of the above be normative, or should this be up to User Agents to explore, and only
-							standardize if and when a clear winning approach emerges?</p>
-					</div>
-
-					<div class="issue">
-						<p>[[css-page-3]] needs to be amended so that <a
-								href="https://drafts.csswg.org/css-page-3/#page-based-counters">page counters</a> are not
-							automatically reset to at the beginning of each new resource belonging to the same <a>Web
-								Publication</a>.</p>
-					</div>
-
-				</section>
-			</section>
-
-			<section id="enh-locators" class="informative">
-				<h3>Internal Locators</h3>
-
-				<p>In addition to a Web Publication's address(es), bookmarking, annotation, and other use cases require
-					internal locators which can be used to identify, locate, retrieve, and/or reference locations and content
-					fragments within a Web Publication (cf. Web Publications Use Cases and Requirements [[pwp-ucr]] and
-					Digital Publishing Annotation Use Cases [[dpub-annotation-uc]]). </p>
-
-				<section id="enh-intrinsicLocators">
-					<h4>Publisher-Provided Locators</h4>
-					<p>In choosing to organize a publication into multiple, individually addressable resources, each with its
-						own URL, the creator(s) of the publication provide locators for individual objects within the
-						publication. Thus Web Publication Resource URLs serve as Web Publication internal locators for
-						directly identifying, retrieving, and/or referencing each constituent resource of a Web Publication
-						in its entirety. </p>
-
-					<p>Within an individual Web Publication Resource, the creator of the resource may further provide anchors
-						or other structures (e.g., the value of an <code>id</code> attribute of a <code>&lt;p&gt;</code>
-						element in an HTML constituent resource, the Document Object Model (DOM) of an XML constituent
-						resource) as a way to facilitate identifying, locating, retrieving, and/or referencing locations and
-						more granular content fragments within that individual constituent resource and thereby within the
-						Web Publication. Intra-resource, publisher-provided anchors and structures of this sort are often
-						used to mint fragment identifiers and Web Publication Locators, as described below. </p>
-				</section>
-
-				<section id="enh-FragmentIds">
-					<h4>Fragment Identifiers</h4>
-
-					<p>The generic syntax for fragment identifiers is defined in RFC 3986 [[!rfc3986]]. The fragment
-						identifier component of a URL comes at the end of the URL and is preceded by a <code>#</code>
-						character. The fragment identifier component of a URL is separated prior to dereferencing and is not
-						sent to the server. The identifying information within the fragment identifier component itself is
-						dereferenced solely by the user agent. Interpretation and resolution of a fragment identifier may be
-						dependent on the media-type of the resource retrieved when the preceding part of the URL is
-						dereferenced. </p>
-
-					<p>A broad range of fragment identifier formats, each specific to resources of one or more media-types,
-						have been defined in various IETF RFCs, W3C Recommendations, etc. These are typically included by
-						reference in IANA-registered media-type specifications [[iana-media-types]]. A fragment identifier of
-						a format appropriate for a Web Publication Resource's media type may be used to identify, retrieve,
-						and/or reference content fragments within that resource.</p>
-
-					<div class="ednote">
-						<p>Could reference or duplicate here with modifications the second table from 4.2.1 of Web Anno Data
-							Model Rec. [[!annotation-model]].</p>
-					</div>
-
-					<p>User agents minting fragment identifiers often take advantage of publisher-provided anchors and
-						structures. For example, the value of the <code>id</code> attribute of a <code>&lt;p&gt;</code>
-						element in an HTML Web Publication Resource can be used to mint a fragment identifier linking to that
-							<code>&lt;p&gt;</code> element (i.e., a paragraph). This type of fragment identifier is
-						illustrated in the following example, which assumes the existence within the HTML resource of an
-						element with id p33, e.g., <code>&lt;p id="p33"&gt;</code>.</p>
-
-					<aside class="example" title="A simple fragment identifier">
-						<pre class="nohighlight" id="example1">https://example.com/html-first/HeatRadiation/OPS/s009-Chapter-001.html#p33</pre>
-					</aside>
-
-					<p>Using other fragment identifier formats, user agents may mint fragment identifiers to serve as Web
-						Publication internal locators even in the absence of any explicit publisher-provided anchor or
-						structure. For example, a media fragment identifier [[!media-frags]] for a still image embedded in a
-						Web Publication may be minted without reference to any publisher-provided anchor or structure, as
-						shown in the following example. In this example, the fragment is a rectangular image segment that is
-						200x150 pixels with its upper left corner at 100 pixels in from the left edge and 500 pixels down
-						from the top edge of the full image.</p>
-
-					<aside class="example" title="A media fragment identifier">
-						<pre class="nohighlight" id="example2">http://example.com/hudf/hudf_300dpi.jpg#xywh=100,500,200,150</pre>
-					</aside>
-				</section>
-
-				<section id="enh-wpLocators">
-					<h4>Web Publication Locators</h4>
-
-					<p>For some use cases it is essential to identify and reference a Web Publication Resource or a location
-						in or a segment of a Web Publication Resource in the scope or context of a Web Publication which
-						includes this resource. The fragment identifier approaches described above do not satisfy this
-						requirement since only the URL of the constituent Web Publication Resource containing the location or
-						content fragment of interest is expressed. Web Publication Locators address this issue by providing
-						the means to express both the URL of the Web Publication Resource and the URL of the Web
-						Publication.</p>
-
-					<div class="ednote">
-						<p>TO DO: Need to update title and insert a reference here to this now separate document. Is an
-							informative reference also needed here to EBPU CFI document?</p>
-					</div>
-
-					<div class="ednote">
-						<p>TO DO: illustrate with example of simple, easy to understand Web Publication Locator such as might
-							be used in annotating a simple Web Publication. More complicated examples can be left to the
-							external "Locators for Web Publications" document.</p>
-					</div>
-
-					<p>The semantics of Web Publication Locators are a mapping and extension of the Web Annotation Data Model
-						[[!annotation-model]] and Vocabulary [[!annotation-vocab]] for describing and referencing a segment
-						of a web resource. As a result, Web Publication Locators provide the expressiveness needed for a
-						broad range of annotation and bookmarking use cases. Additionally, Web Publication Locators provide a
-						way to identify and reference a location within a Web Publication (i.e., as distinct from identifying
-						and referencing a content fragment consisting of a span of characters or bytes). A Web Publication
-						Locator can be used to identify, retrieve and/or reference a fragment of a Web Publication that spans
-						multiple Web Publication Resources. </p>
-
-					<div class="ednote">
-						<p>The separate document will need to illustrate these use cases - i.e., identifying a location as
-							distinct from a fragment and identifying a fragment that spans multiple Web Publication
-							Resources. If not, illustrations are needed here.</p>
-					</div>
-				</section>
-
-				<div class="note">
-					<p>In composing a Web Publication Locator, the canonical identifier of the Web Publication should be used
-						in preference to any alternative addresses. This facilitates the collation of Web Publication
-						Locators associated with a particular Web Publication. URLs of Web Publication Resources appearing in
-						a Web Publication Locator should match the URL for of the Web Publication Resource provided in the
-						Web Publication Infoset.</p>
-				</div>
-
-			</section>
+			<div class="note">
+				<p>In composing a Web Publication Locator, use the canonical identifier of the Web Publication in preference
+					to any alternative addresses. Such use facilitates the collation of Web Publication Locators associated
+					with a particular Web Publication. URLs of Web Publication resources appearing in a Web Publication
+					Locator should match the URL of the resource provided in the <a>infoset</a>.</p>
+			</div>
 		</section>
 		<section id="security">
 			<h2>Security</h2>


### PR DESCRIPTION
Here's a quick summary of the changes in the pull request, as the previews and diffs will not be helpful:

- the infoset properties are grouped into descriptive and structural sets and alphabetized
- the infoset requirements are also split along groupings to try and improve readability
- an infoset property for base direction is added
- json is stated to be the serialization for the manifest (but much more work is needed in the future)
- linking from a manifest is temporarily removed (we need the linking details, as the list of properties that use linking is redundant and the list of technologies that can be expressed with links out of place without it)
- layout is moved to the start of the enhancements section, partially to alphabetize but also to keep the incomplete sections at the end
- locators is bumped up to a top-level section and the explanatory subsections on locators in resources and fragment identifiers are removed

There is also a lot of general editorial cleanup in this PR, including removal of some things that are out-dated.

I'm going to immediately merge this PR as there are too many items to take comments here. If you have an issue with any of the changes, please open a new item in the tracker.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/wpub/restructure.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/wpub/7e5f58a...f324dc3.html)