### PR TITLE
Work-In-Progress: expression experiments

### DIFF
--- a/experiments/html-schema-org-json-ld/index.html
+++ b/experiments/html-schema-org-json-ld/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+<head lang="en">
+    <title>Moby-Dick</title>
+    <script type="application/ld+json" id="manifest">
+    {
+        "@context": "http://schema.org/",
+        "@id": "https://publisher.example.org/mobydick/",
+
+        "@type": "http://schema.org/Book",
+        "name": "Moby-Dick",
+        "author": "Herman Melville",
+        "image": "images/cover.jpg"
+        "inLanguage": "en",
+        "dateModified": "2018-02-10T17:00:00Z"
+      }
+    </script>
+</head>
+<body>
+    <nav role="doc-toc">
+      <ol>
+        <li><a href="html/title.html">Title Page</a></li>
+        <li><a href="html/copyright.html">Copyright</a></li>
+        <li><a href="html/introduction.html">Etymology</a></li>
+        <li><a href="html/epigraph.html">Extracts</a></li>
+        <li><a href="html/c001.html">Chapter 1 - Loomings</a></li>
+        <li><a href="html/c001.html">Chapter 1 - Loomings</a></li>
+        <li><a href="html/c001.html">Chapter 1 - Loomings</a></li>
+        <li><a href="html/c001.html">Chapter 1 - Loomings</a></li>
+        <li><a href="html/c001.html">Chapter 2 - The Carpet-Bad</a></li>
+        <li><a href="html/c001.html">Chapter 3 - The Spouter-Inn</a></li>
+        <li><a href="html/c001.html">Chapter 4 - The Counterpane</a></li>
+        <li><a href="html/c001.html">Chapter 5 - Breakfast</a></li>
+        <li><a href="html/c001.html">Chapter 5 - The Street</a></li>
+      </ol>
+    </nav>
+    ....
+</body>
+</html>

--- a/experiments/manifest_script/mobydick.html
+++ b/experiments/manifest_script/mobydick.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html>
+<head lang="en">
+    <title>Moby Dick—Table of Content</title>
+    <link href="#manifest" rel="wpub-manifest" />
+    <script type="application/ld+json" id="manifest">
+        "@context": "http://www.w3.org/ns/wpub.jsonld",
+        "@id": "https://publisher.example.org/mobydick",
+
+        "metadata": {
+          "@type": "http://schema.org/Book",
+          "title": "Moby-Dick",
+          "author": "Herman Melville",
+          "language": "en",
+          "modified": "2018-02-10T17:00:00Z"
+        },
+
+        "links": [
+          {"rel": "cover", "href": "images/cover.jpg", "type": "image/jpeg", "height": 1253, "width": 797}
+        ],
+
+        "resources": [
+          {"href": "css/mobydick.css", "type": "text/css"},
+          {"href": "fonts/STIXGeneral.otf", "type": "application/vnd.ms-opentype"},
+          {"href": "fonts/STIXGeneralBol.otf", "type": "application/vnd.ms-opentype"},
+          {"href": "fonts/STIXGeneralBolIta.otf", "type": "application/vnd.ms-opentype"},
+          {"href": "fonts/STIXGeneralItalic.otf", "type": "application/vnd.ms-opentype"}
+        ]
+      }
+    </script>
+</head>
+<body>
+    <nav role="doc-toc">
+        <li><a href="html/title.html">Title Page</a></li>
+        <li><a href="html/copyright.html">Copyright</a></li>
+        <li><a href="html/introduction.html">Etymology</a></li>
+        <li><a href="html/epigraph.html">Extracts</a></li>
+        <li><a href="html/c001.html">Chapter 1 - Loomings</a></li>
+        <li><a href="html/c001.html">Chapter 1 - Loomings</a></li>
+        <li><a href="html/c001.html">Chapter 1 - Loomings</a></li>
+        <li><a href="html/c001.html">Chapter 1 - Loomings</a></li>
+        <li><a href="html/c001.html">Chapter 2 - The Carpet-Bad</a></li>
+        <li><a href="html/c001.html">Chapter 3 - The Spouter-Inn</a></li>
+        <li><a href="html/c001.html">Chapter 4 - The Counterpane</a></li>
+        <li><a href="html/c001.html">Chapter 5 - Breakfast</a></li>
+        <li><a href="html/c001.html">Chapter 5 - The Street</a></li>
+    </nav>
+    ....
+</body>
+</html>

--- a/experiments/separate_manifest/mobydick.html
+++ b/experiments/separate_manifest/mobydick.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <title>Moby Dick—Table of Content</title>
+    <link href="mobydick.json" rel="wpub-manifest" />
+</head>
+<body>
+    ....
+</body>
+</html>

--- a/experiments/separate_manifest/mobydick.json
+++ b/experiments/separate_manifest/mobydick.json
@@ -1,0 +1,38 @@
+{
+  "@context": "http://www.w3.org/ns/wpub.jsonld",
+  "@id": "https://publisher.example.org/mobydick",
+
+  "metadata": {
+    "@type": "http://schema.org/Book",
+    "title": "Moby-Dick",
+    "author": "Herman Melville",
+    "language": "en",
+    "modified": "2018-02-10T17:00:00Z"
+  },
+
+  "links": [
+    {"rel": "cover", "href": "images/cover.jpg", "type": "image/jpeg", "height": 1253, "width": 797}
+  ],
+
+  "spine": [
+    {"href": "html/title.html", "type": "text/html", "title": "Title Page"},
+    {"href": "html/copyright.html", "type": "text/html", "title": "Copyright"},
+    {"href": "html/introduction.html", "type": "text/html", "title": "Etymology"},
+    {"href": "html/epigraph.html", "type": "text/html", "title": "Extracts"},
+    {"href": "html/c001.html", "type": "text/html", "title": "Chapter 1 - Loomings"},
+    {"href": "html/c002.html", "type": "text/html", "title": "Chapter 2 - The Carpet-Bad"},
+    {"href": "html/c003.html", "type": "text/html", "title": "Chapter 3 - The Spouter-Inn"},
+    {"href": "html/c004.html", "type": "text/html", "title": "Chapter 4 - The Counterpane"},
+    {"href": "html/c005.html", "type": "text/html", "title": "Chapter 5 - Breakfast"},
+    {"href": "html/c006.html", "type": "text/html", "title": "Chapter 6 - The Street"}
+  ],
+
+  "resources": [
+    {"href": "html/toc.html", "rel": "contents", "type": "text/html", "title": "Table of Contents"},
+    {"href": "css/mobydick.css", "type": "text/css"},
+    {"href": "fonts/STIXGeneral.otf", "type": "application/vnd.ms-opentype"},
+    {"href": "fonts/STIXGeneralBol.otf", "type": "application/vnd.ms-opentype"},
+    {"href": "fonts/STIXGeneralBolIta.otf", "type": "application/vnd.ms-opentype"},
+    {"href": "fonts/STIXGeneralItalic.otf", "type": "application/vnd.ms-opentype"}
+  ]
+}


### PR DESCRIPTION
This PR (currently) includes:
 - @iherman's https://github.com/iherman/misc-notes/tree/master/wp-manifest-experiments files (verbatim) in https://github.com/w3c/wpub/commit/aebfe133dc5305a7b07df8b7949ca5e32246117a
 - my addition of a `<nav>` fallback HTML entry page with an Schema.org-based JSON-LD data block in the header

There's room for many more of these, and perhaps using the GitHub Pull Request review features here will let us explore "line-by-line" feedback (if/as needed).