### PR TITLE
Toronto f2f resolutions start

### DIFF
--- a/index.html
+++ b/index.html
@@ -657,15 +657,12 @@
 					<h4>Resource List</h4>
 
 					<p>The <dfn>resource list</dfn> enumerates all <a href="#wp-resources">resources</a> that are used
-						in the processing and rendering of a <a>Web Publication</a> (i.e., that are within its bounds).
-						This list is the definitive source that user agents have in determining which referenced
-						resources belong to the Web Publication and which are external to it.</p>
+						in the processing and rendering of a <a>Web Publication</a> (i.e., that are within its bounds) and that are not listed in the <a>default reading order</a>. This list is the definitive source that user agents have in determining which referenced resources belong to the Web Publication and which are external to it.</p>
 
 					<p>The completeness of the resource list will affect the usability of the Web Publication in certain
 						reading scenarios (e.g., the ability to read the Web Publication offline). For this reason, it
 						is strongly RECOMMENDED to provide a comprehensive list of all of the Web Publication's
-						constituent resources. At a minimum, the resource list MUST include a list of all resources in
-						the <a>default reading order</a>.</p>
+						constituent resources beyond those listed in the <a>default reading order</a>.</p>
 
 					<p>In some cases, a comprehensive list of these resources might not be easily achieved (e.g.,
 						third-party scripts that reference resources from deep within their source), but a user agent
@@ -673,14 +670,17 @@
 						identified as belonging to the Web Publication (e.g., when it is taken offline without
 						them).</p>
 
-					<p>If a user agent encounters a resource that it cannot locate in the resource list, it MUST treat
-						the resource as external to the Web Publication (e.g., it might alert the user before loading,
-						open the resource in a new window, or unload the current Web Publication and resume normal Web
-						browsing).</p>
+					<div class="ednote">
+						The previous version of the draft included:
+						<blockquote>
+							<p>If a user agent encounters a resource that it cannot locate in the resource list, it MUST treat
+								the resource as external to the Web Publication (e.g., it might alert the user before loading,
+								open the resource in a new window, or unload the current Web Publication and resume normal Web
+								browsing).</p>
+						</blockquote>
 
-
-					<p class="issue" data-number="59">Must the <a>manifest</a> list resources in the default reading
-						order or can these can be inferred?</p>
+						<p>This was not decided on the Toronto F2F, and is still open.</p>
+					</div>
 				</section>
 
 				<section id="wp-table-of-contents">

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
               wgPublicList:      "public-publ-wg",
               wgPatentURI:       "https://www.w3.org/2004/01/pp-impl/100074/status",
 			  github:			 {
-				  repoURL: "https://github.com/w3c/wpub",
+				  repoURL: "https://github.com/w3c/wpub/",
 				  branch: "master"
 			  },
               // otherLinks: [

--- a/index.html
+++ b/index.html
@@ -691,39 +691,13 @@
 						completeness of the table of contents, except that, when specified, it MUST include a link to at
 						least one <a href="#wp-resources">resource</a>.</p>
 
