### PR TITLE
Description of image

### DIFF
--- a/index.html
+++ b/index.html
@@ -1188,8 +1188,7 @@
 			<h2>Image Descriptions</h2>
 
 			<dl>
-				<dt id="WP-diagram-descr">Description for <a role="doc-backlink" href="#WP-diagram">The Structure of Web
-						Publications diagram</a>:</dt>
+				<dt id="WP-diagram-descr">Description for the <a href="#WP-diagram">“Structure of Web Publications” diagram</a>:</dt>
 				<dd>A simplified diagram of the structure of a <a>Web Publication</a>. The Web Publication is broken down
 					into two elements. The first element is the actual contents (all the real things listed in the manifest).
 					This element is broken down into the CSS, the actual “things” such as the HTML, audio, etc, and the
@@ -1197,7 +1196,7 @@
 					to the publication and all of the other documents. The second element is the Manifest (JSON). The
 					manifest is used to generate the <a href="#infoset">Information Set (“Infoset”)</a>, which consists of a
 					list of all the “things” in the publication, the publication metadata, and the default reading order of
-					content. It is noted in the diagram that the entry point has to link to the manifest.</dd>
+					content. It is noted in the diagram that the entry point has to link to the manifest. (<a role="doc-backlink" href="#WP-diagram">Return to the diagram</a> of Web Publication.)</dd>
 			</dl>
 
 		</section>

--- a/index.html
+++ b/index.html
@@ -190,9 +190,9 @@
 				<p>With the establishment of Web Publications, user agents can build new experiences tailored specifically
 					for their unique reading needs.</p>
 
-				<figure>	
-						<img src="images/WP-diagram.svg" alt="Simplified diagram of the structure of a web publication. The web publication is broken down into two elements. The first element is the actual contents (all the real things listed in the manifest.) This element is broken down into the CSS, the actual 'things' such as the html, audio, etc, and the images, fonts etc. The actual 'things' have an additional subset of items that includes the entry point to the  publication and all of the other documents. The second element is the Manifest (JSON). The manifest is used to generate the infoset, which consists of a list of  all the 'things' in the publication, the publication metadata, and the default reading order of content. It is noted in the diagram that the entry point  has to link to the manifest." />
-						 <figcaption>Simplified Diagram of the Structure of Web Publication. (The image is available in <a href="images/WP-diagram.svg">SVG</a> and in <a href="images/WP-diagram.png">PNG</a> formats.)
+				<figure id="WP-diagram">	
+						<img src="images/WP-diagram.svg" alt="Simplified diagram of the structure of a web publication. See the appendix for further details" />
+						 <figcaption>Simplified Diagram of the Structure of Web Publications. <br/>The image is available in <a href="images/WP-diagram.svg">SVG</a> and in <a href="images/WP-diagram.png">PNG</a> formats. A <a href="#WP-diagram-descr">longer description</a> of the diagram is also available in the Appendix.
 						</figcaption>
 				</figure>
 			</section>
@@ -1179,6 +1179,15 @@
 			<h2>Privacy</h2>
 
 			<div class="ednote">Placeholder for privacy issues.</div>
+		</section>
+		<section class="appendix">
+			<h2>Description of images</h2>
+
+			<dl>
+				<dt id="WP-diagram-descr">Description for <a href="#WP-diagram">the diagram for Web Publications</a>:</dt>
+				<dd>A simplified diagram of the structure of a <a>Web Publication</a>. The Web Publication is broken down into two elements. The first element is the actual contents (all the real things listed in the manifest). This element is broken down into the CSS, the actual “things” such as the HTML, audio, etc, and the images, fonts etc. The actual “things” have an additional subset of items that includes the entry point to the  publication and all of the other documents. The second element is the Manifest (JSON). The manifest is used to generate the <a href="#infoset">Information Set (“Infoset”)</a>, which consists of a list of  all the “things” in the publication, the publication metadata, and the default reading order of content. It is noted in the diagram that the entry point has to link to the manifest.</dd>
+			</dl>
+
 		</section>
 		<section id="ack" data-include="common/html/acknowledgements.html" data-include-replace="true"></section>
 	</body>

