### PR TITLE
add explanatory intro for webidl appendix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1866,7 +1866,7 @@
 					<li>Extension point: process any proprietary and/or other supported members at this point in the
 						algorithm. </li>
 					<li>Let <var>manifest</var> be the result of <a href="https://www.w3.org/TR/WebIDL-1/#es-dictionary"
-							>converting</a> [[!WEBIDL]] <var>json</var> to a <a>WebPublicationManifest</a> dictionary.
+							>converting</a> [[!webidl-1]] <var>json</var> to a <a>WebPublicationManifest</a> dictionary.
 					</li>
 				</ol>
 
@@ -2203,6 +2203,19 @@
 		</section>
 		<section class="appendix" id="webidl">
 			<h2>WebIDL</h2>
+
+			<section id="webidl-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>Although a Web Publication manifest is authored as [[json-ld]], user agents process this information
+					into an internal data structure representing the infoset in order to utilize the properties. The
+					exact manner in which this processing occurs, and how the data is used internally, is user
+					agent-dependent. To ensure interoperability when exposing the infoset items, however, this appendix
+					defines a common, abstract representation of the data structures using the standard formalism of the
+					Web Interface Definition Language [[webidl-1]] which can express the expected names, datatypes, and
+					possible restrictions for each member of the infoset. (A WebIDL representation can be mapped onto
+					ECMAScript, C, or other programming languages.)</p>
+			</section>
 
 			<section id="webpublicationmanifest-dictionary">
 				<h3><dfn>WebPublicationManifest</dfn> dictionary </h3>


### PR DESCRIPTION
An attempt to add some context for the inclusion of the Web IDL for anyone not familiar with their purpose.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/227.html" title="Last updated on Jun 14, 2018, 11:57 AM GMT (aeb14e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/227/27d8147...aeb14e2.html" title="Last updated on Jun 14, 2018, 11:57 AM GMT (aeb14e2)">Diff</a>