### PR TITLE
ORCID logo rendering done properly

### DIFF
--- a/common/css/common.css
+++ b/common/css/common.css
@@ -28,5 +28,5 @@ dfn {
 }
 
 span.orcid a {
-	text-decoration: none !important;
+	border-bottom: none !important;
 }

--- a/common/css/common.css
+++ b/common/css/common.css
@@ -26,3 +26,7 @@ dt, dd {
 dfn {
 	font-weight: bold !important;
 }
+
+span.orcid a {
+	text-decoration: none !important;
+}

--- a/common/js/orcid.js
+++ b/common/js/orcid.js
@@ -1,0 +1,55 @@
+/**
+* Add an orcid image linked to the authors' and editors' ORCID ID-s (when applicable)
+*
+* The trigger is an additional "orcid" key in the person's object in the respec config. The "w3cid" key is also necessary (to be used anyway...)
+*/
+function show_orcid(config) {
+	let orcidmaps = {
+	};
+
+	//--------------------------------------------------------------------------------
+	// 1st step: find the authors/editors who have set their ORCID number as part of the persons' structure
+	// This can be extracted from the configuration set by the user (and extended by respec)
+	let personKeys = ["editors", "authors"]
+	personKeys.forEach( key => {
+		if( config[key] ) {
+			config[key].forEach( (editor) => {
+				if(editor.orcid && editor.w3cid) {
+					orcidmaps[editor.w3cid] = editor.orcid
+				}
+			});					
+		}
+	});
+
+	//---------------------------------------------------------------------------------
+	// 2nd step: find the persons in the header, see if their id is listed in orcidmap and, if yes
+	// add the additional image reference.
+	//
+	// 
+	// Persons are in a dd element with the class set to p-author (and some others)
+	document.querySelectorAll("dd.p-author").forEach( (element) => {
+		// Look at the data-editor-id value to see if it is relevant.
+		if( element.dataset.editorId ) {
+			// Get the possible ordicId from the orcid mapping
+			orcidId = orcidmaps[element.dataset.editorId]
+			if(orcidId) {
+				// Bingo; add a span with the image linked to the orcid web site
+				let span = document.createElement('span');
+				let a    = document.createElement('a');
+				let img  = document.createElement('img');
+
+				img.setAttribute('src','https://orcid.org/sites/default/files/images/orcid_16x16.gif');
+				img.setAttribute('alt','orcid logo');
+
+				a.setAttribute('href', `https://orcid.org/${orcidId}`);
+				a.appendChild(img);
+
+				span.setAttribute('class', 'orcid');
+				span.appendChild(a);
+
+				element.innerHTML += " "; 
+				element.appendChild(span);
+			}
+		}
+	});
+}

--- a/common/js/orcid.js
+++ b/common/js/orcid.js
@@ -10,7 +10,7 @@ function show_orcid(config) {
 	//--------------------------------------------------------------------------------
 	// 1st step: find the authors/editors who have set their ORCID number as part of the persons' structure
 	// This can be extracted from the configuration set by the user (and extended by respec)
-	let personKeys = ["editors", "authors"]
+	let personKeys = ["editors", "authors"];
 	personKeys.forEach( key => {
 		if( config[key] ) {
 			config[key].forEach( (editor) => {

--- a/index.html
+++ b/index.html
@@ -5,10 +5,12 @@
 		<title>Web Publications</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
 		<script src="common/js/biblio.js" class="remove"></script>
+		<script src="common/js/orcid.js" class="remove"></script>
 		<link href="common/css/common.css" rel="stylesheet" type="text/css" />
 		<script class="remove">
 		  // <![CDATA[
           var respecConfig = {
+          	  postProcess: [show_orcid],
               wg: "Publishing Working Group",
               specStatus: "ED",
               shortName: "wpub",
@@ -27,13 +29,7 @@
                     "url": "https://www.w3.org/People/Ivan/",
                     "company": "W3C",
 					"w3cid": 7382,
-                    "extras": [
-                    {
-                      //"name": "<img src='https://orcid.org/sites/default/files/images/orcid_16x16.gif' alt='orcid logo'/>",
-                      "name": "orcid",
-                      "href": "http://orcid.org/0000-0003-0782-2704",
-                      "class": "orcid"
-                    }],
+					"orcid": "0000-0003-0782-2704",
                     "companyURL": "https://www.w3.org",
                   }
               ],
@@ -50,13 +46,7 @@
                     "company": "University of Illinois at Urbana-Champaign",
                     "companyURL": "https://illinois.edu",
 					"w3cid": 53965,
-                    "extras": [
-                      {
-                        //"name": "<img src='https://orcid.org/sites/default/files/images/orcid_16x16.gif' alt='orcid logo'/>",
-                        "name": "orcid",
-                        "href": "https://orcid.org/0000-0002-5906-4581",
-                        "class": "orcid"
-                      }]
+					"orcid": "0000-0002-5906-4581"
                   },
 			      {
                     "name": "Dave Cramer",


### PR DESCRIPTION
Added a separate postprocessing script to respec to extract the ORCID ID from the initial config and display the ORCID logo. The ORCID Id should now be a separate key in the persons’ structure.

@mattgarrish I tried to remove the underlining of the logo by adding an extra entry in the CSS file. Did not work:-( Maybe you will be luckier!

If it is o.k. with you, I will make the changes on the annotation document as well


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/158.html" title="Last updated on Mar 3, 2018, 1:30 PM GMT (e32a830)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/158/3e1d32f...e32a830.html" title="Last updated on Mar 3, 2018, 1:30 PM GMT (e32a830)">Diff</a>