### PR TITLE
Added new dictionary in WebIDL for creators

### DIFF
--- a/index.html
+++ b/index.html
@@ -1795,9 +1795,6 @@
 					<dfn>LocalizableString</dfn> dictionary </h3>
 				<p class="ednote">This is a slightly tweaked version of the i18n recommendation that
 					also includes a string value in addition to a language and a direction.</p>
-				<p class="ednote">While this should be enough for the title, this strategy currently
-					limits the manifest to a single author. We'll need to introduce an additional
-					dictionary for authors to avoid this issue.</p>
 				<p>In our <abbr title="information set"><a>infoset</a></abbr>, some metadata have
 					strong requirements for internationalization. For those members, we rely on the
 						<a href="https://w3c.github.io/string-meta/#bestPractices">best practices

--- a/index.html
+++ b/index.html
@@ -1682,7 +1682,7 @@
                                     TextDirection                           dir = "auto";
                                     sequence&lt;LocalizableString&gt;       title;
                                     USVString                               identifier;
-                                    sequence&lt;LocalizableString&gt;       author;
+                                    sequence&lt;Contributor&gt;             author;
                                     DOMString                               modified;
                                     DOMString                               publication_date;
                                     sequence&lt;PublicationLink&gt;         links;
@@ -1755,16 +1755,38 @@
 					<dt>
 						<dfn>ltr</dfn>
 					</dt>
-					<dd> left-to-right text. </dd>
+					<dd> Left-to-right text. </dd>
 					<dt>
 						<dfn>rtl</dfn>
 					</dt>
-					<dd> right-to-left text. </dd>
+					<dd> Right-to-left text. </dd>
 					<dt>
 						<dfn>auto</dfn>
 					</dt>
-					<dd> determined by the Unicode Bidirectional Algorithm [[!UAX9]] algorithm.
+					<dd> Determined by the Unicode Bidirectional Algorithm [[!UAX9]] algorithm.
 					</dd>
+				</dl>
+			</section>
+            
+            <section id="contributor-idl">
+				<h3><code>author</code> member </h3>
+                <p class="ednote">The <a href="#wp-creators">current infoset for creators</a> is currently a little underdefined, and this dictionary might be further improved once this groups fully agrees how they should be handled.</p>
+				<pre class="idl">
+                    dictionary Contributor {
+                        required    LocalizableString       name;
+                                    USVString               identifier;
+                    };
+                </pre>
+				<p> The <code>author</code> member is a sequence of <dfn>Contributor</dfn> dictionaries where each dictionary has the following members: </p>
+				<dl data-dfn-for="Contributor">
+					<dt>
+						<dfn>name</dfn>
+					</dt>
+					<dd> Contains one or more localizable string for the contributor's name. </dd>
+					<dt>
+						<dfn>identifier</dfn>
+					</dt>
+					<dd> Contains a canonical identifier for the contributor. </dd>
 				</dl>
 			</section>
 

--- a/index.html
+++ b/index.html
@@ -1770,7 +1770,7 @@
             
             <section id="contributor-idl">
 				<h3><code>author</code> member </h3>
-                <p class="ednote">The <a href="#wp-creators">current infoset for creators</a> is currently a little underdefined, and this dictionary might be further improved once this groups fully agrees how they should be handled.</p>
+                <p class="ednote">The <a href="#wp-creators">current infoset for creators</a> is a little underdefined, and this dictionary might be further improved once this groups fully agrees how they should be handled.</p>
 				<pre class="idl">
                     dictionary Contributor {
                         required    LocalizableString       name;


### PR DESCRIPTION
Our current WebIDL only allows a single creator for a Web Publication, which goes against our infoset.

This pull request introduces a new dictionary to our WebIDL to allow for multiple creators.

Based on the current discussions in #151, this also introduces a canonical identifier for creators.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/161.html" title="Last updated on Mar 13, 2018, 11:55 AM GMT (8d8cc80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/161/9b248d4...8d8cc80.html" title="Last updated on Mar 13, 2018, 11:55 AM GMT (8d8cc80)">Diff</a>