--- a/index.html
+++ b/index.html
@@ -190,10 +190,14 @@
 				<p>With the establishment of Web Publications, user agents can build new experiences tailored specifically
 					for their unique reading needs.</p>
 
-				<figure id="WP-diagram">	
-						<img src="images/WP-diagram.svg" alt="Simplified diagram of the structure of a web publication. See the appendix for further details" />
-						 <figcaption>Simplified Diagram of the Structure of Web Publications. <br/>The image is available in <a href="images/WP-diagram.svg">SVG</a> and in <a href="images/WP-diagram.png">PNG</a> formats. A <a href="#WP-diagram-descr">longer description</a> of the diagram is also available in the Appendix.
-						</figcaption>
+				<figure id="WP-diagram">
+					<img src="images/WP-diagram.svg"
+						alt="Flowchart depicts the resources Web Publication, their attachment to a manifest, and its relationship to the infoset." />
+					<figcaption>Simplified Diagram of the Structure of Web Publications. <br />A <a href="#WP-diagram-descr"
+							>description of the structure diagram</a> is available in the Appendix. Image available in <a
+							href="images/WP-diagram.svg" title="SVG image of the structure of Web Publications">SVG</a> and
+							<a title="PNG image of the structure of Web Publications" href="images/WP-diagram.png">PNG</a>
+						formats.</figcaption>
 				</figure>
 			</section>
 
@@ -1181,11 +1185,19 @@
 			<div class="ednote">Placeholder for privacy issues.</div>
 		</section>
 		<section class="appendix">
-			<h2>Description of images</h2>
+			<h2>Image Descriptions</h2>
 
 			<dl>
-				<dt id="WP-diagram-descr">Description for <a href="#WP-diagram">the diagram for Web Publications</a>:</dt>
-				<dd>A simplified diagram of the structure of a <a>Web Publication</a>. The Web Publication is broken down into two elements. The first element is the actual contents (all the real things listed in the manifest). This element is broken down into the CSS, the actual “things” such as the HTML, audio, etc, and the images, fonts etc. The actual “things” have an additional subset of items that includes the entry point to the  publication and all of the other documents. The second element is the Manifest (JSON). The manifest is used to generate the <a href="#infoset">Information Set (“Infoset”)</a>, which consists of a list of  all the “things” in the publication, the publication metadata, and the default reading order of content. It is noted in the diagram that the entry point has to link to the manifest.</dd>
+				<dt id="WP-diagram-descr">Description for <a role="doc-backlink" href="#WP-diagram">The Structure of Web
+						Publications diagram</a>:</dt>
+				<dd>A simplified diagram of the structure of a <a>Web Publication</a>. The Web Publication is broken down
+					into two elements. The first element is the actual contents (all the real things listed in the manifest).
+					This element is broken down into the CSS, the actual “things” such as the HTML, audio, etc, and the
+					images, fonts etc. The actual “things” have an additional subset of items that includes the entry point
+					to the publication and all of the other documents. The second element is the Manifest (JSON). The
+					manifest is used to generate the <a href="#infoset">Information Set (“Infoset”)</a>, which consists of a
+					list of all the “things” in the publication, the publication metadata, and the default reading order of
+					content. It is noted in the diagram that the entry point has to link to the manifest.</dd>
 			</dl>
 
 		</section>

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
 
 				<figure id="WP-diagram">
 					<img src="images/WP-diagram.svg"
-						alt="Flowchart depicts the resources Web Publication, their attachment to a manifest, and its relationship to the infoset." />
+						alt="Flowchart depicts the resources of a Web Publication, their attachment to a manifest, and its relationship to the infoset." />
 					<figcaption>Simplified Diagram of the Structure of Web Publications. <br />A <a href="#WP-diagram-descr"
 							>description of the structure diagram</a> is available in the Appendix. Image available in <a
 							href="images/WP-diagram.svg" title="SVG image of the structure of Web Publications">SVG</a> and


### PR DESCRIPTION
A separate Appendix has been created for the image description; there are bidirectional links between the diagram (figure 1) and its corresponding description. The Alt text has been made much shorter.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/116.html" title="Last updated on Dec 6, 2017, 5:33 AM GMT (50fe0b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/116/d436d29...50fe0b6.html" title="Last updated on Dec 6, 2017, 5:33 AM GMT (50fe0b6)">Diff</a>