### PR TITLE
remove "Why Web Publications" from the introduction

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,48 +120,6 @@
 		<section id="intro">
 			<h2>Introduction</h2>
 
-			<section id="why-wp" class="informative">
-				<h3>Why Web Publications</h3>
-
-				<p>The Web is a lonely place. It is unbounded: resources live out their lives on remote servers
-					scattered across the globe, only reachable by addresses sometimes known to only a few people. But
-					life on the Web is not all doom and gloom. Through the power of Web pages, these resources can be
-					brought together to create amazing experiences.</p>
-
-				<p>Web sites add another layer of relationship—this time between pages—but the relationship is a tenuous
-					one that typically depends on hyperlinks to add cohesion. Without a user that understands how to
-					follow the connections, a Web site is still no more than a loose coupling of information.</p>
-
-				<p>The preceding is not a critique of the Web, but meant to highlight that the modern Web is very much
-					an active, event-driven experience. Users follow the necessary paths to obtain the information they
-					need.</p>
-
-				<p>The traditional publishing model, sometimes called the print model, differs from the Web model in
-					that the publisher packages all the information together and thereby establishes the common pathway
-					through it. The user can passively follow the content page-by-page, or actively find other pathways
-					via a table of contents or index. It is a model that has worked to bind information in a cohesive
-					way for millennia, and continues to be an important model alongside the Web. The publication as a
-					bounded edition, made public, is used to carry intellectual and artistic works of innumerable form:
-					novels, plays, poetry, journals, magazines, newspapers, articles, laws, treatises, pamphlets,
-					atlases, comics, manga, notebooks, memos, manuals, and albums of all sorts.</p>
-
-				<p>Attempts to reproduce this model on the Web have had to work around its loose coupling of
-					information: sometimes publications are compressed into a single page; sometimes they are broken
-					across multiple pages and hyperlinked together. These models both have flaws, however: single-page
-					publications are often so large they render slowly, especially on low-power devices; multi-page
-					publications cannot be easily taken offline because their common thread cannot be established.</p>
-
-				<p>As a result, users have had trouble accessing, compiling and downloading Web content for curation and
-					personal use. That, in turn, has fed the continuing development of non-Web digital formats to
-					redress these problems, and made it necessary to create both Web-ready content and alternative
-					renditions for offline use.</p>
-
-				<p>This specification aims to reduce these barriers and reinvigorate publishing by combining the best
-					aspects of both models—the persistent availability and portability of bounded publications with the
-					pervasive accessibility, addressability, and interconnectedness of the Open Web Platform. To do so,
-					it adds an unobtrusive definition of interrelation to the Web model: the <a>Web Publication</a>.</p>
-			</section>
-
 			<section id="what-is-wp" class="informative">
 				<h3>What is a Web Publication</h3>
 


### PR DESCRIPTION
This pull request removes the section from the introduction because it is more advocacy than a practical statement of the technology, and distracts from the specification itself.

Anything we write to replace the current text is only going to speak to a specific point in time, and will date the specification, so removal is better than replacement IMO.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/184.html" title="Last updated on May 1, 2018, 7:22 PM GMT (9d72cdb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/184/721ac64...9d72cdb.html" title="Last updated on May 1, 2018, 7:22 PM GMT (9d72cdb)">Diff</a>