### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,7 +464,7 @@
 						consumption of the content, (e.g., provide a table of contents or a link to one).</p>
 
 					<p>The availability of the address does not preclude the creation and use of other identifiers
-						and/or addresses to retrieve a representation of a <a>Web Publication</a>, whether in whole or
+						and/or addresses to retrieve a <a>Web Publication</a>, whether in whole or
 						in part.</p>
 
 					<div class="note">The Web Publication's address can also be used as value for an identifier link


### PR DESCRIPTION
identifiers and/or addresses allow to retrieve the WP, why representation?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/172.html" title="Last updated on Apr 5, 2018, 6:21 AM GMT (b8b7b24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/172/1af873d...b8b7b24.html" title="Last updated on Apr 5, 2018, 6:21 AM GMT (b8b7b24)">Diff</a>