### PR TITLE
Change editoral note about context to ref #104

### DIFF
--- a/index.html
+++ b/index.html
@@ -986,6 +986,8 @@
 					these approaches is welcome at any time.</p>
 			</div>
 
+			<p class="issue" data-number="104"></p>
+
 			<section id="obtaining-manifest">
 				<h3>Obtaining a manifest</h3>
 
@@ -1032,9 +1034,6 @@
 
 				<p class="note">See the <a href="#obtaining-manifest-diagram">diagram in the appendix</a> for a visual
 					representation of the algorithm.</p>
-
-				<div class="ednote">The <code>publication</code> value for context doesn't exist yet. The working group
-					will need to define and register this context value.</div>
 			</section>
 
 			<section id="processing-manifest">


### PR DESCRIPTION
The matter of where the lifecycle (and by extension WebIDL) exists
is an issue for the working group to discuss and determine, and not
merely an editorial note (as it was previously).

This removes the note and references issue #104 in its place.