-					<p>The table of contents is either specified directly in the manifest or in a <code>nav</code>
-						element&#160;[[!html]]. In the latter case, the manifest MUST provide a link to the Web
-						Publication resource that contains the <code>nav</code> element, with a fragment identifier that
-						specifically identifies it.</p>
-
-					<p>If a user agent requires a table of contents and one is not specified, it MAY construct one. This
-						specification does not mandate how such a table of contents is created. The user agent might: </p>
-
-					<ol>
-						<li>attempt to locate a table of contents in the <a>default reading order</a> (e.g., an <abbr
-								title="Hypertext Markup Language">HTML</abbr> document with a <code>nav</code> element
-							that has the <code>role</code> attribute value <code>doc-toc</code>);</li>
-						<li>use the titles of the resources in the default reading order;</li>
-						<li>calculate a table of contents using its own algorithms.</li>
-					</ol>
+					<p>
+						The table of contents is not specified directly in the manifest. Instead, the manifest SHOULD provide a link to an HTML element in one of the <a href="#wp-resources">resources</a> (most likely a <code>nav</code> element&#160;[[!html]]), with a <code>role</code> attribute value set to <code>doc-toc</code>.
+					</p>
 
 					<p class="issue">This question arises only if the table of contents is accepted: can a table of
 						contents navigation element refer, via links, to any resource that is <em>not</em> listed in the
 							<a>default reading order</a>?</p>
-
-					<div class="issue">
-						<p>The issue of using the <abbr title="Hypertext Markup Language">HTML</abbr>
-							<code>nav</code> element as a possible encoding of the table of contents was mentioned or
-							explicitly addressed in the following (now closed) issues:</p>
-						<ul>
-							<li><a href="https://github.com/w3c/wpub/issues/35">Issue #35</a>: Define the resources in
-								the <a>default reading order</a> of a <a>Web Publication</a> to be the resources
-								referenced from the table of contents.</li>
-							<li><a href="https://github.com/w3c/wpub/issues/39">Issue #39</a>: There is a consensus that
-								a Web Publication must have a <a>default reading order</a> and must/should have a
-									<a>table of contents</a> (the main navigation entry page).</li>
-						</ul>
-					</div>
 				</section>
 			</section>
 

--- a/index.html
+++ b/index.html
@@ -650,32 +650,7 @@
 
 					<p>The default reading order MUST include at least one resource.</p>
 
-					<p>The default reading order is either specified directly in the manifest or in a <code>nav</code>
-						element&#160;[[!html]]. In the latter case, the manifest MUST provide a link to the Web
-						Publication resource that contains the <code>nav</code> element, with a fragment identifier that
-						specifically identifies it.</p>
-
-					<p>The process for extracting a default reading order from a <code>nav</code> element are as
-						follows:</p>
-
-					<ol>
-						<li>extract a list of resource paths referenced from the <code>href</code> attribute of all
-								<code>a</code> elements;</li>
-						<li>strip any fragment identifiers from the references;</li>
-						<li>resolve all relative paths to full <abbr title="Uniform Resource Locators">URLs</abbr>;</li>
-						<li>remove all consecutive references to the same resource, leaving only the first.</li>
-					</ol>
-
-					<p>If a user agent requires a default reading order and one is not provided in the <abbr
-							title="information set"><a>infoset</a></abbr>, it MAY attempt to construct one. This
-						specification does not mandate how such a default reading order is created. The user agent
-						might:</p>
-
-					<ul>
-						<li>use only the resource the user accessed to reach the manifest;</li>
-						<li>search the <a>resource list</a> for a <code>nav</code> element to use;</li>
-						<li>calculate the default reading order using its own algorithm.</li>
-					</ul>
+					<p>The default reading order is either specified directly in the manifest; if this is not the case, the reading order consists of one single resource, namely the primary entry page of the Web Publication (i.e., the resource the user accessed to reach the manifest, see <a href="#wp-linking"></a>.)</p>
 				</section>
 
 				<section id="wp-resource-list">

--- a/index.html
+++ b/index.html
@@ -655,7 +655,7 @@
 
 					<p>The default reading order MUST include at least one resource.</p>
 
-					<p>The default reading order is either specified directly in the manifest; if this is not the case, the reading order consists of one single resource, namely the primary entry page of the Web Publication (i.e., the resource the user accessed to reach the manifest, see <a href="#wp-linking"></a>.)</p>
+					<p>The default reading order is specified directly in the manifest. If the reading order consists of one single resource, namely the primary entry page of the Web Publication (i.e., the resource the user accesses to reach the manifest, see <a href="#wp-linking"></a>), the default reading order need not be specified in the manifest.</p>
 				</section>
 
 				<section id="wp-resource-list">

--- a/index.html
+++ b/index.html
@@ -583,6 +583,9 @@
 
 					<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
 						Publications.</p>
+
+					<p class="issue" data-number="203"></p>
+
 				</section>
 
 				<section id="wp-reading-progression">

--- a/index.html
+++ b/index.html
@@ -75,39 +75,39 @@
               wgURI:             "https://www.w3.org/publishing/groups/publ-wg/",
               wgPublicList:      "public-publ-wg",
               wgPatentURI:       "https://www.w3.org/2004/01/pp-impl/100074/status",
-			  // github:			 {
-				//   repoURL: "https://github.com/w3c/wpub",
-				//   branch: "master"
-			  // },
-              otherLinks: [
-                  {
-                    key: "Participate",
-                    data: [{
-                        value: "Github w3c/wpub",
-                        href: "https://github.com/w3c/wpub"
-                      },
-					  {
-						value: "File a bug",
-						href: "https://github.com/w3c/wpub/issues"
-					  },
-					  {
-						value: "Commit history",
-						href: "https://github.com/w3c/wpub/commits/master"
-					  },
-					  {
-						value: "Pull requests",
-						href: "https://github.com/w3c/wpub/pulls"
-					}]
-                  },
-                  // {
-                  //   key: "Changes",
-                  //   data: [
-                  //   // {
-                  //   //   value: "Diff to previous version",
-                  //   //   href: "diff.html"
-                  //   // },
-                  // }
-              ],
+			  github:			 {
+				  repoURL: "https://github.com/w3c/wpub",
+				  branch: "master"
+			  },
+              // otherLinks: [
+              //     {
+              //       key: "Participate",
+              //       data: [{
+              //           value: "Github w3c/wpub",
+              //           href: "https://github.com/w3c/wpub"
+              //         },
+				// 	  {
+				// 		value: "File a bug",
+				// 		href: "https://github.com/w3c/wpub/issues"
+				// 	  },
+				// 	  {
+				// 		value: "Commit history",
+				// 		href: "https://github.com/w3c/wpub/commits/master"
+				// 	  },
+				// 	  {
+				// 		value: "Pull requests",
+				// 		href: "https://github.com/w3c/wpub/pulls"
+				// 	}]
+              //     },
+              //     // {
+              //     //   key: "Changes",
+              //     //   data: [
+              //     //   // {
+              //     //   //   value: "Diff to previous version",
+              //     //   //   href: "diff.html"
+              //     //   // },
+              //     // }
+              // ],
               localBiblio: biblio
           };
           // ]]>
@@ -470,6 +470,8 @@
 						does not define requirements for the creation of such cover images (e.g., the user agent could
 						use a placeholder image, generate an image dynamically, or incorporate properties of the infoset
 						into a graphic, such as the title or creators).</p>
+
+					<p class="issue" data-number="210"></p>
 				</section>
 
 				<section id="wp-creators">


### PR DESCRIPTION
Made a first draft to incorporate some resolutions around structural infoset items: reading order, TOC, resources, and added references to the issues around cover and privacy policy.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/211.html" title="Last updated on Jun 7, 2018, 1:08 PM GMT (18c82e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/211/769817a...18c82e7.html" title="Last updated on Jun 7, 2018, 1:08 PM GMT (18c82e7)">Diff</a>