### PR TITLE
Aligned WebIDL proposal with recent discussions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1518,7 +1518,7 @@
 				<pre class="idl">
                     dictionary PublicationLink {
                         required    DOMString                           url;
-                                    DOMString                           type;
+                                    DOMString                           fileFormat;
                                     DOMString                           name;
                                     sequence&lt;DOMString&gt;           rel;
                                     sequence&lt;PublicationLink&gt;     children;
@@ -1533,7 +1533,7 @@
 					</dt>
 					<dd>Contains the URL of the linked resource.&#160;[[!url]]</dd>
 					<dt>
-						<dfn>type</dfn>
+						<dfn>fileFormat</dfn>
 					</dt>
 					<dd>Contains the MIME media type of the linked resource.&#160;[[!rfc2046]]</dd>
 					<dt>

--- a/index.html
+++ b/index.html
@@ -1370,17 +1370,17 @@
 
 				<pre class="idl">
                     dictionary WebPublicationManifest {
-                        required    DOMString                               address;
+                        required    DOMString                               url;
                                     DOMString                               lang;
-                                    TextDirection                           dir = "auto";
-                                    TextDirection                           progression = "auto";
-                                    sequence&lt;LocalizableString&gt;       title;
-                                    DOMString                               identifier;
+                                    TextDirection                           direction = "auto";
+                                    TextDirection                           readingProgression = "auto";
+                                    sequence&lt;LocalizableString&gt;       name;
+                                    DOMString                               id;
                                     sequence&lt;Contributor&gt;             authors;
-                                    DOMString                               modified;
-                                    DOMString                               publication_date;
+                                    DOMString                               dateModified;
+                                    DOMString                               datePublished;
                                     sequence&lt;PublicationLink&gt;         links;
-                                    sequence&lt;PublicationLink&gt;         reading_order;
+                                    sequence&lt;PublicationLink&gt;         readingOrder;
                                     sequence&lt;PublicationLink&gt;         resources;
                                     sequence&lt;PublicationLink&gt;         toc;
                     };
@@ -1390,7 +1390,7 @@
 
 				<dl data-dfn-for="WebPublicationManifest">
 					<dt>
-						<dfn>address</dfn>
+						<dfn>url</dfn>
 					</dt>
 					<dd>Contains the <a href="#wp-address">address</a>. Required.</dd>
 					<dt>
@@ -1398,19 +1398,19 @@
 					</dt>
 					<dd>Contains the default value <a href="#wp-language">language</a>.</dd>
 					<dt>
-						<dfn>dir</dfn>
+						<dfn>direction</dfn>
 					</dt>
 					<dd>Contains the default value for <a>base direction</a>.</dd>
 					<dt>
-						<dfn>progression</dfn>
+						<dfn>readingProgression</dfn>
 					</dt>
 					<dd>Contains the value for the <a>reading progression direction</a>.</dd>
 					<dt>
-						<dfn>title</dfn>
+						<dfn>name</dfn>
 					</dt>
 					<dd>Contains the <a href="#wp-title">title</a>.</dd>
 					<dt>
-						<dfn>identifier</dfn>
+						<dfn>id</dfn>
 					</dt>
 					<dd>Contains the <a>canonical identifier</a>.</dd>
 					<dt>
@@ -1418,11 +1418,11 @@
 					</dt>
 					<dd>Contains one or more <a href="#wp-creators">creators</a>.</dd>
 					<dt>
-						<dfn>modified</dfn>
+						<dfn>dateModified</dfn>
 					</dt>
 					<dd>Contains the <a>last modification date</a>.</dd>
 					<dt>
-						<dfn>publication_date</dfn>
+						<dfn>datePublished</dfn>
 					</dt>
 					<dd>Contains the <a>publication date</a>.</dd>
 					<dt>
@@ -1430,7 +1430,7 @@
 					</dt>
 					<dd>Contains links to external resources.</dd>
 					<dt>
-						<dfn>reading_order</dfn>
+						<dfn>readingOrder</dfn>
 					</dt>
 					<dd>Contains the <a>default reading order</a>.</dd>
 					<dt>
@@ -1445,7 +1445,7 @@
 			</section>
 
 			<section id="contributor-idl">
-				<h3><code>author</code> member </h3>
+				<h3><code>authors</code> member </h3>
 
 				<p class="ednote">The <a href="#wp-creators">current infoset for creators</a> is not fully defined; this
 					dictionary might be further improved once there is agreement on how they should be handled.</p>
@@ -1453,7 +1453,7 @@
 				<pre class="idl">
                     dictionary Contributor {
                         required    LocalizableString       name;
-                                    DOMString               identifier;
+                                    DOMString               id;
                     };
                 </pre>
 
@@ -1466,7 +1466,7 @@
 					</dt>
 					<dd>Contains one or more localizable string for the contributor's name.</dd>
 					<dt>
-						<dfn>identifier</dfn>
+						<dfn>id</dfn>
 					</dt>
 					<dd>Contains a canonical identifier for the contributor.</dd>
 				</dl>
@@ -1517,24 +1517,19 @@
 
 				<pre class="idl">
                     dictionary PublicationLink {
-                        required    DOMString                           href;
+                        required    DOMString                           url;
                                     DOMString                           type;
-                                    DOMString                           title;
+                                    DOMString                           name;
                                     sequence&lt;DOMString&gt;           rel;
                                     sequence&lt;PublicationLink&gt;     children;
                     };
                 </pre>
 
-				<p class="ednote">This definition is based on a simplifed model of <abbr
-						title="Readium Web Publication Manifest"><a href="https://github.com/readium/webpub-manifest"
-							>RWPM</a></abbr>, where the link does not contain properties. In the context of EPUB 4, the
-					working group might also need to re-introduce these properties.</p>
-
 				<p>The PublicationLink dictionary contains the following members:</p>
 
 				<dl data-dfn-for="PublicationLink">
 					<dt>
-						<dfn>href</dfn>
+						<dfn>url</dfn>
 					</dt>
 					<dd>Contains the URL of the linked resource.&#160;[[!url]]</dd>
 					<dt>
@@ -1542,7 +1537,7 @@
 					</dt>
 					<dd>Contains the MIME media type of the linked resource.&#160;[[!rfc2046]]</dd>
 					<dt>
-						<dfn>title</dfn>
+						<dfn>name</dfn>
 					</dt>
 					<dd>Text label for the linked resource.</dd>
 					<dt>

--- a/index.html
+++ b/index.html
@@ -1370,18 +1370,19 @@
 
 				<pre class="idl">
                     dictionary WebPublicationManifest {
-                        required    USVString                               address;
+                        required    DOMString                               address;
                                     DOMString                               lang;
                                     TextDirection                           dir = "auto";
                                     TextDirection                           progression = "auto";
                                     sequence&lt;LocalizableString&gt;       title;
-                                    USVString                               identifier;
-                                    sequence&lt;Contributor&gt;             author;
+                                    DOMString                               identifier;
+                                    sequence&lt;Contributor&gt;             authors;
                                     DOMString                               modified;
                                     DOMString                               publication_date;
                                     sequence&lt;PublicationLink&gt;         links;
                                     sequence&lt;PublicationLink&gt;         reading_order;
                                     sequence&lt;PublicationLink&gt;         resources;
+                                    sequence&lt;PublicationLink&gt;         toc;
                     };
       </pre>
 
@@ -1413,7 +1414,7 @@
 					</dt>
 					<dd>Contains the <a>canonical identifier</a>.</dd>
 					<dt>
-						<dfn>author</dfn>
+						<dfn>authors</dfn>
 					</dt>
 					<dd>Contains one or more <a href="#wp-creators">creators</a>.</dd>
 					<dt>
@@ -1436,6 +1437,10 @@
 						<dfn>resources</dfn>
 					</dt>
 					<dd>Contains the <a>resource list</a>.</dd>
+					<dt>
+						<dfn>toc</dfn>
+					</dt>
+					<dd>Contains the <a>table of contents</a>.</dd>
 				</dl>
 			</section>
 
@@ -1448,7 +1453,7 @@
 				<pre class="idl">
                     dictionary Contributor {
                         required    LocalizableString       name;
-                                    USVString               identifier;
+                                    DOMString               identifier;
                     };
                 </pre>
 
@@ -1480,7 +1485,7 @@
 
 				<pre class="idl">
                     dictionary LocalizableString {
-                        required    USVString       value;
+                        required    DOMString       value;
                                     DOMString       lang;
                                     TextDirection   dir = "auto";
                     };
@@ -1512,13 +1517,11 @@
 
 				<pre class="idl">
                     dictionary PublicationLink {
-                        required    USVString                   href;
-                                    DOMString                   type;
-                                    USVString                   title;
-                                    sequence&lt;DOMString&gt;   rel;
-                                    DOMString                   height;
-                                    DOMString                   width;
-                                    boolean                     templated;
+                        required    DOMString                           href;
+                                    DOMString                           type;
+                                    DOMString                           title;
+                                    sequence&lt;DOMString&gt;           rel;
+                                    sequence&lt;PublicationLink&gt;     children;
                     };
                 </pre>
 
@@ -1548,18 +1551,9 @@
 					<dd>Contains one or more relations based on the IANA link
 						registry.&#160;[[!iana-link-relations]]</dd>
 					<dt>
-						<dfn>height</dfn>
+						<dfn>children</dfn>
 					</dt>
-					<dd>Height of the linked resource, expressed in CSS pixels.&#160;[[!css]]</dd>
-					<dt>
-						<dfn>width</dfn>
-					</dt>
-					<dd>Width of the linked resource, expressed in CSS pixels.&#160;[[!css]]</dd>
-					<dt>
-						<dfn>templated</dfn>
-					</dt>
-					<dd>Indicates that the <a href="#dom-publicationlink-rel"><code>href</code></a> is a URI
-						template.&#160;[[!rfc6570]]</dd>
+					<dd>Contains one or more child resources for the current resource.</dd>
 				</dl>
 
 			</section>


### PR DESCRIPTION
Based on the F2F and post-F2F calls, I’ve aligned the WebIDL a bit more with schema.org.

This PR also contains a first take on handling the TOC in the WebIDL, using a tree structure and a single WebIDL dictionary.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/224.html" title="Last updated on Jun 12, 2018, 2:35 PM GMT (5b9d711)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/224/86f437e...5b9d711.html" title="Last updated on Jun 12, 2018, 2:35 PM GMT (5b9d711)">Diff</a>