### PR TITLE
Restructure to de-dup definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,18 +308,23 @@
 								<li><a href="#wp-cover">cover</a></li>
 								<li><a href="#wp-creators">creator</a></li>
 								<li><a href="#wp-language-and-dir">language</a></li>
-								<li><a href="#wp-mod-date">modification date</a></li>
+								<li><a href="#wp-mod-date">last modification date</a></li>
 								<li><a href="#wp-privacy">privacy policy</a></li>
 								<li><a href="#wp-pub-date">publication date</a></li>
+								<li><a href="#wp-reading-progression">reading progression direction</a></li>
 								<li><a href="#wp-title">title</a></li>
 							</ul>
 						</div>
 					</dd>
 					<dt>Structural Properties</dt>
 					<dd>
-						<p>REQUIRED: <a href="#wp-default-reading-order">default reading order</a>, <a
-								href="#wp-resource-list">resource list</a>, and <a href="#wp-reading-progression"
-								>reading progression</a>.</p>
+						<div>
+							<span>REQUIRED: </span>
+							<ul class="flat">
+								<li><a href="#wp-default-reading-order">default reading order</a></li>
+								<li><a href="#wp-resource-list">resource list</a></li>
+							</ul>
+						</div>
 						<p>RECOMMENDED: <a href="#wp-table-of-contents">table of contents</a></p>
 					</dd>
 				</dl>
@@ -342,19 +347,114 @@
 						provided in [[WCAG20]], and are an important source of information in determining the usability
 						of a Web Publication.</p>
 
-					<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a link to an accessibility
-						report when one is available for a Web Publication. It is RECOMMENDED that the report be
-						included as a resource of the Web Publication.</p>
+					<section id="wp-a11y-infoset">
+						<h5>Infoset Requirements</h5>
 
-					<p>It is also RECOMMENDED that the accessibility report be provided in a human-readable format, such
-						as <abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]]. Augmenting these reports
-						with machine-processable metadata, such as provided in Schema.org[[schema.org]], is also
-						RECOMMENDED.</p>
+						<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a link to an
+							accessibility report when one is available for a Web Publication. It is RECOMMENDED that the
+							report be included as a resource of the Web Publication.</p>
 
-					<p class="ednote">Machine-readable accessibility metadata may be recommended in whatever format is
-						used to externalize publication metadata (e.g., to ensure availability for search). Depending
-						how this externalizing is done, adding machine-processable accessibility metadata to such a
-						record could take precedence over, or complement, the accessibility record.</p>
+						<p>It is also RECOMMENDED that the accessibility report be provided in a human-readable format,
+							such as <abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]]. Augmenting these
+							reports with machine-processable metadata, such as provided in Schema.org [[schema.org]], is
+							also RECOMMENDED.</p>
+
+						<p class="ednote">Machine-readable accessibility metadata may be recommended in whatever format
+							is used to externalize publication metadata (e.g., to ensure availability for search).
+							Depending how this externalizing is done, adding machine-processable accessibility metadata
+							to such a record could take precedence over, or complement, the accessibility record.</p>
+					</section>
+
+					<section id="wp-a11y-manifest">
+						<h4>Manifest Expression</h4>
+
+						<p class="issue" data-number="216"></p>
+
+						<p>The accessibility metadata SHOULD map to the family of accessibility terms, as expressed by
+							Schema.org. (A more detailed description of these terms, as well as the possible values, are
+							described on the <a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas Wiki
+								site</a>.) These terms are: </p>
+
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th> Term name with link to definition </th>
+									<th> Short description </th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<a href="http://meta.schema.org/accessMode"><code>accessMode</code></a>
+									</td>
+									<td> The human sensory perceptual system or cognitive faculty through which a person
+										may process or perceive information. </td>
+								</tr>
+								<tr>
+									<td>
+										<a href="http://meta.schema.org/accessModeSufficient"
+												><code>accessModeSufficient</code></a>
+									</td>
+									<td> A list of single or combined accessModes that are sufficient to understand all
+										the intellectual content of a resource. </td>
+								</tr>
+								<tr>
+									<td>
+										<a href="http://schema.org/accessibilityAPI"><code>accessibilityAPI</code></a>
+									</td>
+									<td> Indicates that the resource is compatible with the referenced accessibility
+										API. </td>
+								</tr>
+								<tr>
+									<td>
+										<a href="http://meta.schema.org/accessibilityControl"
+												><code>accessibilityControl</code></a>
+									</td>
+									<td> Identifies input methods that are sufficient to fully control the described
+										resource. </td>
+								</tr>
+								<tr>
+									<td>
+										<a href="http://meta.schema.org/accessibilityFeature"
+												><code>accessibilityFeature</code></a>
+									</td>
+									<td> Content features of the resource, such as accessible media, alternatives and
+										supported enhancements for accessibility. </td>
+								</tr>
+								<tr>
+									<td>
+										<a href="http://meta.schema.org/accessibilityHazard"
+												><code>accessibilityHazard</code></a>
+									</td>
+									<td> A characteristic of the described resource that is physiologically dangerous to
+										some users. </td>
+								</tr>
+								<tr>
+									<td>
+										<a href="http://meta.schema.org/accessibilitySummary"
+												><code>accessibilitySummary</code></a>
+									</td>
+									<td> A human-readable summary of specific accessibility features or deficiencies,
+										consistent with the other accessibility metadata but expressing subtleties such
+										as “short descriptions are present but long descriptions will be needed for
+										non-visual users” or “short descriptions are present and no long descriptions
+										are needed.” </td>
+								</tr>
+							</tbody>
+						</table>
+
+						<pre class="example" title="Example for accessiblity metadata of a purely textual document">
+{
+    "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
+    "@type"    : "CreativeWork",
+    &#8230;
+    "accessMode"            : ["textual", "visual"],
+    "accessModeSufficient"  : ["textual"],
+    &#8230;
+}
+</pre>
+
+					</section>
 				</section>
 
 				<section id="wp-address">
@@ -362,28 +462,69 @@
 
 					<p>A <a>Web Publication's</a>
 						<dfn>address</dfn> is a <abbr title="Uniform Resource Locator">URL</abbr>&#160;[[!url]] that
-						represents the primary entry page for the Web Publication. If this URL does not resolve to an
-							<abbr title="Hypertext Markup Language">HTML</abbr> document&#160;[[!html]], user agents
-						SHOULD NOT provide access to it to users.</p>
+						represents the primary entry page for the Web Publication.</p>
 
-					<p>The referenced document SHOULD be a resource of the Web Publication. It can be any resource,
-						including one that is not listed in the <a>default reading order</a>. This document MUST include
-						a <a href="#wp-linking">link to the manifest</a> to ensure a bidirectional linking relationship
-						(i.e., that user agents can also locate the manifest from the document at the address.</p>
+					<section id="wp-address-infoset">
+						<h5>Infoset Requirements</h5>
 
-					<p>If the document is not a Web Publication resource, user agents SHOULD load the first document in
-						the <a>default reading order</a> when initiating the Web Publication.</p>
+						<p>The referenced document SHOULD be a resource of the Web Publication. It can be any resource,
+							including one that is not listed in the <a>default reading order</a>. This document MUST
+							include a <a href="#wp-linking">link to the manifest</a> to ensure a bidirectional linking
+							relationship (i.e., that user agents can also locate the manifest from the document at the
+							address.</p>
 
-					<p class="note">To improve the usability of Web Publications, particularly in user agents that do
-						not support Web Publications, include navigation aids in the referenced document that facilitate
-						consumption of the content, (e.g., provide a table of contents or a link to one).</p>
+						<p>If the canonical URL does not resolve to an <abbr title="Hypertext Markup Language"
+								>HTML</abbr> document&#160;[[!html]], user agents SHOULD NOT provide access to it to
+							users.</p>
 
-					<p>The availability of the address does not preclude the creation and use of other identifiers
-						and/or addresses to retrieve a <a>Web Publication</a>, whether in whole or in part.</p>
+						<p>If the document is not a Web Publication resource, user agents SHOULD load the first document
+							in the <a>default reading order</a> when initiating the Web Publication.</p>
 
-					<div class="note">The Web Publication's address can also be used as value for an identifier link
-						relation&#160;[[link-relation]].</div>
+						<p class="note">To improve the usability of Web Publications, particularly in user agents that
+							do not support Web Publications, include navigation aids in the referenced document that
+							facilitate consumption of the content, (e.g., provide a table of contents or a link to
+							one).</p>
 
+						<p>The availability of the address does not preclude the creation and use of other identifiers
+							and/or addresses to retrieve a <a>Web Publication</a>, whether in whole or in part.</p>
+
+						<div class="note">The Web Publication's address can also be used as value for an identifier link
+							relation&#160;[[link-relation]].</div>
+					</section>
+
+					<section id="wp-address-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>This infoset item MUST be mapped on the <a href="http://schema.org/url"><code>url</code></a>
+							term.</p>
+
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th> Term name with link to definition </th>
+									<th> Short description </th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<a href="http://schema.org/url"><code>url</code></a>
+									</td>
+									<td> URL of the primary entry page. </td>
+								</tr>
+							</tbody>
+						</table>
+
+						<pre class="example" title="Example for setting the address of the main entry point">
+{
+    "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
+    "@type"    : "Book",
+    &#8230;
+    "url"      : "https://publisher.example.org/mobydick",
+    &#8230;
+}
+</pre>
+					</section>
 				</section>
 
 				<section id="wp-canonical-identifier">
@@ -446,11 +587,11 @@
 					<p class="issue" data-number="210"></p>
 				</section>
 
-				<section id="wp-creators">
-					<h4>Creators</h4>
+				<section id="wp-creator">
+					<h4>Creator</h4>
 
-					<p>Creators are the individuals or entities responsible for the creation of the <a>Web
-							Publication</a>.</p>
+					<p>The creator is the individual or entity responsible for the creation of the <a>Web
+							Publication</a>. A Web Publication MAY have more than one creator.</p>
 
 					<p>The creator property SHOULD include the role the creator played in the creation of the Web
 						Publication (e.g., 'author', 'illustrator', 'translator').</p>
@@ -485,10 +626,10 @@
 					<p class="note">These features make it possible to add the title of a publication in different
 						languages, or repeat the creators’ names using different scripts.</p>
 
-					<p>User agents MUST NOT use the language and base direction outside the context of the manifest
-						(e.g., in the processing or rendering of the Web Publication content). These values are
-							<strong>not</strong> a replacement for such declarations in each resource as defined by its
-						format.</p>
+					<p>User agents MUST NOT use the language and base direction outside the context of the infoset
+						(e.g., in the processing or rendering of the Web Publication content). These values do
+							<strong>not</strong> override similar declarations in any resource, nor do they serve as
+						global defaults when such information is not provided in a resource.</p>
 
 					<p>If a user agent requires the language and one is not available in the <abbr
 							title="information set">infoset</abbr> (globally or specifically for the property), or the
@@ -538,9 +679,9 @@
 
 					<p>Users often have the legal right to know and control what information is collected about them,
 						how such information is stored and for how long, whether it is personally identifiable, and how
-						it can be expunged. Including a statement that addresses all such privacy concerns is
-						consequently an important part of publishing <a>Web Publications</a>. Even if no information is
-						collected, such a declaration increases the trust users have in the content.</p>
+						it can be expunged. Including a statement that addresses such privacy concerns is consequently
+						an important part of publishing <a>Web Publications</a>. Even if no information is collected,
+						such a declaration increases the trust users have in the content.</p>
 
 					<p>To address this concern, a link to a privacy policy can be included in the <abbr
 							title="information set"><a>infoset</a></abbr>. It is RECOMMENDED that the privacy policy be
@@ -635,9 +776,11 @@
 
 					<p>The <dfn>resource list</dfn> enumerates all <a href="#wp-resources">resources</a> that are used
 						in the processing and rendering of a <a>Web Publication</a> (i.e., that are within its bounds)
-						and that are not listed in the <a>default reading order</a>. This list is the definitive source
-						that user agents have in determining which referenced resources belong to the Web Publication
-						and which are external to it.</p>
+						and that are not listed in the <a>default reading order</a>.</p>
+
+					<p class="note">The union of the resource list and default reading order represents the definitive
+						list of resources that belong to the Web Publication. All other resources are external to the
+						Web Publication.</p>
 
 					<p>The completeness of the resource list will affect the usability of the Web Publication in certain
 						reading scenarios (e.g., the ability to read the Web Publication offline). For this reason, it
@@ -833,131 +976,6 @@
 
 				<section>
 					<h4>Descriptive Infoset Properties</h4>
-					<section id="wp-a11y-wpm">
-						<h4>Accessibility</h4>
-
-						<p class="issue" data-number="216"></p>
-
-						<p> As defined in <a href="#wp-a11y"></a>, the Web Publication Manifest MAY inlude accessibility
-							metadata. These SHOULD be mapped on the family of accessibility terms, as expressed by
-							Schema.org. (A more detailed description of these terms, as well as the possible values, are
-							described on the <a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas Wiki
-								site</a>.) These terms are: </p>
-
-						<table class="zebra">
-							<thead>
-								<tr>
-									<th> Term name with link to definition </th>
-									<th> Short description </th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>
-										<a href="http://meta.schema.org/accessMode"><code>accessMode</code></a>
-									</td>
-									<td> The human sensory perceptual system or cognitive faculty through which a person
-										may process or perceive information. </td>
-								</tr>
-								<tr>
-									<td>
-										<a href="http://meta.schema.org/accessModeSufficient"
-												><code>accessModeSufficient</code></a>
-									</td>
-									<td> A list of single or combined accessModes that are sufficient to understand all
-										the intellectual content of a resource. </td>
-								</tr>
-								<tr>
-									<td>
-										<a href="http://schema.org/accessibilityAPI"><code>accessibilityAPI</code></a>
-									</td>
-									<td> Indicates that the resource is compatible with the referenced accessibility
-										API. </td>
-								</tr>
-								<tr>
-									<td>
-										<a href="http://meta.schema.org/accessibilityControl"
-												><code>accessibilityControl</code></a>
-									</td>
-									<td> Identifies input methods that are sufficient to fully control the described
-										resource. </td>
-								</tr>
-								<tr>
-									<td>
-										<a href="http://meta.schema.org/accessibilityFeature"
-												><code>accessibilityFeature</code></a>
-									</td>
-									<td> Content features of the resource, such as accessible media, alternatives and
-										supported enhancements for accessibility. </td>
-								</tr>
-								<tr>
-									<td>
-										<a href="http://meta.schema.org/accessibilityHazard"
-												><code>accessibilityHazard</code></a>
-									</td>
-									<td> A characteristic of the described resource that is physiologically dangerous to
-										some users. </td>
-								</tr>
-								<tr>
-									<td>
-										<a href="http://meta.schema.org/accessibilitySummary"
-												><code>accessibilitySummary</code></a>
-									</td>
-									<td> A human-readable summary of specific accessibility features or deficiencies,
-										consistent with the other accessibility metadata but expressing subtleties such
-										as “short descriptions are present but long descriptions will be needed for
-										non-visual users” or “short descriptions are present and no long descriptions
-										are needed.” </td>
-								</tr>
-							</tbody>
-						</table>
-
-						<pre class="example" title="Example for accessiblity metadata of a purely textual document">
-{
-    "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
-    "@type"    : "CreativeWork",
-    &#8230;
-    "accessMode"            : ["textual", "visual"],
-    "accessModeSufficient"  : ["textual"],
-    &#8230;
-}
-</pre>
-
-					</section>
-					<section>
-						<h4>Address</h4>
-						<p> As described in <a href="#wp-address"></a>, a <a>Web Publication's</a>
-							<a>address</a> is a <abbr title="Uniform Resource Locator">URL</abbr>&#160;[[!url]] that
-							represents the primary entry page for the Web Publication. This infoset item MUST be mapped
-							on the <a href="http://schema.org/url"><code>url</code></a> term. </p>
-
-						<table class="zebra">
-							<thead>
-								<tr>
-									<th> Term name with link to definition </th>
-									<th> Short description </th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>
-										<a href="http://schema.org/url"><code>url</code></a>
-									</td>
-									<td> URL of the primary entry page. </td>
-								</tr>
-							</tbody>
-						</table>
-
-						<pre class="example" title="Example for setting the address of the main entry point">
-{
-    "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
-    "@type"    : "Book",
-    &#8230;
-    "url"      : "https://publisher.example.org/mobydick",
-    &#8230;
-}
-</pre>
-					</section>
 					<section id="wp-canonical-identifier-wpm">
 						<h4>Canonical Identifier</h4>
 						<p> As described in <a href="#wp-canonical-identifier"></a>, a <a>Web Publication's</a>
@@ -1838,10 +1856,10 @@
 			</section>
 
 		</section>
-		<section id="wp-affordances">
-			<h2>Affordances</h2>
+		<section id="wp-features">
+			<h2>User Agent Features</h2>
 
-			<p class="ednote">This section contains placeholders for possible reading enhancements/affordances the user
+			<p class="ednote">This section contains placeholders for possible reading enhancements/features the user
 				agent may/should/must provide. The list is subject to addition, modification and removal as the
 				enhancements get discussed in more detail.</p>
 
@@ -1850,10 +1868,10 @@
 			<section id="aff-publication-mode">
 				<h3>Switch to publication mode</h3>
 
-				<p>When a user agent <a>obtains a manifest</a> it SHOULD display an affordance for switching the display
-					to <a>publication mode</a>.</p>
+				<p>When a user agent <a>obtains a manifest</a> it SHOULD provide the option to switch the display to
+						<a>publication mode</a>.</p>
 
-				<p>This affordance has the following requirements:</p>
+				<p>This feature has the following requirements:</p>
 
 				<ol>
 					<li>it MUST inform the user that the current resource is part of a <a>Web Publication</a></li>
@@ -2035,7 +2053,7 @@
 							<code>link</code> element's <a href="https://www.w3.org/TR/html5/links.html#sec-link-types"
 								><code>next</code> and <code>prev</code> relationships</a>&#160;[[!html]].</p>
 
-					<p>User agents MUST provide an affordance for moving forward and backward in the <a>default reading
+					<p>User agents MUST provide the ability to move forward and backward in the <a>default reading
 							order</a> of a <a>Web Publication</a>.</p>
 
 					<p class="issue" data-number="144"></p>
@@ -2048,8 +2066,8 @@
 					<p>While reading a <a>Web Publication</a>, the user follows a natural progression within a resource
 						as well as between resources (following the <a>default reading order</a>).</p>
 
-					<p>User agents SHOULD provide an affordance that saves this progression in the publication and
-						returns the user to their last location the next time they open the publication.</p>
+					<p>User agents SHOULD provide the option to save this progression in the publication and returns the
+						user to their last location the next time they open the publication.</p>
 
 					<p>When the user agent <a>obtains a manifest</a> for the first time, it MAY also prompt the user
 						whether they would like to:</p>
@@ -2067,41 +2085,37 @@
 					<p class="issue" data-number="146"></p>
 
 					<section>
-				        <h5>Short description</h5>
-						<p>
-							The user agent should provide access to the table of contents without leaving current resource from anywhere in the publication.
-						</p>
-						<p>
-							For accessibility reasons, it is RECOMMENDED for User Agents to use a table of contents to allow multiple ways for users to access content.
-						</p>
+						<h5>Short description</h5>
+						<p> The user agent should provide access to the table of contents without leaving current
+							resource from anywhere in the publication. </p>
+						<p> For accessibility reasons, it is RECOMMENDED for User Agents to use a table of contents to
+							allow multiple ways for users to access content. </p>
 					</section>
 					<section>
-				        <h5>Affordances</h5>
-						<p>
-							The table of contents is a listed as a structural property in the infoset, see <a href="#wp-table-of-contents"></a>
+						<h5>Affordances</h5>
+						<p> The table of contents is a listed as a structural property in the infoset, see <a
+								href="#wp-table-of-contents"></a>
 						</p>
-						<p>
-							The table of content is referred to in the Web Publication Manifest (see <a href="#wp-table-of-contents-pwm"></a>) and is expressed using and HTML element; see <a href="#wp-table-of-contents"></a> for further details.
-						</p>
-						<p>
-							User agents MAY use the <a>default reading order</a> in the case a Table of Contents is not explicitly specified to create a table of contents.
-						</p>
-				    </section>
-				    <section>
-				        <h5>Use Case References</h5>
+						<p> The table of content is referred to in the Web Publication Manifest (see <a
+								href="#wp-table-of-contents-pwm"></a>) and is expressed using and HTML element; see <a
+								href="#wp-table-of-contents"></a> for further details. </p>
+						<p> User agents MAY use the <a>default reading order</a> in the case a Table of Contents is not
+							explicitly specified to create a table of contents. </p>
+					</section>
+					<section>
+						<h5>Use Case References</h5>
 
-							<dl>
-								<dt><a href="https://www.w3.org/TR/pwp-ucr/#r_reading-order">Req. 12</a></dt>
-								<dd>
-									“There should be a means to indicate the author’s preferred navigation structure among the resources of a Web Publication.
-						            A user agent needs to know the sequence in which to present components of a Web Publication to the user, including the starting point.” (See [[pwp-ucr]])
-								</dd>
-								<dt><a href="https://www.w3.org/TR/pwp-ucr/#r_random-access">Req. 13</a></dt>
-								<dd>
-									“Authors of a Web Publication should be able to provide the user agent with information to access random parts of the publication” (See [[pwp-ucr]])
-								</dd>
-							</dl>
-				    </section>
+						<dl>
+							<dt><a href="https://www.w3.org/TR/pwp-ucr/#r_reading-order">Req. 12</a></dt>
+							<dd> “There should be a means to indicate the author’s preferred navigation structure among
+								the resources of a Web Publication. A user agent needs to know the sequence in which to
+								present components of a Web Publication to the user, including the starting point.” (See
+								[[pwp-ucr]]) </dd>
+							<dt><a href="https://www.w3.org/TR/pwp-ucr/#r_random-access">Req. 13</a></dt>
+							<dd> “Authors of a Web Publication should be able to provide the user agent with information
+								to access random parts of the publication” (See [[pwp-ucr]]) </dd>
+						</dl>
+					</section>
 				</section>
 			</section>
 

--- a/index.html
+++ b/index.html
@@ -270,10 +270,10 @@
 					that information.</p>
 
 				<p>The <abbr title="information set">infoset</abbr> is primarily compiled from a Web Publication's
-						<a>manifest</a>, whose serialization requirements are defined in <a
-						href="#wp-manifest"></a>. Some information can be obtained outside the
-					manifest—fallback rules for properties defined in the following subsections allow a user agent to
-					compile information that the author has not provided in the manifest, for example.</p>
+						<a>manifest</a>, whose serialization requirements are defined in <a href="#wp-manifest"></a>.
+					Some information can be obtained outside the manifest—fallback rules for properties defined in the
+					following subsections allow a user agent to compile information that the author has not provided in
+					the manifest, for example.</p>
 
 				<p> A <a>manifest</a> is a serialization of a <a>Web Publication's</a>
 					<abbr title="information set"><a>infoset</a></abbr>. The manifest is serialized using the
@@ -417,6 +417,121 @@
 		<section id="wp-properties">
 			<h2>Web Publication Properties</h2>
 
+			<section id="wp-properties-intro">
+				<h3>Introduction</h3>
+
+				<p>Desciptive Properties in the Web Publication Manifest are based, wherever possible, on the terms
+					defined by <a href="https://schema.org">Schema.org</a>&#160;[[!schema.org]] (including <a
+						href="http://schema.org/docs/schemas.html">hosted extensions</a> of Schema.org). This means that
+					the descriptive infoset properties are mapped to one or several Schema.org properties (inheriting
+					their syntax and semantics). </p>
+
+				<p class="note">Schema.org includes a large number of terms that, though relevant for publishing, are
+					not mentioned in this Recommendation. Web Publication authors may use any of those; this document
+					defines only the minimal set of infoset items, and their mapping to Schema.org when appropriate. </p>
+
+				<p class="ednote">There are discussion on whether a best practices document would be created, referring
+					to more schema.org terms. If so, it should be linked from here. </p>
+
+				<p><a href="#wp-structural-properties">Structural Properties</a> in the Web Publication Manifest use
+					terms that refer to one or more external resources (images, script files, separate metadata files,
+					etc.). These terms do not necessarily have a counterpart in Schema.org, and are therefore defined
+					separately by this specification.</p>
+
+				<p>Values of structural properties are usually links to external resources, or an array thereof. Such a
+					link may be expressed in one of two ways:</p>
+
+				<ol>
+					<li>a string encoding the (absolute or relative) URL of the resources; or</li>
+					<li>an instance of a Schema.org <a href="http://schema.org/StructuredValue"
+								><code>StructuredValue</code></a> that can be used to express, beyond the URL, the media
+						type and other characteristics of the target resource.</li>
+				</ol>
+
+				<pre class="example" title="Expressing external links, either as strings or as objects">
+	{
+        &#8230;
+        "resources" : [
+            "datatypes.svg",
+            {
+                "@type"      : "StructuredValue",
+                "url"        : "test-utf8.csv",
+                "fileFormat" : "text/csv"
+            }
+		]
+	}
+</pre>
+
+				<p class="note"> There will be continuous contacts with Schema.org to see whether some of the structural
+					property terms should not be included in the core Schema.org hierarchy, or one of its extensions. </p>
+
+				<p>Structural infoset properties typically refer to external resources via a URL. This URL-s may refer
+					to resources playing different roles (e.g., cover or privacy policy), may need some additional
+					metadata for, e.g., accessibility purposes. </p>
+
+				<p id="publication-link-def"> The structural properties are expressed via JSON-LD terms that are
+					typically publication specific (i.e., defined through the JSON-LD context file defined for Web
+					Publications, see <a href="#wpub-context"></a>). This context also defines a general type used for
+					external links, called <code>PublicationLink</code>, that contains that following properties (note
+					that most of the properties are ): </p>
+
+				<table class="zebra">
+					<thead>
+						<tr>
+							<th> Term name </th>
+							<th> Short description </th>
+							<th> Required/Optional </th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>
+								<a href="http://schema.org/name"><code>url</code></a>
+							</td>
+							<td> URL&#160;[[url]] of the resource. </td>
+							<td> Required. </td>
+						</tr>
+						<tr>
+							<td>
+								<a href="http://schema.org/fileFormat"><code>fileFormat</code></a>
+							</td>
+							<td> Media type, typically the MIME format&#160;[[!rfc2046]] of the content e.g.
+									<code>application/zip</code>. </td>
+							<td> Optional. </td>
+						</tr>
+						<tr>
+							<td>
+								<a href="http://schema.org/name"><code>name</code></a>
+							</td>
+							<td> Name of the item. </td>
+							<td> Optional. </td>
+						</tr>
+						<tr>
+							<td>
+								<a href="http://schema.org/description"><code>description</code></a>
+							</td>
+							<td> Description of the item. </td>
+							<td> Optional. </td>
+						</tr>
+						<tr>
+							<td>
+								<code>rel</code>
+							</td>
+							<td>One or more relations; the values are either the relevant relationship terms of the IANA
+								link registry&#160;[[!iana-link-relations]], or specially minted URL-s if no suitable
+								link registry item exists.</td>
+							<td>Optional.</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<p class="issue" data-number="235"></p>
+
+				<p class="ednote">If the document is reorganized the "specific" external resources (cover, accessibility
+					report, etc) should be separated in from the general structures and list definitions.</p>
+
+			</section>
+
 			<section id="wp-properties-req">
 				<h3>Requirements</h3>
 
@@ -436,41 +551,31 @@
 					are as follows:</p>
 
 				<dl>
-					<dt>Descriptive Properties</dt>
+					<dt>REQUIRED:</dt>
 					<dd>
-						<p>REQUIRED: <a href="#wp-address">address</a></p>
-						<div>
-							<span>RECOMMENDED:</span>
-							<ul class="flat">
-								<li><a href="#wp-a11y">accessibility report</a></li>
-								<li><a href="#wp-language-and-dir">base direction</a></li>
-								<li><a href="#wp-canonical-identifier">canonical identifier</a></li>
-								<li><a href="#wp-creator">creator</a></li>
-								<li><a href="#wp-language-and-dir">language</a></li>
-								<li><a href="#wp-mod-date">last modification date</a></li>
-								<li><a href="#wp-pub-date">publication date</a></li>
-								<li><a href="#wp-reading-progression">reading progression direction</a></li>
-								<li><a href="#wp-title">title</a></li>
-							</ul>
-						</div>
+						<ul>
+							<li><a href="#wp-address">address</a></li>
+							<li><a href="#wp-default-reading-order">default reading order</a></li>
+							<li><a href="#wp-resource-list">resource list</a></li>
+						</ul>
 					</dd>
-					<dt>Structural Properties</dt>
+					<dt>RECOMMENDED:</dt>
 					<dd>
-						<div>
-							<span>REQUIRED: </span>
-							<ul class="flat">
-								<li><a href="#wp-default-reading-order">default reading order</a></li>
-								<li><a href="#wp-resource-list">resource list</a></li>
-							</ul>
-						</div>
-						<div>
-							<span>RECOMMENDED:</span>
-							<ul>
-								<li><a href="#wp-cover">cover</a></li>
-								<li><a href="#wp-privacy">privacy policy</a></li>
-								<li><a href="#wp-table-of-contents">table of contents</a></li>
-							</ul>
-						</div>
+						<ul>
+							<li><a href="#wp-a11y">accessibility report</a></li>
+							<li><a href="#wp-language-and-dir">base direction</a></li>
+							<li><a href="#wp-canonical-identifier">canonical identifier</a></li>
+							<li><a href="#wp-cover">cover</a></li>
+							<li><a href="#wp-creator">creator</a></li>
+							<li><a href="#wp-extra-resources">extra resources</a></li>
+							<li><a href="#wp-language-and-dir">language</a></li>
+							<li><a href="#wp-mod-date">last modification date</a></li>
+							<li><a href="#wp-pub-date">publication date</a></li>
+							<li><a href="#wp-privacy">privacy policy</a></li>
+							<li><a href="#wp-reading-progression">reading progression direction</a></li>
+							<li><a href="#wp-table-of-contents">table of contents</a></li>
+							<li><a href="#wp-title">title</a></li>
+						</ul>
 					</dd>
 				</dl>
 
@@ -481,24 +586,6 @@
 
 			<section id="wp-descriptive-properties">
 				<h3>Descriptive Properties</h3>
-
-				<section id="wp-descriptive-properties-intro">
-					<h4>Introduction</h4>
-
-					<p> Desciptive Properties in the Web Publication Manifest are based, wherever possible, on the terms
-						defined by <a href="https://schema.org">Schema.org</a>&#160;[[!schema.org]] (including <a
-							href="http://schema.org/docs/schemas.html">hosted extensions</a> of Schema.org). This means
-						that the descriptive infoset properties are mapped to one or several Schema.org properties
-						(inheriting their syntax and semantics). </p>
-
-					<p class="note"> Schema.org includes a large number of terms that, though relevant for publishing,
-						are not mentioned in this Recommendation. Web Publication authors may use any of those; this
-						document defines only the minimal set of infoset items, and their mapping to Schema.org when
-						appropriate. </p>
-
-					<p class="ednote"> There are discussion on whether a best practices document would be created,
-						referring to more schema.org terms. If so, it should be linked from here. </p>
-				</section>
 
 				<section id="wp-a11y">
 					<h4>Accessibility</h4>
@@ -1064,8 +1151,8 @@
 }
 </pre>
 							<p>The value of the language tag must be set to the language code as defined in [[!bcp47]].
-								If not set, the default value is the <a href="#wp-language-and-dir-manifest">default value
-									of the manifest</a>.</p>
+								If not set, the default value is the <a href="#wp-language-and-dir-manifest">default
+									value of the manifest</a>.</p>
 
 							<p class="issue" data-number="219"></p>
 						</section>
@@ -1321,112 +1408,8 @@
 				</section>
 			</section>
 
-			<section id="wp-structural-properties">
-				<h3>Structural Properties</h3>
-
-				<section id="wp-structural-properties-intro">
-					<h4>Introduction</h4>
-
-					<p>
-						<a href="#wp-structural-properties">Structural Properties</a> in the Web Publication Manifest
-						use terms that refer to one or more external resources (images, script files, separate metadata
-						files, etc.). These terms do not necessarily have a counterpart in Schema.org, and are therefore
-						defined separately by this specification. </p>
-
-					<p> Values of structural properties are usually links to external resources, or an array thereof.
-						Such a link may be expressed in one of two ways: </p>
-
-					<ol>
-						<li>a string encoding the (absolute or relative) URL of the resources; or</li>
-						<li>an instance of a Schema.org <a href="http://schema.org/StructuredValue"
-									><code>StructuredValue</code></a> that can be used to express, beyond the URL, the
-							media type and other characteristics of the target resource.</li>
-					</ol>
-
-					<pre class="example" title="Expressing external links, either as strings or as objects">
-	{
-        &#8230;
-        "resources" : [
-            "datatypes.svg",
-            {
-                "@type"      : "StructuredValue",
-                "url"        : "test-utf8.csv",
-                "fileFormat" : "text/csv"
-            }
-		]
-	}
-</pre>
-
-					<p class="note"> There will be continuous contacts with Schema.org to see whether some of the
-						structural property terms should not be included in the core Schema.org hierarchy, or one of its
-						extensions. </p>
-
-					<p>Structural infoset properties typically refer to external resources via a URL. This URL-s may
-						refer to resources playing different roles (e.g., cover or privacy policy), may need some
-						additional metadata for, e.g., accessibility purposes. </p>
-
-					<p id="publication-link-def"> The structural properties are expressed via JSON-LD terms that are
-						typically publication specific (i.e., defined through the JSON-LD context file defined for Web
-						Publications, see <a href="#wpub-context"></a>). This context also defines a general type used
-						for external links, called <code>PublicationLink</code>, that contains that following properties
-						(note that most of the properties are ): </p>
-
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th> Term name </th>
-								<th> Short description </th>
-								<th> Required/Optional </th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<a href="http://schema.org/name"><code>url</code></a>
-								</td>
-								<td> URL&#160;[[url]] of the resource. </td>
-								<td> Required. </td>
-							</tr>
-							<tr>
-								<td>
-									<a href="http://schema.org/fileFormat"><code>fileFormat</code></a>
-								</td>
-								<td> Media type, typically the MIME format&#160;[[!rfc2046]] of the content e.g.
-										<code>application/zip</code>. </td>
-								<td> Optional. </td>
-							</tr>
-							<tr>
-								<td>
-									<a href="http://schema.org/name"><code>name</code></a>
-								</td>
-								<td> Name of the item. </td>
-								<td> Optional. </td>
-							</tr>
-							<tr>
-								<td>
-									<a href="http://schema.org/description"><code>description</code></a>
-								</td>
-								<td> Description of the item. </td>
-								<td> Optional. </td>
-							</tr>
-							<tr>
-								<td>
-									<code>rel</code>
-								</td>
-								<td>One or more relations; the values are either the relevant relationship terms of the
-									IANA link registry&#160;[[!iana-link-relations]], or specially minted URL-s if no
-									suitable link registry item exists.</td>
-								<td>Optional.</td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p class="issue" data-number="235"></p>
-
-					<p class="ednote">If the document is reorganized the "specific" external resources (cover,
-						accessibility report, etc) should be separated in from the general structures and list
-						definitions.</p>
-				</section>
+			<section id="wp-informative-properties">
+				<h3>Informative Properties</h3>
 
 				<section id="wp-a11y-report">
 					<h4>Accessibility Report</h4>
@@ -1492,6 +1475,67 @@
 					</section>
 				</section>
 
+				<section id="wp-privacy">
+					<h4>Privacy Policy</h4>
+
+					<p>Users often have the legal right to know and control what information is collected about them,
+						how such information is stored and for how long, whether it is personally identifiable, and how
+						it can be expunged. Including a statement that addresses such privacy concerns is consequently
+						an important part of publishing <a>Web Publications</a>. Even if no information is collected,
+						such a declaration increases the trust users have in the content.</p>
+
+					<section id="wp-privacy-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>To address this concern, a link to a privacy policy can be included in the <abbr
+								title="information set"><a>infoset</a></abbr>. It is RECOMMENDED that the privacy policy
+							be included as a resource of the Web Publication.</p>
+
+						<p>It is RECOMMENDED that the privacy policy be provided in a human-readable format, such as
+								<abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]].</p>
+
+						<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
+							Publications.</p>
+
+						<p class="issue" data-number="203"></p>
+					</section>
+
+					<section id="wp-privacy-manifest">
+						<h4>Manifest Expression</h4>
+
+						<p>As described in <a href="#wp-privacy"></a>, it is RECOMMENDED that the privacy policy be
+							included as a resource of the Web Publication. When present, link to such resource MUST be
+							expressed using a <a href="#publication-link-def"><code>PublicationLink</code></a> object.
+							The <code>rel</code> value of the <a href="#publication-link-def"
+									><code>PublicationLink</code></a> MUST include the <code>privacy-policy</code>
+							(IANA) identifier.</p>
+
+						<pre class="example" title="Privacy policy expressed as an external link">
+{
+    "@context"   : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
+    "@type"      : "CreativeWork",
+    &#8230;
+    "identifier" : "http://www.w3.org/TR/tabular-data-model/",
+    "url"        : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
+    &#8230;
+    "externalResources"  : [{
+        "@type"      : "PublicationLink",
+        "url"        : "https://www.w3.org/Consortium/Legal/privacy-statement-20140324",
+        "fileFormat" : "text/html",
+        "rel"        : "privacy-policy"
+    },{
+            &#8230;
+    }],
+    &#8230;
+}
+</pre>
+					</section>
+				</section>
+			</section>
+
+			<section id="wp-structural-properties">
+				<h3>Structural Properties</h3>
+
 				<section id="wp-cover">
 					<h4>Cover</h4>
 
@@ -1550,35 +1594,33 @@
 					</section>
 				</section>
 
-				<section id="wp-extra-list">
-					<h4>List of extra resources</h4>
+				<section id="wp-table-of-contents">
+					<h4>Table of Contents</h4>
 
-					<p>The <dfn>list of extra resources</dfn> enumerates all <a href="#wp-resources">resources</a> that
-						are used in the processing and rendering of a <a>Web Publication</a> but are <em>not</em> within
-						its bounds (i.e., are not listed in the <a>default reading order</a> or the <a>resource
-						list</a>) but are, rather, external to the Web Publication. </p>
+					<p>The <dfn>table of contents</dfn> is a hierarchical list of links that reflects the structural
+						outline of the major sections of the Web Publication.</p>
 
-					<section id="wp-extra-list-infoset">
+					<section id="wp-table-of-contents-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The completeness of the resource list will affect the usability of the Web Publication in
-							certain scenarios (e.g., the ability to access privacy policy information). For this reason,
-							it is strongly RECOMMENDED to provide a comprehensive list of all of the Web Publication's
-							external resources beyond those listed in the <a>default reading order</a> or <a>resource
-								list</a>.</p>
+						<p>There are no requirements on the completeness of the table of contents, except that, when
+							specified, it MUST include a link to at least one <a href="#wp-resources">resource</a>.</p>
 
-						<p>In some cases, a comprehensive list of these resources might not be easily achieved (e.g.,
-							third-party scripts that reference resources from deep within their source), but a user
-							agent SHOULD still be able to render a Web Publication even if some of these resources are
-							not identified as belonging to the Web Publication (e.g., when it is taken offline without
-							them).</p>
+						<p>The table of contents is not specified directly in the manifest. Instead, the manifest SHOULD
+							provide a link to an HTML element in one of the <a href="#wp-resources">resources</a> (most
+							likely a <code>nav</code> element&#160;[[!html]]), with a <code>role</code> attribute value
+							set to <code>doc-toc</code>.</p>
+
+						<p class="issue">This question arises only if the table of contents is accepted: can a table of
+							contents navigation element refer, via links, to any resource that is <em>not</em> listed in
+							the <a>default reading order</a>?</p>
 					</section>
 
-					<section id="wp-extra-list-manifest">
-						<h5>Manifest Expression</h5>
+					<section id="wp-table-of-contents-manifest">
+						<h5>Manifest Expresion</h5>
 
-						<p>If present in the Web Publication Manifest, the list of extra resources MUST be mapped on the
-								<code>extraResources</code> term, defined specifically for Web Publications. </p>
+						<p>If present in the Web Publication Manifest this item MUST be mapped on the
+								<code>tableOfContents</code> term, defined specifically for Web Publications. </p>
 
 						<table class="zebra">
 							<thead>
@@ -1590,18 +1632,46 @@
 							<tbody>
 								<tr>
 									<td>
-										<code>extraResources</code>
+										<code>tableOfContents</code>
 									</td>
-									<td> An array of: <ul>
-											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
-											<li>an instance of a <a href="#publication-link-def"
-														><code>PublicationLink</code></a> object</li>
-										</ul> The order in the array is <em>not significant</em>. </td>
+									<td> A (relative or absolute) URL&#160;[[url]] </td>
 								</tr>
 							</tbody>
 						</table>
+						<pre class="example" title="Reference to a table of content element, in the same file that contains the manifest is">
+&lt;head&gt;
+    &#8230;
+    &lt;script type="application/ld+json"&gt;
+    {
+        "@context"        : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
+        "@type"           : "CreativeWork",
+        &#8230;
+        "identifier"      : "http://www.w3.org/TR/tabular-data-model/",
+        "url"             : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
+        "tableOfContents" : "#toc"
+        &#8230;
+    }
+    &lt;/script&gt;
+    &#8230;
+&lt;/head&gt;
+&lt;body&gt;
+    &#8230;
+    &lt;section id="toc" role="doc-toc"&gt;
+        &#8230;
+    &lt;/section&gt;
+    &#8230;
+&lt;/body&gt;
+</pre>
+						<p class="issue">The term <code>tableOfContents</code> has not been approved by the Working
+							Group yet; it is currently a placeholder. </p>
+
+						<p class="issue" data-number="234"></p>
 					</section>
 				</section>
+			</section>
+
+			<section id="wp-categorization-properties">
+				<h3>Resource Categorization Properties</h3>
 
 				<section id="wp-default-reading-order">
 					<h4>Default Reading Order</h4>
@@ -1691,63 +1761,6 @@
     },{
         &#8230;
     }]
-}
-</pre>
-					</section>
-				</section>
-
-				<section id="wp-privacy">
-					<h4>Privacy Policy</h4>
-
-					<p>Users often have the legal right to know and control what information is collected about them,
-						how such information is stored and for how long, whether it is personally identifiable, and how
-						it can be expunged. Including a statement that addresses such privacy concerns is consequently
-						an important part of publishing <a>Web Publications</a>. Even if no information is collected,
-						such a declaration increases the trust users have in the content.</p>
-
-					<section id="wp-privacy-infoset">
-						<h5>Infoset Requirements</h5>
-
-						<p>To address this concern, a link to a privacy policy can be included in the <abbr
-								title="information set"><a>infoset</a></abbr>. It is RECOMMENDED that the privacy policy
-							be included as a resource of the Web Publication.</p>
-
-						<p>It is RECOMMENDED that the privacy policy be provided in a human-readable format, such as
-								<abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]].</p>
-
-						<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
-							Publications.</p>
-
-						<p class="issue" data-number="203"></p>
-					</section>
-
-					<section id="wp-privacy-manifest">
-						<h4>Manifest Expression</h4>
-
-						<p>As described in <a href="#wp-privacy"></a>, it is RECOMMENDED that the privacy policy be
-							included as a resource of the Web Publication. When present, link to such resource MUST be
-							expressed using a <a href="#publication-link-def"><code>PublicationLink</code></a> object.
-							The <code>rel</code> value of the <a href="#publication-link-def"
-									><code>PublicationLink</code></a> MUST include the <code>privacy-policy</code>
-							(IANA) identifier.</p>
-
-						<pre class="example" title="Privacy policy expressed as an external link">
-{
-    "@context"   : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
-    "@type"      : "CreativeWork",
-    &#8230;
-    "identifier" : "http://www.w3.org/TR/tabular-data-model/",
-    "url"        : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
-    &#8230;
-    "externalResources"  : [{
-        "@type"      : "PublicationLink",
-        "url"        : "https://www.w3.org/Consortium/Legal/privacy-statement-20140324",
-        "fileFormat" : "text/html",
-        "rel"        : "privacy-policy"
-    },{
-            &#8230;
-    }],
-    &#8230;
 }
 </pre>
 					</section>
@@ -1856,33 +1869,35 @@
 					</section>
 				</section>
 
-				<section id="wp-table-of-contents">
-					<h4>Table of Contents</h4>
+				<section id="wp-extra-list">
+					<h4>List of extra resources</h4>
 
-					<p>The <dfn>table of contents</dfn> is a hierarchical list of links that reflects the structural
-						outline of the major sections of the Web Publication.</p>
+					<p>The <dfn>list of extra resources</dfn> enumerates all <a href="#wp-resources">resources</a> that
+						are used in the processing and rendering of a <a>Web Publication</a> but are <em>not</em> within
+						its bounds (i.e., are not listed in the <a>default reading order</a> or the <a>resource
+						list</a>) but are, rather, external to the Web Publication. </p>
 
-					<section id="wp-table-of-contents-infoset">
+					<section id="wp-extra-list-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>There are no requirements on the completeness of the table of contents, except that, when
-							specified, it MUST include a link to at least one <a href="#wp-resources">resource</a>.</p>
+						<p>The completeness of the resource list will affect the usability of the Web Publication in
+							certain scenarios (e.g., the ability to access privacy policy information). For this reason,
+							it is strongly RECOMMENDED to provide a comprehensive list of all of the Web Publication's
+							external resources beyond those listed in the <a>default reading order</a> or <a>resource
+								list</a>.</p>
 
-						<p>The table of contents is not specified directly in the manifest. Instead, the manifest SHOULD
-							provide a link to an HTML element in one of the <a href="#wp-resources">resources</a> (most
-							likely a <code>nav</code> element&#160;[[!html]]), with a <code>role</code> attribute value
-							set to <code>doc-toc</code>.</p>
-
-						<p class="issue">This question arises only if the table of contents is accepted: can a table of
-							contents navigation element refer, via links, to any resource that is <em>not</em> listed in
-							the <a>default reading order</a>?</p>
+						<p>In some cases, a comprehensive list of these resources might not be easily achieved (e.g.,
+							third-party scripts that reference resources from deep within their source), but a user
+							agent SHOULD still be able to render a Web Publication even if some of these resources are
+							not identified as belonging to the Web Publication (e.g., when it is taken offline without
+							them).</p>
 					</section>
 
-					<section id="wp-table-of-contents-manifest">
-						<h5>Manifest Expresion</h5>
+					<section id="wp-extra-list-manifest">
+						<h5>Manifest Expression</h5>
 
-						<p>If present in the Web Publication Manifest this item MUST be mapped on the
-								<code>tableOfContents</code> term, defined specifically for Web Publications. </p>
+						<p>If present in the Web Publication Manifest, the list of extra resources MUST be mapped on the
+								<code>extraResources</code> term, defined specifically for Web Publications. </p>
 
 						<table class="zebra">
 							<thead>
@@ -1894,40 +1909,16 @@
 							<tbody>
 								<tr>
 									<td>
-										<code>tableOfContents</code>
+										<code>extraResources</code>
 									</td>
-									<td> A (relative or absolute) URL&#160;[[url]] </td>
+									<td> An array of: <ul>
+											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
+											<li>an instance of a <a href="#publication-link-def"
+														><code>PublicationLink</code></a> object</li>
+										</ul> The order in the array is <em>not significant</em>. </td>
 								</tr>
 							</tbody>
 						</table>
-						<pre class="example" title="Reference to a table of content element, in the same file that contains the manifest is">
-&lt;head&gt;
-    &#8230;
-    &lt;script type="application/ld+json"&gt;
-    {
-        "@context"        : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
-        "@type"           : "CreativeWork",
-        &#8230;
-        "identifier"      : "http://www.w3.org/TR/tabular-data-model/",
-        "url"             : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
-        "tableOfContents" : "#toc"
-        &#8230;
-    }
-    &lt;/script&gt;
-    &#8230;
-&lt;/head&gt;
-&lt;body&gt;
-    &#8230;
-    &lt;section id="toc" role="doc-toc"&gt;
-        &#8230;
-    &lt;/section&gt;
-    &#8230;
-&lt;/body&gt;
-</pre>
-						<p class="issue">The term <code>tableOfContents</code> has not been approved by the Working
-							Group yet; it is currently a placeholder. </p>
-
-						<p class="issue" data-number="234"></p>
 					</section>
 				</section>
 			</section>
@@ -2158,8 +2149,8 @@
 				</ol>
 
 				<p><dfn>Publication mode</dfn> is a display mode implemented by the user agent that follows the
-					conventions listed in <a href="#feature-presentation">presentation</a> and <a href="#feature-navigation"
-						>navigation</a>.</p>
+					conventions listed in <a href="#feature-presentation">presentation</a> and <a
+						href="#feature-navigation">navigation</a>.</p>
 			</section>
 
 			<section id="feature-presentation">
@@ -2374,8 +2365,8 @@
 								href="#wp-table-of-contents"></a>
 						</p>
 						<p> The table of content is referred to in the Web Publication Manifest (see <a
-								href="#wp-table-of-contents-manifest"></a>) and is expressed using and HTML element; see <a
-								href="#wp-table-of-contents"></a> for further details. </p>
+								href="#wp-table-of-contents-manifest"></a>) and is expressed using and HTML element; see
+								<a href="#wp-table-of-contents"></a> for further details. </p>
 						<p> User agents MAY use the <a>default reading order</a> in the case a Table of Contents is not
 							explicitly specified to create a table of contents. </p>
 					</section>

--- a/index.html
+++ b/index.html
@@ -514,8 +514,6 @@
 					<section id="wp-a11y-manifest">
 						<h5>Manifest Expression</h5>
 
-						<p class="issue" data-number="216"></p>
-
 						<p>The accessibility metadata SHOULD map to the family of accessibility terms, as expressed by
 							Schema.org. (A more detailed description of these terms, as well as the possible values, are
 							described on the <a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas Wiki
@@ -947,7 +945,6 @@
     &#8230;
 }
 </pre>
-						<p class="issue" data-number="217"></p>
 					</section>
 				</section>
 
@@ -1518,8 +1515,6 @@
 							specification does not define requirements for the creation of such cover images (e.g., the
 							user agent could use a placeholder image, generate an image dynamically, or incorporate
 							properties of the infoset into a graphic, such as the title or creators).</p>
-
-						<p class="issue" data-number="210"></p>
 					</section>
 
 					<section id="wp-cover-manifest">
@@ -1577,8 +1572,6 @@
 							agent SHOULD still be able to render a Web Publication even if some of these resources are
 							not identified as belonging to the Web Publication (e.g., when it is taken offline without
 							them).</p>
-
-						<p class="issue" data-number="225"></p>
 					</section>
 
 					<section id="wp-extra-list-manifest">
@@ -1586,9 +1579,6 @@
 
 						<p>If present in the Web Publication Manifest, the list of extra resources MUST be mapped on the
 								<code>extraResources</code> term, defined specifically for Web Publications. </p>
-
-						<p class="note">The <code>extraResources</code> to be used in JSON has not yet been decided;
-							waiting on the resolution of issue #225.</p>
 
 						<table class="zebra">
 							<thead>
@@ -1610,7 +1600,6 @@
 								</tr>
 							</tbody>
 						</table>
-						<p class="issue" data-number="225"></p>
 					</section>
 				</section>
 

--- a/index.html
+++ b/index.html
@@ -346,8 +346,9 @@
 				</section>
 				<section id="manifest-properties">
 					<h3>Properties</h3>
-					
-					<p>The naming, syntax and requirements for manifest properties are defined in <a href="#wp-properties"/>.</p>
+
+					<p>The naming, syntax and requirements for manifest properties are defined in <a
+							href="#wp-properties"></a>.</p>
 				</section>
 			</section>
 
@@ -414,9 +415,9 @@
 			</section>
 		</section>
 		<section id="wp-properties">
-			<h3>Web Publication Properties</h3>
+			<h2>Web Publication Properties</h2>
 
-			<section id="infoset">
+			<section id="wp-properties-req">
 				<h3>Requirements</h3>
 
 				<p class="ednote">As the serialization of the manifest remains an open issue, specifics about how
@@ -444,11 +445,9 @@
 								<li><a href="#wp-a11y">accessibility report</a></li>
 								<li><a href="#wp-language-and-dir">base direction</a></li>
 								<li><a href="#wp-canonical-identifier">canonical identifier</a></li>
-								<li><a href="#wp-cover">cover</a></li>
 								<li><a href="#wp-creators">creator</a></li>
 								<li><a href="#wp-language-and-dir">language</a></li>
 								<li><a href="#wp-mod-date">last modification date</a></li>
-								<li><a href="#wp-privacy">privacy policy</a></li>
 								<li><a href="#wp-pub-date">publication date</a></li>
 								<li><a href="#wp-reading-progression">reading progression direction</a></li>
 								<li><a href="#wp-title">title</a></li>
@@ -464,7 +463,14 @@
 								<li><a href="#wp-resource-list">resource list</a></li>
 							</ul>
 						</div>
-						<p>RECOMMENDED: <a href="#wp-table-of-contents">table of contents</a></p>
+						<div>
+							<span>RECOMMENDED:</span>
+							<ul>
+								<li><a href="#wp-cover">cover</a></li>
+								<li><a href="#wp-privacy">privacy policy</a></li>
+								<li><a href="#wp-table-of-contents">table of contents</a></li>
+							</ul>
+						</div>
 					</dd>
 				</dl>
 
@@ -472,6 +478,7 @@
 					remain open that could change whether an item is required or recommended. Refer to the property
 					descriptions for more information.</p>
 			</section>
+
 			<section id="wp-descriptive-properties">
 				<h3>Descriptive Properties</h3>
 
@@ -481,7 +488,7 @@
 					<p>
 						<a href="infoset-meta">Desciptive Properties</a> in the Web Publication Manifest are based,
 						wherever possible, on the terms defined by <a href="https://schema.org"
-						>Schema.org</a>&#160;[[schema.org]] (including <a href="http://schema.org/docs/schemas.html"
+						>Schema.org</a>&#160;[[!schema.org]] (including <a href="http://schema.org/docs/schemas.html"
 							>hosted extensions</a> of Schema.org). This means that the descriptive infoset properties
 						are mapped to one or several Schema.org properties (inheriting their syntax and semantics). </p>
 
@@ -495,34 +502,18 @@
 				</section>
 
 				<section id="wp-a11y">
-					<h4>Accessibility Report</h4>
+					<h4>Accessibility</h4>
 
-					<p>An accessibility report provides information about the suitability of a <a>Web Publication</a>
-						for consumption by users with varying preferred reading modalities. These reports typically
-						identify the result of an evaluation against established accessibility criteria, such as those
-						provided in [[WCAG20]], and are an important source of information in determining the usability
-						of a Web Publication.</p>
+					<p>&#8230;</p>
 
 					<section id="wp-a11y-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a link to an
-							accessibility report when one is available for a Web Publication. It is RECOMMENDED that the
-							report be included as a resource of the Web Publication.</p>
-
-						<p>It is also RECOMMENDED that the accessibility report be provided in a human-readable format,
-							such as <abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]]. Augmenting these
-							reports with machine-processable metadata, such as provided in Schema.org [[schema.org]], is
-							also RECOMMENDED.</p>
-
-						<p class="ednote">Machine-readable accessibility metadata may be recommended in whatever format
-							is used to externalize publication metadata (e.g., to ensure availability for search).
-							Depending how this externalizing is done, adding machine-processable accessibility metadata
-							to such a record could take precedence over, or complement, the accessibility record.</p>
+						<p>&#8230;</p>
 					</section>
 
 					<section id="wp-a11y-manifest">
-						<h4>Manifest Expression</h4>
+						<h5>Manifest Expression</h5>
 
 						<p class="issue" data-number="216"></p>
 
@@ -598,6 +589,10 @@
 								</tr>
 							</tbody>
 						</table>
+
+						<p>Note that the author MAY also provide a reference to a more detailed <a
+								href="#wp-a11y-report-wpm">Accessibility Report</a>, beyond the accessibility
+							information expressed by these terms.</p>
 
 						<pre class="example" title="Example for accessiblity metadata of a purely textual document">
 {
@@ -788,40 +783,6 @@
 					</section>
 				</section>
 
-				<section id="wp-cover">
-					<h4>Cover</h4>
-
-					<p>The <dfn>cover</dfn> is an image that user agents can use to present the <a>Web Publication</a>
-						to users (e.g., in a library or bookshelf, or when initially loading the Web Publication).</p>
-
-					<section id="wp-cover-infoset">
-						<h5>Infoset Requirements</h5>
-
-						<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a reference to a cover
-							image.</p>
-
-						<p>User agents SHOULD NOT use the cover image as the sole means of selecting or accessing Web
-							Publications. A user agent SHOULD use the Web Publication's <a href="#wp-title">title</a>
-							and <a href="#wp-creators">creators</a> as text alternatives for such interfaces.</p>
-
-						<p>More than one cover image MAY be referenced from the infoset to provide alternative sizes and
-							resolutions for different device screens.</p>
-
-						<p>A user agent MAY create a cover for a Web Publication if one is not present. This
-							specification does not define requirements for the creation of such cover images (e.g., the
-							user agent could use a placeholder image, generate an image dynamically, or incorporate
-							properties of the infoset into a graphic, such as the title or creators).</p>
-
-						<p class="issue" data-number="210"></p>
-					</section>
-
-					<section id="wp-cover-manifest">
-						<h5>Manifest Expression</h5>
-
-						<p>&#8230;</p>
-					</section>
-				</section>
-
 				<section id="wp-creator">
 					<h4>Creator</h4>
 
@@ -840,13 +801,7 @@
 					<section id="wp-creator-manifest">
 						<h5>Manifest Expression</h5>
 
-						<p>There isn’t one single Schema.org term this item must be mapped onto; instead, there are a
-							number of terms and, if this Infoset Item is used, the Web Publication Manifest SHOULD use
-							one of those. The value of these terms are one or more <a href="http://schema.org/Person"
-									><code>Person</code></a> objects or, in some cases, <a
-								href="http://schema.org/Person"><code>Person</code></a> or an <a
-								href="http://schema.org/Organization"><code><code>Organization</code></code></a> items.
-							These terms are: </p>
+						<p>This Infoset Item is mapped to the following [[!schema.org]] terms: </p>
 
 						<table class="zebra">
 							<thead>
@@ -942,6 +897,11 @@
 								</tr>
 							</tbody>
 						</table>
+
+						<p>The Web Publication Manifest SHOULD use one or more <a href="http://schema.org/Person"
+									><code>Person</code></a> or <a href="http://schema.org/Organization"
+										><code><code>Organization</code></code></a> items, as appropriate for the
+							specified term.</p>
 
 						<pre class="example" title="Author of a book">
 {
@@ -1231,38 +1191,6 @@
 					</section>
 				</section>
 
-				<section id="wp-privacy">
-					<h4>Privacy Policy</h4>
-
-					<p>Users often have the legal right to know and control what information is collected about them,
-						how such information is stored and for how long, whether it is personally identifiable, and how
-						it can be expunged. Including a statement that addresses such privacy concerns is consequently
-						an important part of publishing <a>Web Publications</a>. Even if no information is collected,
-						such a declaration increases the trust users have in the content.</p>
-
-					<section id="wp-privacy-infoset">
-						<h5>Infoset Requirements</h5>
-
-						<p>To address this concern, a link to a privacy policy can be included in the <abbr
-								title="information set"><a>infoset</a></abbr>. It is RECOMMENDED that the privacy policy
-							be included as a resource of the Web Publication.</p>
-
-						<p>It is RECOMMENDED that the privacy policy be provided in a human-readable format, such as
-								<abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]].</p>
-
-						<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
-							Publications.</p>
-
-						<p class="issue" data-number="203"></p>
-					</section>
-
-					<section id="wp-privacy-manifest">
-						<h5>Manifest Expression</h5>
-
-						<p>&#8230;</p>
-					</section>
-				</section>
-
 				<section id="wp-reading-progression">
 					<h4>Reading Progression Direction</h4>
 
@@ -1400,8 +1328,8 @@
 			<section id="wp-structural-properties">
 				<h3>Structural Properties</h3>
 
-				<section>
-					<h4>Structural Infoset Properties</h4>
+				<section id="wp-structural-properties-intro">
+					<h4>Introduction</h4>
 
 					<p>
 						<a href="infoset-structure">Structural Properties</a> in the Web Publication Manifest use terms
@@ -1436,12 +1364,11 @@
 					<p class="note"> There will be continuous contacts with Schema.org to see whether some of the
 						structural property terms should not be included in the core Schema.org hierarchy, or one of its
 						extensions. </p>
-				</section>
-
-				<section>
-					<p> Structural infoset properties typically refer to external resources via a URL. This URL-s may
+					
+					<p>Structural infoset properties typically refer to external resources via a URL. This URL-s may
 						refer to resources playing different roles (e.g., cover or privacy policy), may need some
 						additional metadata for, e.g., accessibility purposes. </p>
+					
 					<p id="publication-link-def"> The structural properties are expressed via JSON-LD terms that are
 						typically publication specific (i.e., defined through the JSON-LD context file defined for Web
 						Publications, see <a href="#wpub-context"></a>). This context also defines a general type used
@@ -1490,12 +1417,201 @@
 								<td>
 									<code>rel</code>
 								</td>
-								<td> A single relation the IANA link registry&#160;[[!iana-link-relations]], or an array
-									of similar relations. </td>
-								<td> Optional. </td>
+								<td>One or more relations; the values are either the relevant relationship terms of the
+									IANA link registry&#160;[[!iana-link-relations]], or specially minted URL-s if no
+									suitable link registry item exists.</td>
+								<td>Optional.</td>
 							</tr>
 						</tbody>
 					</table>
+
+					<p class="issue" data-number="235"></p>
+
+					<p class="ednote">If the document is reorganized the "specific" external resources (cover,
+						accessibility report, etc) should be separated in from the general structures and list
+						definitions.</p>
+				</section>
+
+				<section id="wp-a11y-report">
+					<h4>Accessibility Report</h4>
+					
+					<p>An accessibility report provides information about the suitability of a <a>Web Publication</a>
+						for consumption by users with varying preferred reading modalities. These reports typically
+						identify the result of an evaluation against established accessibility criteria, such as those
+						provided in [[WCAG20]], and are an important source of information in determining the usability
+						of a Web Publication.</p>
+					
+					<section id="wp-a11y-report-infoset">
+						<h5>Infoset Requirements</h5>
+						
+						<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a link to an
+							accessibility report when one is available for a Web Publication. It is RECOMMENDED that the
+							report be included as a resource of the Web Publication.</p>
+						
+						<p>It is also RECOMMENDED that the accessibility report be provided in a human-readable format,
+							such as <abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]]. Augmenting these
+							reports with machine-processable metadata, such as provided in Schema.org [[schema.org]], is
+							also RECOMMENDED.</p>
+						
+						<p class="ednote">Machine-readable accessibility metadata may be recommended in whatever format
+							is used to externalize publication metadata (e.g., to ensure availability for search).
+							Depending how this externalizing is done, adding machine-processable accessibility metadata
+							to such a record could take precedence over, or complement, the accessibility record.</p>
+					</section>
+					
+					<section id="wp-a11y-report-manifest">
+						<h5>Manifest Expression</h5>
+						
+						<p>As described in <a href="#wp-a11y"></a> the authors MAY provide an accessibility report
+							providing information about the suitability of a <a>Web Publication</a> for consumption by
+							users with varying preferred reading modalities. This report may be complementary to the
+							information expressed by the descriptive properties as described in <a href="#wp-a11y-wpm"
+								></a>. This report is accessed via an external resource (e.g., and HTML file). When present,
+							link to such resource MUST be expressed using a <a href="#publication-link-def"
+								><code>PublicationLink</code></a> object. The <code>rel</code> value of the <a
+									href="#publication-link-def"><code>PublicationLink</code></a> MUST include the
+							<code>https://www.w3.org/ns/wpub#accessibility-report</code> identifier.</p>
+						
+						<p class="note">The Working Group will attempt to define the <code>accessibility-report</code>
+							term by IANA, to avoid using a URL.</p>
+						
+						<pre class="example" title="Link to an accessibility report">
+{
+    "@context"   : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
+    "@type"      : "Book",
+    &#8230;
+    "url"        : "https://publisher.example.org/mobydick",
+    "name"       : "Moby Dick",
+    "extraResources"  : [{
+        "@type"       : "PublicationLink",
+        "url"         : "https://www.publisher.example.org/mobydick-accessibility.html",
+        "rel"         : "https://www.w3.org/ns/wpub/accessibility-report"
+    },{
+        &#8230;
+    }],
+    &#8230;
+}
+</pre>
+					</section>
+				</section>
+				
+				<section id="wp-cover">
+					<h4>Cover</h4>
+
+					<p>The <dfn>cover</dfn> is an image that user agents can use to present the <a>Web Publication</a>
+						to users (e.g., in a library or bookshelf, or when initially loading the Web Publication).</p>
+
+					<section id="wp-cover-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a reference to a cover
+							image.</p>
+
+						<p>User agents SHOULD NOT use the cover image as the sole means of selecting or accessing Web
+							Publications. A user agent SHOULD use the Web Publication's <a href="#wp-title">title</a>
+							and <a href="#wp-creators">creators</a> as text alternatives for such interfaces.</p>
+
+						<p>More than one cover image MAY be referenced from the infoset to provide alternative sizes and
+							resolutions for different device screens.</p>
+
+						<p>A user agent MAY create a cover for a Web Publication if one is not present. This
+							specification does not define requirements for the creation of such cover images (e.g., the
+							user agent could use a placeholder image, generate an image dynamically, or incorporate
+							properties of the infoset into a graphic, such as the title or creators).</p>
+
+						<p class="issue" data-number="210"></p>
+					</section>
+
+					<section id="wp-cover-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>As described in <a href="#wp-cover"></a>, the infoset SHOULD include a reference to a cover.
+							When present, link to such resource MUST be expressed using a <a
+								href="#publication-link-def"><code>PublicationLink</code></a>. The <code>rel</code>
+							value of the <a href="#publication-link-def"><code>PublicationLink</code></a> MUST include
+							the <code>https://www.w3.org/ns/wpub/cover-page</code> identifier.</p>
+
+						<p class="note">The Working Group will attempt to define the <code>cover-page</code> term by
+							IANA, to avoid using a URL.</p>
+
+						<pre class="example" title="Cover page expressed as resource">
+{
+    "@context"   : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
+    "@type"      : "Book",
+    &#8230;
+    "url"        : "https://publisher.example.org/mobydick",
+    "name"       : "Moby Dick",
+    "resources"  : [{
+        "@type"      : "PublicationLink",
+        "url"        : "whale-image.jpg",
+        "fileFormat" : "image/jpeg"
+        "rel"        : "https://www.w3.org/ns/wpub/cover-page"
+    },{
+        &#8230;
+    }],
+    &#8230;
+}
+</pre>
+					</section>
+				</section>
+
+				<section id="wp-extra-list">
+					<h4>List of extra resources</h4>
+
+					<p>The <dfn>list of extra resources</dfn> enumerates all <a href="#wp-resources">resources</a> that
+						are used in the processing and rendering of a <a>Web Publication</a> but are <em>not</em> within
+						its bounds (i.e., are not listed in the <a>default reading order</a> or the <a>resource
+						list</a>) but are, rather, external to the Web Publication. </p>
+
+					<section id="wp-extra-list-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>The completeness of the resource list will affect the usability of the Web Publication in
+							certain scenarios (e.g., the ability to access privacy policy information). For this reason,
+							it is strongly RECOMMENDED to provide a comprehensive list of all of the Web Publication's
+							external resources beyond those listed in the <a>default reading order</a> or <a>resource
+								list</a>.</p>
+
+						<p>In some cases, a comprehensive list of these resources might not be easily achieved (e.g.,
+							third-party scripts that reference resources from deep within their source), but a user
+							agent SHOULD still be able to render a Web Publication even if some of these resources are
+							not identified as belonging to the Web Publication (e.g., when it is taken offline without
+							them).</p>
+
+						<p class="issue" data-number="225"></p>
+					</section>
+
+					<section id="wp-extra-list-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>If present in the Web Publication Manifest, the list of extra resources MUST be mapped on the
+								<code>extraResources</code> term, defined specifically for Web Publications. </p>
+
+						<p class="note">The <code>extraResources</code> to be used in JSON has not yet been decided;
+							waiting on the resolution of issue #225.</p>
+
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th> Term name with link to definition </th>
+									<th> Short description </th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code>extraResources</code>
+									</td>
+									<td> An array of: <ul>
+											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
+											<li>an instance of a <a href="#publication-link-def"
+														><code>PublicationLink</code></a> object</li>
+										</ul> The order in the array is <em>not significant</em>. </td>
+								</tr>
+							</tbody>
+						</table>
+						<p class="issue" data-number="225"></p>
+					</section>
 				</section>
 
 				<section id="wp-default-reading-order">
@@ -1537,11 +1653,15 @@
 									<td>
 										<code>readingOrder</code>
 									</td>
-									<td> An array of: <ul>
+									<td>
+										<p>An array of:</p>
+										<ul>
 											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
 											<li>an instance of a <a href="#publication-link-def"
 														><code>PublicationLink</code></a> object</li>
-										</ul> The order in the array is <em>significant</em>. </td>
+										</ul>
+										<p>The order in the array is <em>significant</em>.</p>
+									</td>
 								</tr>
 							</tbody>
 						</table>
@@ -1582,6 +1702,63 @@
     },{
         &#8230;
     }]
+}
+</pre>
+					</section>
+				</section>
+
+				<section id="wp-privacy">
+					<h4>Privacy Policy</h4>
+
+					<p>Users often have the legal right to know and control what information is collected about them,
+						how such information is stored and for how long, whether it is personally identifiable, and how
+						it can be expunged. Including a statement that addresses such privacy concerns is consequently
+						an important part of publishing <a>Web Publications</a>. Even if no information is collected,
+						such a declaration increases the trust users have in the content.</p>
+
+					<section id="wp-privacy-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>To address this concern, a link to a privacy policy can be included in the <abbr
+								title="information set"><a>infoset</a></abbr>. It is RECOMMENDED that the privacy policy
+							be included as a resource of the Web Publication.</p>
+
+						<p>It is RECOMMENDED that the privacy policy be provided in a human-readable format, such as
+								<abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]].</p>
+
+						<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
+							Publications.</p>
+
+						<p class="issue" data-number="203"></p>
+					</section>
+
+					<section id="wp-privacy-manifest">
+						<h4>Manifest Expression</h4>
+
+						<p>As described in <a href="#wp-privacy"></a>, it is RECOMMENDED that the privacy policy be
+							included as a resource of the Web Publication. When present, link to such resource MUST be
+							expressed using a <a href="#publication-link-def"><code>PublicationLink</code></a> object.
+							The <code>rel</code> value of the <a href="#publication-link-def"
+									><code>PublicationLink</code></a> MUST include the <code>privacy-policy</code>
+							(IANA) identifier.</p>
+
+						<pre class="example" title="Privacy policy expressed as an external link">
+{
+    "@context"   : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
+    "@type"      : "CreativeWork",
+    &#8230;
+    "identifier" : "http://www.w3.org/TR/tabular-data-model/",
+    "url"        : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
+    &#8230;
+    "externalResources"  : [{
+        "@type"      : "PublicationLink",
+        "url"        : "https://www.w3.org/Consortium/Legal/privacy-statement-20140324",
+        "fileFormat" : "text/html",
+        "rel"        : "privacy-policy"
+    },{
+            &#8230;
+    }],
+    &#8230;
 }
 </pre>
 					</section>
@@ -1646,11 +1823,15 @@
 									<td>
 										<code>resources</code>
 									</td>
-									<td> An array of: <ul>
+									<td>
+										<p>An array of:</p>
+										<ul>
 											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
 											<li>an instance of a <a href="#publication-link-def"
 														><code>PublicationLink</code></a> object</li>
-										</ul> The order in the array is <em>significant</em>. </td>
+										</ul>
+										<p>The order in the array is <em>not significant</em>.</p>
+									</td>
 								</tr>
 							</tbody>
 						</table>
@@ -1691,17 +1872,17 @@
 
 					<p>The <dfn>table of contents</dfn> is a hierarchical list of links that reflects the structural
 						outline of the major sections of the Web Publication.</p>
-
+					
 					<section id="wp-table-of-contents-infoset">
 						<h5>Infoset Requirements</h5>
 
 						<p>There are no requirements on the completeness of the table of contents, except that, when
 							specified, it MUST include a link to at least one <a href="#wp-resources">resource</a>.</p>
 
-						<p> The table of contents is not specified directly in the manifest. Instead, the manifest
+						<p>The table of contents is not specified directly in the manifest. Instead, the manifest
 							SHOULD provide a link to an HTML element in one of the <a href="#wp-resources">resources</a>
 							(most likely a <code>nav</code> element&#160;[[!html]]), with a <code>role</code> attribute
-							value set to <code>doc-toc</code>. </p>
+							value set to <code>doc-toc</code>.</p>
 
 						<p class="issue">This question arises only if the table of contents is accepted: can a table of
 							contents navigation element refer, via links, to any resource that is <em>not</em> listed in
@@ -1709,7 +1890,7 @@
 					</section>
 
 					<section id="wp-table-of-contents-manifest">
-						<h5>Table of Contents</h5>
+						<h5>Manifest Expresion</h5>
 
 						<p>If present in the Web Publication Manifest this item MUST be mapped on the
 								<code>tableOfContents</code> term, defined specifically for Web Publications. </p>
@@ -1754,8 +1935,10 @@
     &#8230;
 &lt;/body&gt;
 </pre>
-						<p class="issue"> The term <code>tableOfContents</code> has not been approved by the Working
+						<p class="issue">The term <code>tableOfContents</code> has not been approved by the Working
 							Group yet; it is currently a placeholder. </p>
+
+						<p class="issue" data-number="234"></p>
 					</section>
 				</section>
 			</section>
@@ -1763,18 +1946,53 @@
 			<section id="wp-extensibility">
 				<h3>Extensibility</h3>
 
-				<p>The <abbr title="information set"><a>infoset</a></abbr> is designed to provide a basic set of
-					properties for use by user agents in presenting and rendering a <a>Web Publication</a>, but MAY be
-					extended in the following ways:</p>
+				<section id="wp-extensibility-infoset">
+					<h4>Infoset</h4>
 
-				<ol>
-					<li>through the inclusion of additional properties in the manifest;</li>
-					<li>by the provision of linked metadata records.</li>
-				</ol>
+					<p>The <abbr title="information set"><a>infoset</a></abbr> is designed to provide a basic set of
+						properties for use by user agents in presenting and rendering a <a>Web Publication</a>, but MAY
+						be extended in the following ways:</p>
 
-				<p>User Agents MAY support additional properties but MUST NOT include unrecognized properties in the
-						<abbr title="information set">infoset</abbr>. The use of linked records is RECOMMENDED whenever
-					possible, as the use of native formats standardizes and simplifies processing by user agents.</p>
+					<ol>
+						<li>through the inclusion of additional properties in the manifest;</li>
+						<li>by the provision of linked metadata records.</li>
+					</ol>
+
+					<p>User Agents MAY support additional properties but MUST NOT include unrecognized properties in the
+							<abbr title="information set">infoset</abbr>. The use of linked records is RECOMMENDED
+						whenever possible, as the use of native formats standardizes and simplifies processing by user
+						agents.</p>
+				</section>
+
+				<section id="wp-extensibility-manifest">
+					<h4>Manifest</h4>
+
+					<p>Extending the manifest to allow additional infoset properties is done, for example, via links to
+						an external ONIX&#160;[[onix]] or BibTeX&#160;[[bibtex]] file. When present, link to such
+						resource MUST be expressed using a <a href="#publication-link-def"
+							><code>PublicationLink</code></a> object. The <code>rel</code> value of the <a
+							href="#publication-link-def"><code>PublicationLink</code></a> MUST include the
+							<code>describedby</code> (IANA) identifier.</p>
+
+					<pre class="example" title="Link to external ONIX for Books Metadata file">
+{
+    "@context"   : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
+    "@type"      : "Book",
+    &#8230;
+    "url"        : "https://publisher.example.org/mobydick",
+    "name"       : "Moby Dick",
+    "extraResources"  : [{
+        "@type"       : "PublicationLink",
+        "url"         : "https://www.publisher.example.org/mobydick-onix.xml",
+        "fileFormat"  : "application/xml",
+        "rel"         : "describedby"
+    },{
+        &#8230;
+    }],
+    &#8230;
+}
+</pre>
+				</section>
 			</section>
 		</section>
 		<section id="wp-lifecycle">

--- a/index.html
+++ b/index.html
@@ -166,7 +166,6 @@
 					<h4>Web App Manifest</h4>
 
 					<p class="ednote">We may want to write something here on the relationships&#8230;</p>
-
 				</section>
 			</section>
 
@@ -253,23 +252,11 @@
 				</ul>
 			</section>
 		</section>
-		<section id="infoset">
-			<h2>Information Set</h2>
+		<section id="wp-construct">
+			<h2>Web Publication Construction</h2>
 
-			<p class="ednote">As the serialization of the manifest remains an open issue, specifics about how properties
-				are compiled into the <abbr title="information set">infoset</abbr> remain under-specified. This
-				includes, but is not limited to, what specific names the properties will have in the <abbr
-					title="information set">infoset</abbr>, whether the names in the <a>manifest</a> will be the same as
-				those in the <abbr title="information set">infoset</abbr> and/or whether mappings to properties from
-				known vocabularies will be used.</p>
-
-			<p class="issue" data-number="63">The name "<abbr title="information set">infoset</abbr>" might change
-				depending on feedback. Although this term has a different meaning for individuals familiar with <abbr
-					title="Extensible Markup Language">XML</abbr>, alternatives such as "properties" and "metadata" do
-				not fully capture the nature or purpose of the collected information.</p>
-
-			<section id="infoset-expl" class="informative">
-				<h3>Explanation</h3>
+			<section id="wp-intro" class="informative">
+				<h3>Infoset and Manifest</h3>
 
 				<p>A <a>Web Publication</a> is defined by a set of properties known as its <dfn data-lt="infoset"
 						>information set</dfn> (<abbr title="information set">infoset</abbr>). The <abbr
@@ -287,10 +274,162 @@
 						href="#manifest-serialization"></a>. Some information can be obtained outside the
 					manifest—fallback rules for properties defined in the following subsections allow a user agent to
 					compile information that the author has not provided in the manifest, for example.</p>
+
+				<p> A <a>manifest</a> is a serialization of a <a>Web Publication's</a>
+					<abbr title="information set"><a>infoset</a></abbr>. The manifest is serialized using the
+					JSON&#160;[[!ecma-404]], more specifically the JSON-LD&#160;[[!json-ld]] format. The manifest can be
+					a separate JSON-LD file, or it can be part of an HTML resource using the <a
+						href="https://www.w3.org/TR/html5/semantics-scripting.html#the-script-element"
+							><code>script</code> element</a> in HTML&#160;[[!html]]. If the latter, the
+						<code>type</code> attribute of the <code>script</code> element MUST be set to
+						<code>application/ld+json</code>. </p>
+
+				<pre class="example" title="A Web Publication Manifest included in an HTML resource">
+	&lt;script id="example_manifest" type="application/ld+json"&gt;
+	{
+    &#8230;
+	}
+	&lt;/script&gt;
+</pre>
 			</section>
 
-			<section id="infoset-req">
+			<section id="wp-manifest">
+				<h3>Creating a Manifest</h3>
+
+				<section id="wpub-context">
+					<h4>Web Publication Manifest Contexts</h4>
+
+					<p> A Web Publication Manifest MUST start by setting the appropriate (JSON-LD) contexts. This
+						context has two major components: </p>
+					<ul>
+						<li>the “core” Schema.org context, i.e., <code>http://schema.org</code>;</li>
+						<li>the separate, WP-specific context file: <code>https://www.w3.org/ns/wpub.jsonld</code></li>
+					</ul>
+
+					<p> Note that the latter may also add some features to terms defined in Schema.org. </p>
+
+					<div class="note">
+						<p> An example for the latter is the requirement for the <a href="https://schema.org/creator"
+								>creator</a> term to be order preserving. </p>
+						<p> As part of the continuous contacts with Schema.org the additional requirements defined in
+							the WP specific context file may migrate to the core Schema.org. </p>
+					</div>
+
+					<p> In practice, this means that a Web Publication Manifest MUST begin with, at the minimum: </p>
+
+					<pre class="example">
+{
+    "@context" : ["http://schema.org", "https://www.w3.org/ns/wpub.jsonld"],
+    &#8230;
+}
+</pre>
+
+					<p> In some cases, this structure may have to be extended by additional, local information, see the
+							<a href="#manifest-language-and-dir"></a>. </p>
+				</section>
+				<section>
+					<h4>Publication Types</h4>
+					<p> The manifest MUST also include a <dfn>Publication Type</dfn>. This MAY be mapped onto the
+						Schema.org <a href="http://schema.org/CreativeWork"><code>CreativeWork</code></a> type, using
+						the <code>@type</code> of JSON-LD&#160;[[json-ld]]. Schema.org also includes a number of more
+						specific types (see the <a href="http://schema.org/CreativeWork">list</a> on the Schema.org
+						site) which include a type for <a href="http://schema.org/Article">Article</a>, <a
+							href="http://schema.org/Book">Book</a>, or <a href="http://schema.org/Course">Course</a>;
+						these may MAY also be used instead of <code>CreativeWork</code>. </p>
+					<pre class="example" title="Setting type of the publication to be a Book">
+{
+    "@context" : ["http://schema.org", "https://www.w3.org/ns/wpub.jsonld"],
+    "@type"    : "Book"
+    &#8230;
+}
+</pre>
+				</section>
+				<section id="manifest-properties">
+					<h3>Properties</h3>
+					
+					<p>The naming, syntax and requirements for manifest properties are defined in <a href="#wp-properties"/>.</p>
+				</section>
+			</section>
+
+			<section id="wp-resources">
+				<h2>Resources</h2>
+
+				<p>A <a>Web Publication</a> MUST include at least one <abbr title="Hypertext Markup Language"
+						>HTML</abbr> document&#160;[[!html]] that <a href="#wp-linking">links to the manifest</a>.</p>
+
+				<p>There are no restrictions on a Web Publication beyond this requirement. The Web Publication MAY
+					include references to resources of any media type, both in the <a>default reading order</a> and as
+					dependencies of other resources.</p>
+
+				<div class="note">
+					<p>When adding resources to a Web Publication, consider support in user agents. The use of
+						progressive enhancement techniques and the provision of fallback content, as appropriate, will
+						ensure a more consistent reading experience for users regardless of their preferred user
+						agent.</p>
+				</div>
+			</section>
+
+			<section id="wp-linking">
+				<h2>Linking to a Manifest</h2>
+
+				<p>Resources SHOULD provide a link to the manifest of the Web Publication to which they belong to enable
+					discovery. Links MUST take one or both of the following forms:</p>
+
+				<ul>
+					<li><p>An HTTP <code>Link</code> header field&#160;[[!rfc5988]] with its <code>rel</code> parameter
+							set to the value "<code>publication</code>".</p>
+						<pre class="example">Link: &lt;https://example.com/webpub/manifest>; rel=publication</pre>
+					</li>
+					<li><p>A <code>link</code> element&#160;[[!html]] with its <code>rel</code> attribute set to the
+							value "<code>publication</code>".</p>
+						<pre class="example">&lt;link href="https://example.com/webpub/manifest" rel="publication"/></pre>
+					</li>
+				</ul>
+
+				<p>The <code>href</code> attribute may also contain a fragment identifier, referring to the Web
+					Publication Manifest expressed as part of an HTML resource (see <a href="#manifest-intro"></a>). </p>
+
+				<pre class="example" title="Link to a manifest within the same HTML resource">
+	&lt;link href="#example_manifest" rel="publication"&gt;
+	&#8230;
+	&lt;script id="example_manifest" type="application/ld+json"&gt;
+	{
+    "@context" : "http://schema.org",
+    &#8230;
+	}
+	&lt;/script&gt;
+</pre>
+
+				<p class="issue">The exact value of <code>rel</code> is still to be agreen upon.</p>
+
+				<p class="ednote">The following details might be moved to the lifecycle section in a future draft.</p>
+
+				<p>When a resource links to multiple manifests, a user agent MAY choose to present one or more
+					alternatives to the end user, or choose a single alternative on its own. The user agent MAY choose
+					to present any manifest based upon information that it possesses, even one that is not explicitly
+					listed as a parent (e.g., based upon information it calculates or acquires out of band). In the
+					absence of a preference by user agent implementers, selection of the first manifest listed is
+					suggested as a default.</p>
+
+			</section>
+		</section>
+		<section id="wp-properties">
+			<h3>Web Publication Properties</h3>
+
+			<section id="infoset">
 				<h3>Requirements</h3>
+
+				<p class="ednote">As the serialization of the manifest remains an open issue, specifics about how
+					properties are compiled into the <abbr title="information set">infoset</abbr> remain
+					under-specified. This includes, but is not limited to, what specific names the properties will have
+					in the <abbr title="information set">infoset</abbr>, whether the names in the <a>manifest</a> will
+					be the same as those in the <abbr title="information set">infoset</abbr> and/or whether mappings to
+					properties from known vocabularies will be used.</p>
+
+				<p class="issue" data-number="63">The name "<abbr title="information set">infoset</abbr>" might change
+					depending on feedback. Although this term has a different meaning for individuals familiar with
+						<abbr title="Extensible Markup Language">XML</abbr>, alternatives such as "properties" and
+					"metadata" do not fully capture the nature or purpose of the collected information.</p>
 
 				<p>The requirements for the expression of <abbr title="information set"><a>infoset</a></abbr> properties
 					are as follows:</p>
@@ -332,11 +471,28 @@
 				<p class="ednote">These requirements reflect the current minimum consensus, though a number of issues
 					remain open that could change whether an item is required or recommended. Refer to the property
 					descriptions for more information.</p>
-
 			</section>
-
-			<section id="infoset-meta">
+			<section id="wp-descriptive-properties">
 				<h3>Descriptive Properties</h3>
+
+				<section id="wp-descriptive-properties-intro">
+					<h4>Introduction</h4>
+
+					<p>
+						<a href="infoset-meta">Desciptive Properties</a> in the Web Publication Manifest are based,
+						wherever possible, on the terms defined by <a href="https://schema.org"
+						>Schema.org</a>&#160;[[schema.org]] (including <a href="http://schema.org/docs/schemas.html"
+							>hosted extensions</a> of Schema.org). This means that the descriptive infoset properties
+						are mapped to one or several Schema.org properties (inheriting their syntax and semantics). </p>
+
+					<p class="note"> Schema.org includes a large number of terms that, though relevant for publishing,
+						are not mentioned in this Recommendation. Web Publication authors may use any of those; this
+						document defines only the minimal set of infoset items, and their mapping to Schema.org when
+						appropriate. </p>
+
+					<p class="ednote"> There are discussion on whether a best practices document would be created,
+						referring to more schema.org terms. If so, it should be linked from here. </p>
+				</section>
 
 				<section id="wp-a11y">
 					<h4>Accessibility Report</h4>
@@ -532,456 +688,52 @@
 
 					<p>A <a>Web Publication's</a>
 						<dfn>canonical identifier</dfn> is a unique identifier that resolves to the preferred version of
-						the Web Publication. The canonical identifier MUST be an <a>address</a> or a value that allows a
-						one-to-one mapping to an address (e.g., a <abbr title="Digital Object Identifier"
-						>DOI</abbr>&#160;[[doi]] can be resolved to a <abbr title="Uniform Resource Locator"
-						>URL</abbr>&#160;[[url]] via a <abbr title="Digital Object Identifier">DOI</abbr> resolver). If
-						a user agent cannot resolve the canonical identifier to an address, it SHOULD ignore the
-						property.</p>
-
-					<p>If a Web Publication is hosted at more than one address, the canonical identifier allows a user
-						agent to identify the shared relationship between the versions and to determine which of the
-						available addresses is primary.</p>
-
-					<p>The canonical identifier is also intended to provide a measure of permanence above and beyond the
-						Web Publication's <a>address</a>. Even if a Web Publication is permanently relocated to a new
-						address, for example, the canonical identifier will provide a way of locating the new location
-						(e.g., a <abbr title="Digital Object Identifier">DOI</abbr> registry could be updated with the
-						new <abbr title="Uniform Resource Locator">URL</abbr>, or a redirect could be added to the <abbr
-							title="Uniform Resource Locator">URL</abbr> of the canonical identifier).</p>
-
-					<p>When assigned, the canonical identifier needs to be unique to one and only one Web Publication,
-						independent of its address(es). Ensuring uniqueness is outside the scope of this specification,
-						however. The actual uniqueness achievable depends on such factors as the conventions of the
-						identifier scheme used and the degree of control over assignment of identifiers.</p>
-
-					<p class="note">If the canonical identifier is a <abbr title="Uniform Resource Locator">URL</abbr>,
-						it can be used as the target of a "canonical" link&#160;[[rfc6596]] (e.g., a <code>link</code>
-						element&#160;[[html]] whose <code>rel</code> attribute has the value <code>canonical</code> or
-						an <abbr title="Hypertext Transfer Protocol">HTTP</abbr>
-						<code>Link</code> header field&#160;[[rfc5988]] similarly identified).</p>
-
-					<p class="issue" data-number="58">Is a canonical identifier necessary to call out explicitly in the
-							<abbr title="information set">infoset</abbr>, or can it be handled by other metadata.</p>
-				</section>
-
-				<section id="wp-cover">
-					<h4>Cover</h4>
-
-					<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a reference to a cover
-						image. This image can be used by user agents to present the <a>Web Publication</a> to users
-						(e.g., in a library or bookshelf, or when initially loading the Web Publication).</p>
-
-					<p>User agents SHOULD NOT use the cover image as the sole means of selecting or accessing Web
-						Publications. A user agent SHOULD use the Web Publication's <a href="#wp-title">title</a> and <a
-							href="#wp-creators">creators</a> as text alternatives for such interfaces.</p>
-
-					<p>More than one cover image MAY be referenced from the infoset to provide alternative sizes and
-						resolutions for different device screens.</p>
-
-					<p>A user agent MAY create a cover for a Web Publication if one is not present. This specification
-						does not define requirements for the creation of such cover images (e.g., the user agent could
-						use a placeholder image, generate an image dynamically, or incorporate properties of the infoset
-						into a graphic, such as the title or creators).</p>
-
-					<p class="issue" data-number="210"></p>
-				</section>
-
-				<section id="wp-creator">
-					<h4>Creator</h4>
-
-					<p>The creator is the individual or entity responsible for the creation of the <a>Web
-							Publication</a>. A Web Publication MAY have more than one creator.</p>
-
-					<p>The creator property SHOULD include the role the creator played in the creation of the Web
-						Publication (e.g., 'author', 'illustrator', 'translator').</p>
-				</section>
-
-				<section id="wp-language-and-dir">
-					<h4>Language and Base Direction</h4>
-
-					<p>Each textual property in the <a>Web Publication's</a>
-						<abbr title="information set"><a>infoset</a></abbr> (e.g., <a href="#wp-title">title</a>, <a
-							href="#wp-creator">creators</a>) is <a
-							href="https://w3c.github.io/string-meta/#dom-localizable"
-						>Localizable</a>&#160;[[string-meta]]. This means it is possible to assign:</p>
-
-					<ul>
-						<li>the natural <dfn>language</dfn>, which MUST be a tag that conforms to&#160;[[!bcp47]];</li>
-						<li>the <dfn>base direction</dfn>, which identifies the display direction for the property using
-							one of the following possible values: <ul>
-								<li><code>ltr</code>: left-to-right;</li>
-								<li><code>rtl</code>: right-to-left;</li>
-								<li><code>auto</code>: direction is determined from the value of the property.</li>
-							</ul>
-						</li>
-					</ul>
-
-					<p>The Web Publication's <abbr title="information set">infoset</abbr> MAY contain global language
-						and the base direction declarations using the same conventions (i.e., [[!bcp47]] tags for
-						language, and the values <code>ltr</code>/<code>rtl</code>/<code>auto</code> for base
-						direction). These are used as defaults for textual properties in the <abbr
-							title="information set">infoset</abbr>, unless overwritten by the properties themselves.</p>
-
-					<p class="note">These features make it possible to add the title of a publication in different
-						languages, or repeat the creators’ names using different scripts.</p>
-
-					<p>User agents MUST NOT use the language and base direction outside the context of the infoset
-						(e.g., in the processing or rendering of the Web Publication content). These values do
-							<strong>not</strong> override similar declarations in any resource, nor do they serve as
-						global defaults when such information is not provided in a resource.</p>
-
-					<p>If a user agent requires the language and one is not available in the <abbr
-							title="information set">infoset</abbr> (globally or specifically for the property), or the
-						obtained value is invalid, the user agent MAY attempt to determine the language. This
-						specification does not mandate how such a language tag is created. The user agent might:</p>
-
-					<ul>
-						<li>use the <a>non-empty</a> language declaration of the manifest;</li>
-						<li>use the first non-empty language declaration found in a resource in the <a>default reading
-								order</a>;</li>
-						<li>calculate the language using its own algorithm.</li>
-					</ul>
-
-					<p>If a language tag cannot be determined, user agents MUST use the value "<code>und</code>"
-						(undetermined). If the base direction cannot be determined, user agents MUST assume the value
-							<code>auto</code>.</p>
-
-				</section>
-
-				<section id="wp-mod-date">
-					<h4>Last Modification Date</h4>
-
-					<p>The <dfn>last modification date</dfn> is the date when the <a>Web Publication</a> was last
-						updated (i.e., whenever changes were last made to any of the resources of the Web Publication,
-						including the <a>manifest</a>).</p>
-
-					<p>This date does not necessarily reflect all changes to the Web Publication (e.g., third-party
-						content could change without the author being aware). User agents SHOULD check the last
-						modification date of individual resources to determine if they have changed and need
-						updating.</p>
-				</section>
-
-				<section id="wp-pub-date">
-					<h4>Publication Date</h4>
-
-					<p>The <dfn>publication date</dfn> is the date on which the <a>Web Publication</a> was originally
-						published. It represents a static event in the lifecycle of a Web Publication and allows
-						subsequent revisions to be identified and compared.</p>
-
-					<p>The exact moment of publication is intentionally left open to interpretation: it could be when
-						the Web Publication is first made available online or could be a point in time before
-						publication when the Web Publication is considered final.</p>
-				</section>
-
-				<section id="wp-privacy">
-					<h4>Privacy Policy</h4>
-
-					<p>Users often have the legal right to know and control what information is collected about them,
-						how such information is stored and for how long, whether it is personally identifiable, and how
-						it can be expunged. Including a statement that addresses such privacy concerns is consequently
-						an important part of publishing <a>Web Publications</a>. Even if no information is collected,
-						such a declaration increases the trust users have in the content.</p>
-
-					<p>To address this concern, a link to a privacy policy can be included in the <abbr
-							title="information set"><a>infoset</a></abbr>. It is RECOMMENDED that the privacy policy be
-						included as a resource of the Web Publication.</p>
-
-					<p>It is RECOMMENDED that the privacy policy be provided in a human-readable format, such as <abbr
-							title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]].</p>
-
-					<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
-						Publications.</p>
-
-					<p class="issue" data-number="203"></p>
-
-				</section>
-
-				<section id="wp-reading-progression">
-					<h4>Reading Progression Direction</h4>
-
-					<p>The <dfn data-lt="reading progression direction">reading progression</dfn> establishes the
-						reading direction from one resource to the next within a <a>Web Publication</a>. The value of
-						this property may be:</p>
-
-					<ul>
-						<li><code>ltr</code>: left-to-right;</li>
-						<li><code>rtl</code>: right-to-left;</li>
-						<li><code>auto</code>: the user agent chooses the direction.</li>
-					</ul>
-
-					<p>The default value is <code>auto</code>.</p>
-
-					<p>This information item has <em>no effect</em> on the rendering of the individual primary
-						resources; it is only relevant for the progression direction from one resource to the other.</p>
-
-					<p class="note">The reading progression of a <a>Web Publication</a> is used to adapt such
-						publication level interactions as menu position, swap direction, defining tap zones to lead the
-						user to the next and previous pages, touch gestures, etc.</p>
-
-
-				</section>
-
-				<section id="wp-title">
-					<h4>Title</h4>
-
-					<p>The title provides the human-readable name of the <a>Web Publication</a>.</p>
-
-					<p>When specified in the <abbr title="information set"><a>infoset</a></abbr>, the title MUST be
-							<a>non-empty</a>.</p>
-
-					<p>If a user agent requires a title and one is not available in the <abbr title="information set"
-							>infoset</abbr>, the user agent MAY create one. This specification does not mandate how such
-						a title is created. The user agent might:</p>
-
-					<ul>
-						<li>use the first <a>non-empty</a>
-							<code>title</code> element found in a resource in the <a>default reading order</a>;</li>
-						<li>provide a language-specific placeholder title (e.g., 'Untitled Publication');</li>
-						<li>use the <abbr title="Uniform Resource Locator">URL</abbr> of the manifest;</li>
-						<li>calculate a title using its own algorithm.</li>
-					</ul>
-
-					<div class="note">
-						<p>A user agent is not expected to produce a <a
-								href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title">meaningful
-							title</a>&#160;[[wcag20]] for a Web Publication when one is not specified.</p>
-					</div>
-				</section>
-			</section>
-
-			<section id="infoset-structure">
-				<h3>Structural Properties</h3>
-
-				<section id="wp-default-reading-order">
-					<h4>Default Reading Order</h4>
-
-					<p>The <dfn>default reading order</dfn> is a specific progression through a set of <a>Web
-							Publication</a> resources.</p>
-
-					<p>A user might follow alternative pathways through the content, but in the absence of such
-						interaction the default reading order defines the expected progression from one resource to the
-						next.</p>
-
-					<p>The default reading order MUST include at least one resource.</p>
-
-					<p>The default reading order is specified directly in the manifest. If the reading order consists of
-						one single resource, namely the primary entry page of the Web Publication (i.e., the resource
-						the user accesses to reach the manifest, see <a href="#wp-linking"></a>), the default reading
-						order need not be specified in the manifest.</p>
-				</section>
-
-				<section id="wp-resource-list">
-					<h4>Resource List</h4>
-
-					<p>The <dfn>resource list</dfn> enumerates all <a href="#wp-resources">resources</a> that are used
-						in the processing and rendering of a <a>Web Publication</a> (i.e., that are within its bounds)
-						and that are not listed in the <a>default reading order</a>.</p>
-
-					<p class="note">The union of the resource list and default reading order represents the definitive
-						list of resources that belong to the Web Publication. All other resources are external to the
-						Web Publication.</p>
-
-					<p>The completeness of the resource list will affect the usability of the Web Publication in certain
-						reading scenarios (e.g., the ability to read the Web Publication offline). For this reason, it
-						is strongly RECOMMENDED to provide a comprehensive list of all of the Web Publication's
-						constituent resources beyond those listed in the <a>default reading order</a>.</p>
-
-					<p>In some cases, a comprehensive list of these resources might not be easily achieved (e.g.,
-						third-party scripts that reference resources from deep within their source), but a user agent
-						SHOULD still be able to render a Web Publication even if some of these resources are not
-						identified as belonging to the Web Publication (e.g., when it is taken offline without
-						them).</p>
-
-					<div class="ednote"> The previous version of the draft included: <blockquote>
-							<p>If a user agent encounters a resource that it cannot locate in the resource list, it MUST
-								treat the resource as external to the Web Publication (e.g., it might alert the user
-								before loading, open the resource in a new window, or unload the current Web Publication
-								and resume normal Web browsing).</p>
-						</blockquote>
-						<p>This was not decided on the Toronto F2F, and is still open.</p>
-					</div>
-				</section>
-
-				<section id="wp-table-of-contents">
-					<h4>Table of Contents</h4>
-
-					<p>The <dfn>table of contents</dfn> is a hierarchical list of links that reflects the structural
-						outline of the major sections of the Web Publication. There are no requirements on the
-						completeness of the table of contents, except that, when specified, it MUST include a link to at
-						least one <a href="#wp-resources">resource</a>.</p>
-
-					<p> The table of contents is not specified directly in the manifest. Instead, the manifest SHOULD
-						provide a link to an HTML element in one of the <a href="#wp-resources">resources</a> (most
-						likely a <code>nav</code> element&#160;[[!html]]), with a <code>role</code> attribute value set
-						to <code>doc-toc</code>. </p>
-
-					<p class="issue">This question arises only if the table of contents is accepted: can a table of
-						contents navigation element refer, via links, to any resource that is <em>not</em> listed in the
-							<a>default reading order</a>?</p>
-				</section>
-			</section>
-
-			<section id="wp-extensibility">
-				<h3>Extensibility</h3>
-
-				<p>The <abbr title="information set"><a>infoset</a></abbr> is designed to provide a basic set of
-					properties for use by user agents in presenting and rendering a <a>Web Publication</a>, but MAY be
-					extended in the following ways:</p>
-
-				<ol>
-					<li>through the inclusion of additional properties in the manifest;</li>
-					<li>by the provision of linked metadata records.</li>
-				</ol>
-
-				<p>User Agents MAY support additional properties but MUST NOT include unrecognized properties in the
-						<abbr title="information set">infoset</abbr>. The use of linked records is RECOMMENDED whenever
-					possible, as the use of native formats standardizes and simplifies processing by user agents.</p>
-			</section>
-		</section>
-		<section id="manifest">
-			<h2>Web Publication Manifest</h2>
-
-			<section id="manifest-intro">
-				<h3>Overview</h3>
-
-				<p> A <a>manifest</a> is a serialization of a <a>Web Publication's</a>
-					<abbr title="information set"><a>infoset</a></abbr>. The manifest is serialized using the
-					JSON&#160;[[!ecma-404]], more specifically the JSON-LD&#160;[[!json-ld]] format. The manifest can be
-					a separate JSON-LD file, or it can be part of an HTML resource using the <a
-						href="https://www.w3.org/TR/html5/semantics-scripting.html#the-script-element"
-							><code>script</code> element</a> in HTML&#160;[[!html]]. If the latter, the
-						<code>type</code> attribute of the <code>script</code> element MUST be set to
-						<code>application/ld+json</code>. </p>
-
-				<pre class="example" title="A Web Publication Manifest included in an HTML resource">
-	&lt;script id="example_manifest" type="application/ld+json"&gt;
-	{
-    &#8230;
-	}
-	&lt;/script&gt;
-</pre>
-
-				<section>
-					<h4>Descriptive Infoset Properties</h4>
-
-					<p>
-						<a href="infoset-meta">Desciptive Properties</a> in the Web Publication Manifest are based,
-						wherever possible, on the terms defined by <a href="https://schema.org"
-						>Schema.org</a>&#160;[[schema.org]] (including <a href="http://schema.org/docs/schemas.html"
-							>hosted extensions</a> of Schema.org). This means that the descriptive infoset properties
-						are mapped to one or several Schema.org properties (inheriting their syntax and semantics). </p>
-
-					<p class="note"> Schema.org includes a large number of terms that, though relevant for publishing,
-						are not mentioned in this Recommendation. Web Publication authors may use any of those; this
-						document defines only the minimal set of infoset items, and their mapping to Schema.org when
-						appropriate. </p>
-
-					<p class="ednote"> There are discussion on whether a best practices document would be created,
-						referring to more schema.org terms. If so, it should be linked from here. </p>
-				</section>
-
-
-				<section>
-					<h4>Structural Infoset Properties</h4>
-
-					<p>
-						<a href="infoset-structure">Structural Properties</a> in the Web Publication Manifest use terms
-						that refer to one or more external resources (images, script files, separate metadata files,
-						etc.). These terms do not necessarily have a counterpart in Schema.org, and are therefore
-						defined separately by this specification. </p>
-
-					<p> Values of structural properties are usually links to external resources, or an array thereof.
-						Such a link may be expressed in one of two ways: </p>
-
-					<ol>
-						<li>a string encoding the (absolute or relative) URL of the resources; or</li>
-						<li>an instance of a Schema.org <a href="http://schema.org/StructuredValue"
-									><code>StructuredValue</code></a> that can be used to express, beyond the URL, the
-							media type and other characteristics of the target resource.</li>
-					</ol>
-
-					<pre class="example" title="Expressing external links, either as strings or as objects">
-	{
-        &#8230;
-        "resources" : [
-            "datatypes.svg",
-            {
-                "@type"      : "StructuredValue",
-                "url"        : "test-utf8.csv",
-                "fileFormat" : "text/csv"
-            }
-		]
-	}
-</pre>
-
-					<p class="note"> There will be continuous contacts with Schema.org to see whether some of the
-						structural property terms should not be included in the core Schema.org hierarchy, or one of its
-						extensions. </p>
-				</section>
-
-				<section id="wpub-context">
-					<h4>Web Publication Manifest Contexts</h4>
-
-					<p> A Web Publication Manifest MUST start by setting the appropriate (JSON-LD) contexts. This
-						context has two major components: </p>
-					<ul>
-						<li>the “core” Schema.org context, i.e., <code>http://schema.org</code>;</li>
-						<li>the separate, WP-specific context file: <code>https://www.w3.org/ns/wpub.jsonld</code></li>
-					</ul>
-
-					<p> Note that the latter may also add some features to terms defined in Schema.org. </p>
-
-					<div class="note">
-						<p> An example for the latter is the requirement for the <a href="https://schema.org/creator"
-								>creator</a> term to be order preserving. </p>
-						<p> As part of the continuous contacts with Schema.org the additional requirements defined in
-							the WP specific context file may migrate to the core Schema.org. </p>
-					</div>
-
-					<p> In practice, this means that a Web Publication Manifest MUST begin with, at the minimum: </p>
-
-					<pre class="example">
-{
-    "@context" : ["http://schema.org", "https://www.w3.org/ns/wpub.jsonld"],
-    &#8230;
-}
-</pre>
-
-					<p> In some cases, this structure may have to be extended by additional, local information, see the
-							<a href="#manifest-language-and-dir"></a>. </p>
-				</section>
-				<section>
-					<h4>Publication Types</h4>
-					<p> The manifest MUST also include a <dfn>Publication Type</dfn>. This MAY be mapped onto the
-						Schema.org <a href="http://schema.org/CreativeWork"><code>CreativeWork</code></a> type, using
-						the <code>@type</code> of JSON-LD&#160;[[json-ld]]. Schema.org also includes a number of more
-						specific types (see the <a href="http://schema.org/CreativeWork">list</a> on the Schema.org
-						site) which include a type for <a href="http://schema.org/Article">Article</a>, <a
-							href="http://schema.org/Book">Book</a>, or <a href="http://schema.org/Course">Course</a>;
-						these may MAY also be used instead of <code>CreativeWork</code>. </p>
-					<pre class="example" title="Setting type of the publication to be a Book">
-{
-    "@context" : ["http://schema.org", "https://www.w3.org/ns/wpub.jsonld"],
-    "@type"    : "Book"
-    &#8230;
-}
-</pre>
-
-				</section>
-			</section>
-
-			<section>
-				<h3>Specification of Web Publication Manifest Items</h3>
-
-				<section>
-					<h4>Descriptive Infoset Properties</h4>
-					<section id="wp-canonical-identifier-wpm">
-						<h4>Canonical Identifier</h4>
-						<p> As described in <a href="#wp-canonical-identifier"></a>, a <a>Web Publication's</a>
-							<a>canonical identifier</a> is a unique identifier that resolves to the preferred version of
-							the Web Publication. This infoset item MUST be mapped on the <a href="http://schema.org/id"
-									><code>id</code></a> term, whose value is a URL. </p>
+						the Web Publication.</p>
+
+					<section id="wp-canonical-identifier-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>The canonical identifier MUST be an <a>address</a> or a value that allows a one-to-one
+							mapping to an address (e.g., a <abbr title="Digital Object Identifier"
+							>DOI</abbr>&#160;[[doi]] can be resolved to a <abbr title="Uniform Resource Locator"
+								>URL</abbr>&#160;[[url]] via a <abbr title="Digital Object Identifier">DOI</abbr>
+							resolver). If a user agent cannot resolve the canonical identifier to an address, it SHOULD
+							ignore the property.</p>
+
+						<p>If a Web Publication is hosted at more than one address, the canonical identifier allows a
+							user agent to identify the shared relationship between the versions and to determine which
+							of the available addresses is primary.</p>
+
+						<p>The canonical identifier is also intended to provide a measure of permanence above and beyond
+							the Web Publication's <a>address</a>. Even if a Web Publication is permanently relocated to
+							a new address, for example, the canonical identifier will provide a way of locating the new
+							location (e.g., a <abbr title="Digital Object Identifier">DOI</abbr> registry could be
+							updated with the new <abbr title="Uniform Resource Locator">URL</abbr>, or a redirect could
+							be added to the <abbr title="Uniform Resource Locator">URL</abbr> of the canonical
+							identifier).</p>
+
+						<p>When assigned, the canonical identifier needs to be unique to one and only one Web
+							Publication, independent of its address(es). Ensuring uniqueness is outside the scope of
+							this specification, however. The actual uniqueness achievable depends on such factors as the
+							conventions of the identifier scheme used and the degree of control over assignment of
+							identifiers.</p>
+
+						<p class="note">If the canonical identifier is a <abbr title="Uniform Resource Locator"
+								>URL</abbr>, it can be used as the target of a "canonical" link&#160;[[rfc6596]] (e.g.,
+							a <code>link</code> element&#160;[[html]] whose <code>rel</code> attribute has the value
+								<code>canonical</code> or an <abbr title="Hypertext Transfer Protocol">HTTP</abbr>
+							<code>Link</code> header field&#160;[[rfc5988]] similarly identified).</p>
+
+						<p class="issue" data-number="58">Is a canonical identifier necessary to call out explicitly in
+							the <abbr title="information set">infoset</abbr>, or can it be handled by other
+							metadata.</p>
+					</section>
+
+					<section id="wp-canonical-identifier-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>This infoset item MUST be mapped on the <a href="http://schema.org/id"><code>id</code></a>
+							term, whose value is a URL. </p>
 
 						<p> Additionally, the term <a href="http://schema.org/identifier"><code>itentifier</code></a>
 							MAY also be used; in Schema.org, the value of this term can be a URL, a textual information
@@ -1034,13 +786,63 @@
 </pre>
 
 					</section>
-					<section id="wp-creators-wpm">
-						<h4>Creator</h4>
-						<p> As desribed in <a href="#wp-creators"></a>, a <a>Web Publication's</a> creators are the
-							individuals or entities responsible for the creation of the <a>Web Publication</a>. There
-							isn’t one single Schema.org term this item must be mapped onto; instead, there are a number
-							of terms and, if this Infoset Item is used, the Web Publication Manifest SHOULD use one of
-							those. The value of these terms are one or more <a href="http://schema.org/Person"
+				</section>
+
+				<section id="wp-cover">
+					<h4>Cover</h4>
+
+					<p>The <dfn>cover</dfn> is an image that user agents can use to present the <a>Web Publication</a>
+						to users (e.g., in a library or bookshelf, or when initially loading the Web Publication).</p>
+
+					<section id="wp-cover-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a reference to a cover
+							image.</p>
+
+						<p>User agents SHOULD NOT use the cover image as the sole means of selecting or accessing Web
+							Publications. A user agent SHOULD use the Web Publication's <a href="#wp-title">title</a>
+							and <a href="#wp-creators">creators</a> as text alternatives for such interfaces.</p>
+
+						<p>More than one cover image MAY be referenced from the infoset to provide alternative sizes and
+							resolutions for different device screens.</p>
+
+						<p>A user agent MAY create a cover for a Web Publication if one is not present. This
+							specification does not define requirements for the creation of such cover images (e.g., the
+							user agent could use a placeholder image, generate an image dynamically, or incorporate
+							properties of the infoset into a graphic, such as the title or creators).</p>
+
+						<p class="issue" data-number="210"></p>
+					</section>
+
+					<section id="wp-cover-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>&#8230;</p>
+					</section>
+				</section>
+
+				<section id="wp-creator">
+					<h4>Creator</h4>
+
+					<p>The <dfn>creator</dfn> is the individual or entity responsible for the creation of the <a>Web
+							Publication</a>.</p>
+
+					<section id="wp-creator-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>A Web Publication MAY have more than one creator.</p>
+
+						<p>The creator property SHOULD include the role the creator played in the creation of the Web
+							Publication (e.g., 'author', 'illustrator', 'translator').</p>
+					</section>
+
+					<section id="wp-creator-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>There isn’t one single Schema.org term this item must be mapped onto; instead, there are a
+							number of terms and, if this Infoset Item is used, the Web Publication Manifest SHOULD use
+							one of those. The value of these terms are one or more <a href="http://schema.org/Person"
 									><code>Person</code></a> objects or, in some cases, <a
 								href="http://schema.org/Person"><code>Person</code></a> or an <a
 								href="http://schema.org/Organization"><code><code>Organization</code></code></a> items.
@@ -1188,13 +990,73 @@
 </pre>
 						<p class="issue" data-number="217"></p>
 					</section>
+				</section>
 
-					<section id="wp-language-and-dir-wpm">
-						<h4>Language and Base Direction</h4>
-						<p> As described in <a href="#wp-language-and-dir"></a> this infoset item refers to several
-							aspects of setting language and direction; these are treated separately. </p>
-						<section id="manifest-language-and-dir">
-							<h5>Default language and direction</h5>
+				<section id="wp-language-and-dir">
+					<h4>Language and Base Direction</h4>
+
+					<p>Each textual property in the <a>Web Publication's</a>
+						<abbr title="information set"><a>infoset</a></abbr> (e.g., <a href="#wp-title">title</a>, <a
+							href="#wp-creator">creators</a>) is <a
+							href="https://w3c.github.io/string-meta/#dom-localizable"
+						>Localizable</a>&#160;[[string-meta]]. This means it is possible to assign:</p>
+
+					<ul>
+						<li>the natural <dfn>language</dfn>, which MUST be a tag that conforms to&#160;[[!bcp47]];</li>
+						<li>the <dfn>base direction</dfn>, which identifies the display direction for the property using
+							one of the following possible values: <ul>
+								<li><code>ltr</code>: left-to-right;</li>
+								<li><code>rtl</code>: right-to-left;</li>
+								<li><code>auto</code>: direction is determined from the value of the property.</li>
+							</ul>
+						</li>
+					</ul>
+
+					<section id="wp-language-and-dir-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>The Web Publication's <abbr title="information set">infoset</abbr> MAY contain global
+							language and the base direction declarations using the same conventions (i.e., [[!bcp47]]
+							tags for language, and the values <code>ltr</code>/<code>rtl</code>/<code>auto</code> for
+							base direction). These are used as defaults for textual properties in the <abbr
+								title="information set">infoset</abbr>, unless overwritten by the properties
+							themselves.</p>
+
+						<p class="note">These features make it possible to add the title of a publication in different
+							languages, or repeat the creators’ names using different scripts.</p>
+
+						<p>User agents MUST NOT use the language and base direction outside the context of the infoset
+							(e.g., in the processing or rendering of the Web Publication content). These values do
+								<strong>not</strong> override similar declarations in any resource, nor do they serve as
+							global defaults when such information is not provided in a resource.</p>
+
+						<p>If a user agent requires the language and one is not available in the <abbr
+								title="information set">infoset</abbr> (globally or specifically for the property), or
+							the obtained value is invalid, the user agent MAY attempt to determine the language. This
+							specification does not mandate how such a language tag is created. The user agent might:</p>
+
+						<ul>
+							<li>use the <a>non-empty</a> language declaration of the manifest;</li>
+							<li>use the first non-empty language declaration found in a resource in the <a>default
+									reading order</a>;</li>
+							<li>calculate the language using its own algorithm.</li>
+						</ul>
+
+						<p>If a language tag cannot be determined, user agents MUST use the value "<code>und</code>"
+							(undetermined). If the base direction cannot be determined, user agents MUST assume the
+							value <code>auto</code>.</p>
+					</section>
+
+
+					<section id="wp-language-and-dir-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>As this infoset item refers to several aspects of setting language and direction, each is
+							treated separately. </p>
+
+						<section id="manifest-default-language-and-dir">
+							<h6>Default language and direction</h6>
+
 							<p> The infoset described in <a href="#wp-language-and-dir"></a> requires the possibility to
 								set a <em>default</em> language and base direction for all textual information in the
 								manifest. These MUST be set by <em>extending</em> the context of the manifest to include
@@ -1221,8 +1083,10 @@
 
 							<p class="issue" data-number="218"></p>
 						</section>
-						<section>
-							<h5>Item specific language and direction</h5>
+
+						<section id="manifest-specific-language-and-dir">
+							<h6>Item specific language and direction</h6>
+
 							<p> The infoset described in <a href="#wp-language-and-dir"></a> also requires the
 								possibility to set the language and base direction for any textual information in the
 								manifest. This MUST be set for each item separately, also using the <a
@@ -1249,17 +1113,35 @@
 
 							<p class="issue" data-number="219"></p>
 						</section>
+
 						<p class="issue" data-number="220"></p>
 					</section>
-					<section id="wp-mod-date-wpm">
-						<h4>Last Modification Date</h4>
+				</section>
 
-						<p> As described in <a href="#wp-mod-date"></a>, the <a>last modification date</a> is the date
-							when the <a>Web Publication</a> was last updated. This infoset item MUST be mapped on the <a
-								href="http://schema.org/dateModified"><code>dateModified</code></a> term, whose value is
-							a <a href="http://schema.org/Date"><code>Date</code></a> or <a
+				<section id="wp-mod-date">
+					<h4>Last Modification Date</h4>
+
+					<p>The <dfn>last modification date</dfn> is the date when the <a>Web Publication</a> was last
+						updated (i.e., whenever changes were last made to any of the resources of the Web Publication,
+						including the <a>manifest</a>).</p>
+
+					<section id="wp-mod-date-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>The last modification date does not necessarily reflect all changes to the Web Publication
+							(e.g., third-party content could change without the author being aware). User agents SHOULD
+							check the last modification date of individual resources to determine if they have changed
+							and need updating.</p>
+					</section>
+
+					<section id="wp-mod-date-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>This infoset item MUST be mapped on the <a href="http://schema.org/dateModified"
+									><code>dateModified</code></a> term, whose value is a <a
+								href="http://schema.org/Date"><code>Date</code></a> or <a
 								href="http://schema.org/DateTime"><code>DateTime</code></a>, both expressed in ISO 8601
-							date, or Date Time formats, respectively [[iso8601]]. </p>
+							date, or Date Time formats, respectively [[iso8601]].</p>
 
 						<table class="zebra">
 							<thead>
@@ -1290,13 +1172,31 @@
 </pre>
 
 					</section>
-					<section id="wp-pub-date-wpm">
-						<h4>Publication Date</h4>
+				</section>
 
-						<p> As described in <a href="#wp-pub-date"></a>, the <a>last modification date</a> is the date
-							when the <a>Web Publication</a> was originall published. This infoset item MUST be mapped on
-							the <a href="http://schema.org/datePublished"><code>datePublished</code></a> term, whose
-							value is a <a href="http://schema.org/Date"><code>Date</code></a> or <a
+				<section id="wp-pub-date">
+					<h4>Publication Date</h4>
+
+					<p>The <dfn>publication date</dfn> is the date on which the <a>Web Publication</a> was originally
+						published. It represents a static event in the lifecycle of a Web Publication and allows
+						subsequent revisions to be identified and compared.</p>
+
+					<p>The exact moment of publication is intentionally left open to interpretation: it could be when
+						the Web Publication is first made available online or could be a point in time before
+						publication when the Web Publication is considered final.</p>
+
+					<section id="wp-pub-date-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>&#8230;</p>
+					</section>
+
+					<section id="wp-pub-date-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>This infoset item MUST be mapped on the <a href="http://schema.org/datePublished"
+									><code>datePublished</code></a> term, whose value is a <a
+								href="http://schema.org/Date"><code>Date</code></a> or <a
 								href="http://schema.org/DateTime"><code>DateTime</code></a>, both expressed in ISO 8601
 							date, or Date Time formats, respectively [[iso8601]]. </p>
 
@@ -1329,12 +1229,74 @@
 }
 </pre>
 					</section>
-					<section id="wp-reading-progression-wpm">
-						<h4>Reading Progression Direction</h4>
-						<p> As described in <a href="#wp-reading-progression"></a>, this infoset item establishes the
-							reading direction from one resource to the next. There is no corresponding term in
-							Schema.org; instead, this item MUST be mapped on the <code>readingProgression</code> term,
-							defined specifically for Web Publications. </p>
+				</section>
+
+				<section id="wp-privacy">
+					<h4>Privacy Policy</h4>
+
+					<p>Users often have the legal right to know and control what information is collected about them,
+						how such information is stored and for how long, whether it is personally identifiable, and how
+						it can be expunged. Including a statement that addresses such privacy concerns is consequently
+						an important part of publishing <a>Web Publications</a>. Even if no information is collected,
+						such a declaration increases the trust users have in the content.</p>
+
+					<section id="wp-privacy-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>To address this concern, a link to a privacy policy can be included in the <abbr
+								title="information set"><a>infoset</a></abbr>. It is RECOMMENDED that the privacy policy
+							be included as a resource of the Web Publication.</p>
+
+						<p>It is RECOMMENDED that the privacy policy be provided in a human-readable format, such as
+								<abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]].</p>
+
+						<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
+							Publications.</p>
+
+						<p class="issue" data-number="203"></p>
+					</section>
+
+					<section id="wp-privacy-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>&#8230;</p>
+					</section>
+				</section>
+
+				<section id="wp-reading-progression">
+					<h4>Reading Progression Direction</h4>
+
+					<p>The <dfn data-lt="reading progression direction">reading progression</dfn> establishes the
+						reading direction from one resource to the next within a <a>Web Publication</a>.</p>
+
+					<section id="wp-reading-progression-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>The value of this property may be:</p>
+
+						<ul>
+							<li><code>ltr</code>: left-to-right;</li>
+							<li><code>rtl</code>: right-to-left;</li>
+							<li><code>auto</code>: the user agent chooses the direction.</li>
+						</ul>
+
+						<p>The default value is <code>auto</code>.</p>
+
+						<p>This information item has <em>no effect</em> on the rendering of the individual primary
+							resources; it is only relevant for the progression direction from one resource to the
+							other.</p>
+
+						<p class="note">The reading progression of a <a>Web Publication</a> is used to adapt such
+							publication level interactions as menu position, swap direction, defining tap zones to lead
+							the user to the next and previous pages, touch gestures, etc.</p>
+					</section>
+
+					<section id="wp-reading-progression-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>There is no corresponding term in Schema.org; instead, this item MUST be mapped on the
+								<code>readingProgression</code> term, defined specifically for Web Publications. </p>
+
 						<table class="zebra">
 							<thead>
 								<tr>
@@ -1367,13 +1329,43 @@
 </pre>
 
 					</section>
+				</section>
 
-					<section id="wp-title-wmp">
-						<h4>Title</h4>
+				<section id="wp-title">
+					<h4>Title</h4>
 
-						<p> As described in <a href="#wp-title"></a>, the title provides the human-readable name of the
-							Web Publication. If set explicitly in the Manifest (i.e., if it is not to be derived from
-							the <code>title</code> element of the primary entry point), this item MUST be mapped on the
+					<p>The title provides the human-readable name of the <a>Web Publication</a>.</p>
+
+					<section id="wp-title-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>When specified in the <abbr title="information set"><a>infoset</a></abbr>, the title MUST be
+								<a>non-empty</a>.</p>
+
+						<p>If a user agent requires a title and one is not available in the <abbr
+								title="information set">infoset</abbr>, the user agent MAY create one. This
+							specification does not mandate how such a title is created. The user agent might:</p>
+
+						<ul>
+							<li>use the first <a>non-empty</a>
+								<code>title</code> element found in a resource in the <a>default reading order</a>;</li>
+							<li>provide a language-specific placeholder title (e.g., 'Untitled Publication');</li>
+							<li>use the <abbr title="Uniform Resource Locator">URL</abbr> of the manifest;</li>
+							<li>calculate a title using its own algorithm.</li>
+						</ul>
+
+						<div class="note">
+							<p>A user agent is not expected to produce a <a
+									href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title">meaningful
+									title</a>&#160;[[wcag20]] for a Web Publication when one is not specified.</p>
+						</div>
+					</section>
+
+					<section id="wp-title-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>If set explicitly in the Manifest (i.e., if it is not to be derived from the
+								<code>title</code> element of the primary entry point), this item MUST be mapped on the
 							Schema.org <a href="http://schema.org/name"><code>name</code></a> term. </p>
 
 						<table class="zebra">
@@ -1403,9 +1395,50 @@
 </pre>
 					</section>
 				</section>
-				<section id="structural-infoset-properties-wpm">
+			</section>
+
+			<section id="wp-structural-properties">
+				<h3>Structural Properties</h3>
+
+				<section>
 					<h4>Structural Infoset Properties</h4>
 
+					<p>
+						<a href="infoset-structure">Structural Properties</a> in the Web Publication Manifest use terms
+						that refer to one or more external resources (images, script files, separate metadata files,
+						etc.). These terms do not necessarily have a counterpart in Schema.org, and are therefore
+						defined separately by this specification. </p>
+
+					<p> Values of structural properties are usually links to external resources, or an array thereof.
+						Such a link may be expressed in one of two ways: </p>
+
+					<ol>
+						<li>a string encoding the (absolute or relative) URL of the resources; or</li>
+						<li>an instance of a Schema.org <a href="http://schema.org/StructuredValue"
+									><code>StructuredValue</code></a> that can be used to express, beyond the URL, the
+							media type and other characteristics of the target resource.</li>
+					</ol>
+
+					<pre class="example" title="Expressing external links, either as strings or as objects">
+	{
+        &#8230;
+        "resources" : [
+            "datatypes.svg",
+            {
+                "@type"      : "StructuredValue",
+                "url"        : "test-utf8.csv",
+                "fileFormat" : "text/csv"
+            }
+		]
+	}
+</pre>
+
+					<p class="note"> There will be continuous contacts with Schema.org to see whether some of the
+						structural property terms should not be included in the core Schema.org hierarchy, or one of its
+						extensions. </p>
+				</section>
+
+				<section>
 					<p> Structural infoset properties typically refer to external resources via a URL. This URL-s may
 						refer to resources playing different roles (e.g., cover or privacy policy), may need some
 						additional metadata for, e.g., accessibility purposes. </p>
@@ -1463,14 +1496,35 @@
 							</tr>
 						</tbody>
 					</table>
+				</section>
 
-					<section id="wp-default-reading-order-wpm">
-						<h4>Default Reading Order</h4>
-						<p> As defined in <a href="#wp-default-reading-order"></a>, the <a>default reading order</a> is
-							a specific progression through a set of Web Publication resources. If present in the Web
-							Publication Manifest (i.e., if the Web Publication has other items in the default reading
-							order than just the primary entry page), this item MUST be mapped on the
-								<code>readingOrder</code> term, defined specifically for Web Publications. </p>
+				<section id="wp-default-reading-order">
+					<h4>Default Reading Order</h4>
+
+					<p>The <dfn>default reading order</dfn> is a specific progression through a set of <a>Web
+							Publication</a> resources.</p>
+
+					<p>A user might follow alternative pathways through the content, but in the absence of such
+						interaction the default reading order defines the expected progression from one resource to the
+						next.</p>
+
+					<section id="wp-default-reading-order-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>The default reading order MUST include at least one resource.</p>
+
+						<p>The default reading order is specified directly in the manifest. If the reading order
+							consists of one single resource, namely the primary entry page of the Web Publication (i.e.,
+							the resource the user accesses to reach the manifest, see <a href="#wp-linking"></a>), the
+							default reading order need not be specified in the manifest.</p>
+					</section>
+
+					<section id="wp-default-reading-order-manifest">
+						<h5>Manifest Expression</h5>
+
+						<p>If present in the Web Publication Manifest (i.e., if the Web Publication has other items in
+							the default reading order than just the primary entry page), this item MUST be mapped on the
+								<code>readingOrder</code> term, defined specifically for Web Publications.</p>
 						<table class="zebra">
 							<thead>
 								<tr>
@@ -1531,8 +1585,47 @@
 }
 </pre>
 					</section>
-					<section id="wp-resource-list-wpm">
-						<h4>Resource List</h4>
+				</section>
+
+				<section id="wp-resource-list">
+					<h4>Resource List</h4>
+
+					<p>The <dfn>resource list</dfn> enumerates all <a href="#wp-resources">resources</a> that are used
+						in the processing and rendering of a <a>Web Publication</a> (i.e., that are within its bounds)
+						and that are not listed in the <a>default reading order</a>.</p>
+
+					<p class="note">The union of the resource list and default reading order represents the definitive
+						list of resources that belong to the Web Publication. All other resources are external to the
+						Web Publication.</p>
+
+					<section id="wp-resource-list-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>The completeness of the resource list will affect the usability of the Web Publication in
+							certain reading scenarios (e.g., the ability to read the Web Publication offline). For this
+							reason, it is strongly RECOMMENDED to provide a comprehensive list of all of the Web
+							Publication's constituent resources beyond those listed in the <a>default reading
+							order</a>.</p>
+
+						<p>In some cases, a comprehensive list of these resources might not be easily achieved (e.g.,
+							third-party scripts that reference resources from deep within their source), but a user
+							agent SHOULD still be able to render a Web Publication even if some of these resources are
+							not identified as belonging to the Web Publication (e.g., when it is taken offline without
+							them).</p>
+
+						<div class="ednote"> The previous version of the draft included: <blockquote>
+								<p>If a user agent encounters a resource that it cannot locate in the resource list, it
+									MUST treat the resource as external to the Web Publication (e.g., it might alert the
+									user before loading, open the resource in a new window, or unload the current Web
+									Publication and resume normal Web browsing).</p>
+							</blockquote>
+							<p>This was not decided on the Toronto F2F, and is still open.</p>
+						</div>
+					</section>
+
+					<section id="wp-resource-list-manifest">
+						<h5>Manifest Expression</h5>
+
 						<p> As defined in <a href="#wp-resource-list"></a>, the <a>resource list</a> enumerates all <a
 								href="#wp-resources">resources</a> that are used in the processing and rendering of a
 								<a>Web Publication</a> (i.e., that are within its bounds) and that are not listed in the
@@ -1540,6 +1633,7 @@
 							Web Publication has other items in the default reading order than just the primary entry
 							page), this item MUST be mapped on the <code>resources</code> term, defined specifically for
 							Web Publications. </p>
+
 						<table class="zebra">
 							<thead>
 								<tr>
@@ -1590,12 +1684,36 @@
 </pre>
 
 					</section>
-					<section id="wp-table-of-contents-wpm">
-						<h4>Table of Contents</h4>
-						<p> As defined in <a href="#wp-table-of-contents"></a>, the manifest SHOULD provide a link to an
-							HTML element in one of the <a href="#wp-resources">resources</a> representing the table of
-							content. If present in the Web Publication Manifest this item MUST be mapped on the
+				</section>
+
+				<section id="wp-table-of-contents">
+					<h4>Table of Contents</h4>
+
+					<p>The <dfn>table of contents</dfn> is a hierarchical list of links that reflects the structural
+						outline of the major sections of the Web Publication.</p>
+
+					<section id="wp-table-of-contents-infoset">
+						<h5>Infoset Requirements</h5>
+
+						<p>There are no requirements on the completeness of the table of contents, except that, when
+							specified, it MUST include a link to at least one <a href="#wp-resources">resource</a>.</p>
+
+						<p> The table of contents is not specified directly in the manifest. Instead, the manifest
+							SHOULD provide a link to an HTML element in one of the <a href="#wp-resources">resources</a>
+							(most likely a <code>nav</code> element&#160;[[!html]]), with a <code>role</code> attribute
+							value set to <code>doc-toc</code>. </p>
+
+						<p class="issue">This question arises only if the table of contents is accepted: can a table of
+							contents navigation element refer, via links, to any resource that is <em>not</em> listed in
+							the <a>default reading order</a>?</p>
+					</section>
+
+					<section id="wp-table-of-contents-manifest">
+						<h5>Table of Contents</h5>
+
+						<p>If present in the Web Publication Manifest this item MUST be mapped on the
 								<code>tableOfContents</code> term, defined specifically for Web Publications. </p>
+
 						<table class="zebra">
 							<thead>
 								<tr>
@@ -1641,70 +1759,22 @@
 					</section>
 				</section>
 			</section>
-		</section>
-		<section id="wp-construction">
-			<h2>Web Publication Construction</h2>
 
-			<section id="wp-resources">
-				<h2>Resources</h2>
+			<section id="wp-extensibility">
+				<h3>Extensibility</h3>
 
-				<p>A <a>Web Publication</a> MUST include at least one <abbr title="Hypertext Markup Language"
-						>HTML</abbr> document&#160;[[!html]] that <a href="#wp-linking">links to the manifest</a>.</p>
+				<p>The <abbr title="information set"><a>infoset</a></abbr> is designed to provide a basic set of
+					properties for use by user agents in presenting and rendering a <a>Web Publication</a>, but MAY be
+					extended in the following ways:</p>
 
-				<p>There are no restrictions on a Web Publication beyond this requirement. The Web Publication MAY
-					include references to resources of any media type, both in the <a>default reading order</a> and as
-					dependencies of other resources.</p>
+				<ol>
+					<li>through the inclusion of additional properties in the manifest;</li>
+					<li>by the provision of linked metadata records.</li>
+				</ol>
 
-				<div class="note">
-					<p>When adding resources to a Web Publication, consider support in user agents. The use of
-						progressive enhancement techniques and the provision of fallback content, as appropriate, will
-						ensure a more consistent reading experience for users regardless of their preferred user
-						agent.</p>
-				</div>
-			</section>
-
-			<section id="wp-linking">
-				<h2>Linking to a Manifest</h2>
-
-				<p>Resources SHOULD provide a link to the manifest of the Web Publication to which they belong to enable
-					discovery. Links MUST take one or both of the following forms:</p>
-
-				<ul>
-					<li><p>An HTTP <code>Link</code> header field&#160;[[!rfc5988]] with its <code>rel</code> parameter
-							set to the value "<code>publication</code>".</p>
-						<pre class="example">Link: &lt;https://example.com/webpub/manifest>; rel=publication</pre>
-					</li>
-					<li><p>A <code>link</code> element&#160;[[!html]] with its <code>rel</code> attribute set to the
-							value "<code>publication</code>".</p>
-						<pre class="example">&lt;link href="https://example.com/webpub/manifest" rel="publication"/></pre>
-					</li>
-				</ul>
-
-				<p>The <code>href</code> attribute may also contain a fragment identifier, referring to the Web
-					Publication Manifest expressed as part of an HTML resource (see <a href="#manifest-intro"></a>). </p>
-
-				<pre class="example" title="Link to a manifest within the same HTML resource">
-	&lt;link href="#example_manifest" rel="publication"&gt;
-	&#8230;
-	&lt;script id="example_manifest" type="application/ld+json"&gt;
-	{
-    "@context" : "http://schema.org",
-    &#8230;
-	}
-	&lt;/script&gt;
-</pre>
-
-				<p class="issue">The exact value of <code>rel</code> is still to be agreen upon.</p>
-
-				<p class="ednote">The following details might be moved to the lifecycle section in a future draft.</p>
-
-				<p>When a resource links to multiple manifests, a user agent MAY choose to present one or more
-					alternatives to the end user, or choose a single alternative on its own. The user agent MAY choose
-					to present any manifest based upon information that it possesses, even one that is not explicitly
-					listed as a parent (e.g., based upon information it calculates or acquires out of band). In the
-					absence of a preference by user agent implementers, selection of the first manifest listed is
-					suggested as a default.</p>
-
+				<p>User Agents MAY support additional properties but MUST NOT include unrecognized properties in the
+						<abbr title="information set">infoset</abbr>. The use of linked records is RECOMMENDED whenever
+					possible, as the use of native formats standardizes and simplifies processing by user agents.</p>
 			</section>
 		</section>
 		<section id="wp-lifecycle">

--- a/index.html
+++ b/index.html
@@ -1364,11 +1364,11 @@
 					<p class="note"> There will be continuous contacts with Schema.org to see whether some of the
 						structural property terms should not be included in the core Schema.org hierarchy, or one of its
 						extensions. </p>
-					
+
 					<p>Structural infoset properties typically refer to external resources via a URL. This URL-s may
 						refer to resources playing different roles (e.g., cover or privacy policy), may need some
 						additional metadata for, e.g., accessibility purposes. </p>
-					
+
 					<p id="publication-link-def"> The structural properties are expressed via JSON-LD terms that are
 						typically publication specific (i.e., defined through the JSON-LD context file defined for Web
 						Publications, see <a href="#wpub-context"></a>). This context also defines a general type used
@@ -1424,10 +1424,6 @@
 							</tr>
 						</tbody>
 					</table>
-					<p class=issue data-number=235></p>
-
-					<p class=ednote>If the document is reorganized the "specific" external resources (cover, accessibility report, etc) should be separated in from the general structures and list definitions.</p>
-
 
 					<p class="issue" data-number="235"></p>
 
@@ -1438,47 +1434,47 @@
 
 				<section id="wp-a11y-report">
 					<h4>Accessibility Report</h4>
-					
+
 					<p>An accessibility report provides information about the suitability of a <a>Web Publication</a>
 						for consumption by users with varying preferred reading modalities. These reports typically
 						identify the result of an evaluation against established accessibility criteria, such as those
 						provided in [[WCAG20]], and are an important source of information in determining the usability
 						of a Web Publication.</p>
-					
+
 					<section id="wp-a11y-report-infoset">
 						<h5>Infoset Requirements</h5>
-						
+
 						<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a link to an
 							accessibility report when one is available for a Web Publication. It is RECOMMENDED that the
 							report be included as a resource of the Web Publication.</p>
-						
+
 						<p>It is also RECOMMENDED that the accessibility report be provided in a human-readable format,
 							such as <abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]]. Augmenting these
 							reports with machine-processable metadata, such as provided in Schema.org [[schema.org]], is
 							also RECOMMENDED.</p>
-						
+
 						<p class="ednote">Machine-readable accessibility metadata may be recommended in whatever format
 							is used to externalize publication metadata (e.g., to ensure availability for search).
 							Depending how this externalizing is done, adding machine-processable accessibility metadata
 							to such a record could take precedence over, or complement, the accessibility record.</p>
 					</section>
-					
+
 					<section id="wp-a11y-report-manifest">
 						<h5>Manifest Expression</h5>
-						
+
 						<p>As described in <a href="#wp-a11y"></a> the authors MAY provide an accessibility report
 							providing information about the suitability of a <a>Web Publication</a> for consumption by
 							users with varying preferred reading modalities. This report may be complementary to the
 							information expressed by the descriptive properties as described in <a href="#wp-a11y-wpm"
-								></a>. This report is accessed via an external resource (e.g., and HTML file). When present,
+							></a>. This report is accessed via an external resource (e.g., and HTML file). When present,
 							link to such resource MUST be expressed using a <a href="#publication-link-def"
-								><code>PublicationLink</code></a> object. The <code>rel</code> value of the <a
-									href="#publication-link-def"><code>PublicationLink</code></a> MUST include the
-							<code>https://www.w3.org/ns/wpub#accessibility-report</code> identifier.</p>
-						
+									><code>PublicationLink</code></a> object. The <code>rel</code> value of the <a
+								href="#publication-link-def"><code>PublicationLink</code></a> MUST include the
+								<code>https://www.w3.org/ns/wpub#accessibility-report</code> identifier.</p>
+
 						<p class="note">The Working Group will attempt to define the <code>accessibility-report</code>
 							term by IANA, to avoid using a URL.</p>
-						
+
 						<pre class="example" title="Link to an accessibility report">
 {
     "@context"   : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
@@ -1498,7 +1494,7 @@
 </pre>
 					</section>
 				</section>
-				
+
 				<section id="wp-cover">
 					<h4>Cover</h4>
 
@@ -1606,8 +1602,7 @@
 									<td>
 										<code>extraResources</code>
 									</td>
-									<td> An array of: 
-										<ul>
+									<td> An array of: <ul>
 											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
 											<li>an instance of a <a href="#publication-link-def"
 														><code>PublicationLink</code></a> object</li>
@@ -1877,17 +1872,17 @@
 
 					<p>The <dfn>table of contents</dfn> is a hierarchical list of links that reflects the structural
 						outline of the major sections of the Web Publication.</p>
-					
+
 					<section id="wp-table-of-contents-infoset">
 						<h5>Infoset Requirements</h5>
 
 						<p>There are no requirements on the completeness of the table of contents, except that, when
 							specified, it MUST include a link to at least one <a href="#wp-resources">resource</a>.</p>
 
-						<p>The table of contents is not specified directly in the manifest. Instead, the manifest
-							SHOULD provide a link to an HTML element in one of the <a href="#wp-resources">resources</a>
-							(most likely a <code>nav</code> element&#160;[[!html]]), with a <code>role</code> attribute
-							value set to <code>doc-toc</code>.</p>
+						<p>The table of contents is not specified directly in the manifest. Instead, the manifest SHOULD
+							provide a link to an HTML element in one of the <a href="#wp-resources">resources</a> (most
+							likely a <code>nav</code> element&#160;[[!html]]), with a <code>role</code> attribute value
+							set to <code>doc-toc</code>.</p>
 
 						<p class="issue">This question arises only if the table of contents is accepted: can a table of
 							contents navigation element refer, via links, to any resource that is <em>not</em> listed in
@@ -2426,50 +2421,43 @@
 			</section>
 
 			<section id="aff-reading-state">
-	      <h4>Reading State</h4>
+				<h4>Reading State</h4>
 
-	      <p class="issue" data-number="145"></p>
+				<p class="issue" data-number="145"></p>
 
-			<section>	      
-				<h5>Short description</h5>
-		        <p>
-			        The user must be able to leave the Web Publication and return to it at the last position they left from. The User Agent must retain the reading position, based on the last known position of the reader in the web publication. The position should be based on the reader's position in the file, within the reading order.
-			    </p>
-			    <p>
-		        	The user agent may retain reading state if the web publication is revised.
-		        </p>
+				<section>
+					<h5>Short description</h5>
+					<p> The user must be able to leave the Web Publication and return to it at the last position they
+						left from. The User Agent must retain the reading position, based on the last known position of
+						the reader in the web publication. The position should be based on the reader's position in the
+						file, within the reading order. </p>
+					<p> The user agent may retain reading state if the web publication is revised. </p>
+				</section>
+				<section>
+					<h5>Affordances</h5>
+					<p> The navigation of the web publication should be defined in the <a>Default Reading Order</a>
+						required by the Information Set. </p>
+					<p> User Agents should not have to set the reading state in the following type of resources: </p>
+					<ul>
+						<li>External Links (i.e. a link to google.com)</li>
+						<li>Data references (i.e. a linked CSV file)</li>
+						<li>Multimedia content (i.e. a video)</li>
+					</ul>
+
+					<p> Reading state should only apply to content documents listed as being within the bounds of the
+						Web Publication. </p>
+				</section>
+				<section>
+					<h5>Examples</h5>
+					<p> Example 1:<br /> Sarah is reading a long article on her way to work. She arrives before she has
+						finished, but wants to continue from the place she left off. The user agent should remember her
+						reading state for the next time she opens the publication. </p>
+
+					<h5>Testing</h5>
+					<p> If a tester opens a web publication in a WP-aware UA, moves ahead in the publication, closes the
+						reader, then reopens it, they should be returned to the last known reading state. </p>
+				</section>
 			</section>
-			<section>  
-		       <h5>Affordances</h5>
-		        <p>
-		        	The navigation of the web publication should be defined in the <a>Default Reading Order</a> required by the Information Set.
-		        </p>
-		        <p>
-					User Agents should not have to set the reading state in the following type of resources:
-				</p>
-		        <ul>
-		        	<li>External Links (i.e. a link to google.com)</li>
-		        	<li>Data references (i.e. a linked CSV file)</li>
-		        	<li>Multimedia content (i.e. a video)</li>
-		        </ul>
-
-	        	<p>
-	        		Reading state should only apply to content documents listed as being within the bounds of the Web Publication.
-	        	</p>
-			</section>
-			<section>		
-		       <h5>Examples</h5>
-		       	<p>
-		        Example 1:<br />
-		        Sarah is reading a long article on her way to work. She arrives before she has finished, but wants to continue from the place she left off. The user agent should remember her reading state for the next time she opens the publication.
-		        </p>
-
-		       <h5>Testing</h5>
-		       	<p>
-		        If a tester opens a web publication in a WP-aware UA, moves ahead in the publication, closes the reader, then reopens it, they should be returned to the last known reading state.
-		        </p>
-			</section>
-	    </section>
 		</section>
 		<section id="locators" class="informative">
 			<h3>Web Publication Locators</h3>

--- a/index.html
+++ b/index.html
@@ -7,48 +7,6 @@
 		<script src="common/js/biblio.js" class="remove"></script>
 		<script src="common/js/orcid.js" class="remove"></script>
 		<link href="common/css/common.css" rel="stylesheet" type="text/css" />
-		<style>
-			/* Table zebra style... */
-			table.zebra {
-				font-size: inherit;
-				font: 90%;
-				margin: 1em;
-			}
-			
-			table.zebra td {
-				padding-left: 0.3em;
-			}
-			
-			table.zebra th {
-				font-weight: bold;
-				text-align: center;
-				background-color: NavyBlue !important;
-				font-size: 110%;
-				background: hsl(180, 30%, 50%);
-				color: #fff;
-			}
-			
-			table.zebra th a:link {
-				color: #fff;
-			}
-			
-			table.zebra th a:visited {
-				color: #aaa;
-			}
-			
-			table.zebra tr:nth-child(even) {
-				background-color: hsl(180, 30%, 93%)
-			}
-			
-			table.zebra th {
-				border-bottom: 1px solid #bbb;
-				padding: .2em 1em;
-			}
-			table.zebra td {
-				border-bottom: 1px solid #ddd;
-				padding: .2em 1em;
-			}</style>
-
 		<script class="remove">
 		  // <![CDATA[
           var respecConfig = {
@@ -207,7 +165,7 @@
 				<section id="rel-wam">
 					<h4>Web App Manifest</h4>
 
-					<p class="ednote">We may want to write something here on the relationships...</p>
+					<p class="ednote">We may want to write something here on the relationships&#8230;</p>
 
 				</section>
 			</section>
@@ -756,7 +714,7 @@
 				<pre class="example" title="A Web Publication Manifest included in an HTML resource">
 	&lt;script id="example_manifest" type="application/ld+json"&gt;
 	{
-    ...
+    &#8230;
 	}
 	&lt;/script&gt;
 </pre>
@@ -802,7 +760,7 @@
 
 					<pre class="example" title="Expressing external links, either as strings or as objects">
 	{
-        ...
+        &#8230;
         "resources" : [
             "datatypes.svg",
             {
@@ -843,7 +801,7 @@
 					<pre class="example">
 {
     "@context" : ["http://schema.org", "https://www.w3.org/ns/wpub.jsonld"],
-    ...
+    &#8230;
 }
 </pre>
 
@@ -863,7 +821,7 @@
 {
     "@context" : ["http://schema.org", "https://www.w3.org/ns/wpub.jsonld"],
     "@type"    : "Book"
-    ...
+    &#8230;
 }
 </pre>
 
@@ -958,10 +916,10 @@
 {
     "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"    : "CreativeWork",
-    ...
+    &#8230;
     "accessMode"            : ["textual", "visual"],
     "accessModeSufficient"  : ["textual"],
-    ...
+    &#8230;
 }
 </pre>
 
@@ -994,9 +952,9 @@
 {
     "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"    : "Book",
-    ...
+    &#8230;
     "url"      : "https://publisher.example.org/mobydick",
-    ...
+    &#8230;
 }
 </pre>
 					</section>
@@ -1016,7 +974,7 @@
 									><code>serialNumber</code></a>. See also the Schema.org description for further
 							details. </p>
 
-						<p class="ednote"> Not clear how one would describe the relationships between these two... </p>
+						<p class="ednote"> Not clear how one would describe the relationships between these two&#8230; </p>
 
 						<table class="zebra">
 							<thead>
@@ -1039,10 +997,10 @@
 {
     "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"    : "CreativeWork",
-    ...
+    &#8230;
     "id"       : "http://www.w3.org/TR/tabular-data-model/",
     "url"      : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
-    ...
+    &#8230;
 }
 </pre>
 
@@ -1050,10 +1008,10 @@
 {
     "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"    : "Book",
-    ...
+    &#8230;
     "isbn"     : "1234567890123",
     "url"      : "https://publisher.example.org/mobydick",
-    ...
+    &#8230;
 }
 </pre>
 
@@ -1169,7 +1127,7 @@
 {
     "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"    : "Book",
-    ...
+    &#8230;
     "url"      : "https://publisher.example.org/mobydick",
     "author"   : {
         "@type" : "Person",
@@ -1181,7 +1139,7 @@
 {
     "@context"   : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"      : "CreativeWork",
-    ...
+    &#8230;
     "identifier" : "http://www.w3.org/TR/tabular-data-model/",
     "url"        : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
     "author"     : [{
@@ -1207,7 +1165,7 @@
         "name" : "World Wide Web Consortium",
         "url"  : "https://www.w3.org/"
     }
-    ...
+    &#8230;
 }
 </pre>
 						<p class="issue" data-number="217"></p>
@@ -1236,7 +1194,7 @@
             "@language" : "fr"
         }
     ],
-    ...
+    &#8230;
 }
 </pre>
 
@@ -1257,7 +1215,7 @@
 {
     "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"    : "Book",
-    ...
+    &#8230;
     "author" : {
         "@type" : "Person",
         "name" : {
@@ -1305,11 +1263,11 @@
 {
     "@context"     : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"        : "CreativeWork",
-    ...
+    &#8230;
     "identifier"   : "http://www.w3.org/TR/tabular-data-model/",
     "url"          : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
     "dateModified" : "2015-12-17",
-    ...
+    &#8230;
 }
 </pre>
 
@@ -1344,12 +1302,12 @@
 {
     "@context"      : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"         : "CreativeWork",
-    ...
+    &#8230;
     "identifier"    : "http://www.w3.org/TR/tabular-data-model/",
     "url"           : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
     "datePublished" : "2015-12-17",
     "dateModified"  : "2016-01-30",
-    ...
+    &#8230;
 }
 </pre>
 					</section>
@@ -1384,7 +1342,7 @@
 {
     "@context"           : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"              : "Book",
-    ...
+    &#8230;
     "url"                : "https://publisher.example.org/mobydick",
     "readingProgression" : "ltr"
 }
@@ -1420,7 +1378,7 @@
 {
     "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"    : "Book",
-    ...
+    &#8230;
     "url"      : "https://publisher.example.org/mobydick",
     "name"     : "Moby Dick"
 }
@@ -1519,7 +1477,7 @@
 {
     "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"    : "Book",
-    ...
+    &#8230;
     "url"      : "https://publisher.example.org/mobydick",
     "name"     : "Moby Dick",
     "readingOrder" : [
@@ -1528,7 +1486,7 @@
         "html/introduction.html",
         "html/epigraph.html",
         "html/c001.html",
-        ...
+        &#8230;
     ]
 }
 </pre>
@@ -1536,7 +1494,7 @@
 {
     "@context" : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"    : "Book",
-    ...
+    &#8230;
     "url"      : "https://publisher.example.org/mobydick",
     "name"     : "Moby Dick",
     "readingOrder" : [{
@@ -1550,7 +1508,7 @@
         "fileFormat" : "text/html",
         "name"       : "Copyright page"
     },{
-        ...
+        &#8230;
     }]
 }
 </pre>
@@ -1588,10 +1546,10 @@
 {
     "@context"   : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
     "@type"      : "CreativeWork",
-    ...
+    &#8230;
     "identifier" : "http://www.w3.org/TR/tabular-data-model/",
     "url"        : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
-    ...
+    &#8230;
     "resources"  : [
         "datatypes.html",
         "datatypes.svg",
@@ -1606,10 +1564,10 @@
             "url"           : "test-utf8-bom.csv",
             "fileFormat"    : "text/csv"
         },{
-            ...
+            &#8230;
         }
     ],
-    ...
+    &#8230;
 }
 </pre>
 
@@ -1638,26 +1596,26 @@
 						</table>
 						<pre class="example" title="Reference to a table of content element, in the same file that contains the manifest is">
 &lt;head&gt;
-    ...
+    &#8230;
     &lt;script type="application/ld+json"&gt;
     {
         "@context"        : ["http://schema.org","https://www.w3.org/ns/wpub.jsonld"],
         "@type"           : "CreativeWork",
-        ...
+        &#8230;
         "identifier"      : "http://www.w3.org/TR/tabular-data-model/",
         "url"             : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
         "tableOfContents" : "#toc"
-        ...
+        &#8230;
     }
     &lt;/script&gt;
-    ...
+    &#8230;
 &lt;/head&gt;
 &lt;body&gt;
-    ...
+    &#8230;
     &lt;section id="toc" role="doc-toc"&gt;
-        ...
+        &#8230;
     &lt;/section&gt;
-    ...
+    &#8230;
 &lt;/body&gt;
 </pre>
 						<p class="issue"> The term <code>tableOfContents</code> has not been approved by the Working
@@ -1709,11 +1667,11 @@
 
 				<pre class="example" title="Link to a manifest within the same HTML resource">
 	&lt;link href="#example_manifest" rel="publication"&gt;
-	...
+	&#8230;
 	&lt;script id="example_manifest" type="application/ld+json"&gt;
 	{
     "@context" : "http://schema.org",
-    ...
+    &#8230;
 	}
 	&lt;/script&gt;
 </pre>
@@ -2106,7 +2064,7 @@
 
 				<section id="aff-toc">
 					<h4>Table of Contents</h4>
-					<p class="issue" data-number=146></p>
+					<p class="issue" data-number="146"></p>
 
 					<section>
 				        <h5>Short description</h5>

--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
 					criteria:</p>
 
 				<ul>
-					<li>it has a <a>manifest</a> that conforms to <a href="#manifest-req"></a>;</li>
+					<li>it has a <a>manifest</a> that conforms to <a href="#wp-properties-req"></a>;</li>
 					<li>it adheres to the construction requirements defined in <a href="#wp-construction"></a>.</li>
 				</ul>
 
@@ -247,12 +247,12 @@
 					criteria:</p>
 
 				<ul>
-					<li>it is capable of generating a conforming <a href="#infoset"><abbr title="information set"
+					<li>it is capable of generating a conforming <a href="#wp-properties"><abbr title="information set"
 								>infoset</abbr></a> for a Web Publication.</li>
 				</ul>
 			</section>
 		</section>
-		<section id="wp-construct">
+		<section id="wp-construction">
 			<h2>Web Publication Construction</h2>
 
 			<section id="wp-intro" class="informative">
@@ -271,7 +271,7 @@
 
 				<p>The <abbr title="information set">infoset</abbr> is primarily compiled from a Web Publication's
 						<a>manifest</a>, whose serialization requirements are defined in <a
-						href="#manifest-serialization"></a>. Some information can be obtained outside the
+						href="#wp-manifest"></a>. Some information can be obtained outside the
 					manifest—fallback rules for properties defined in the following subsections allow a user agent to
 					compile information that the author has not provided in the manifest, for example.</p>
 
@@ -325,7 +325,7 @@
 </pre>
 
 					<p> In some cases, this structure may have to be extended by additional, local information, see the
-							<a href="#manifest-language-and-dir"></a>. </p>
+							<a href="#wp-language-and-dir-manifest"></a>. </p>
 				</section>
 				<section>
 					<h4>Publication Types</h4>
@@ -388,7 +388,7 @@
 				</ul>
 
 				<p>The <code>href</code> attribute may also contain a fragment identifier, referring to the Web
-					Publication Manifest expressed as part of an HTML resource (see <a href="#manifest-intro"></a>). </p>
+					Publication Manifest expressed as part of an HTML resource (see <a href="#wp-intro"></a>). </p>
 
 				<pre class="example" title="Link to a manifest within the same HTML resource">
 	&lt;link href="#example_manifest" rel="publication"&gt;
@@ -445,7 +445,7 @@
 								<li><a href="#wp-a11y">accessibility report</a></li>
 								<li><a href="#wp-language-and-dir">base direction</a></li>
 								<li><a href="#wp-canonical-identifier">canonical identifier</a></li>
-								<li><a href="#wp-creators">creator</a></li>
+								<li><a href="#wp-creator">creator</a></li>
 								<li><a href="#wp-language-and-dir">language</a></li>
 								<li><a href="#wp-mod-date">last modification date</a></li>
 								<li><a href="#wp-pub-date">publication date</a></li>
@@ -485,12 +485,11 @@
 				<section id="wp-descriptive-properties-intro">
 					<h4>Introduction</h4>
 
-					<p>
-						<a href="infoset-meta">Desciptive Properties</a> in the Web Publication Manifest are based,
-						wherever possible, on the terms defined by <a href="https://schema.org"
-						>Schema.org</a>&#160;[[!schema.org]] (including <a href="http://schema.org/docs/schemas.html"
-							>hosted extensions</a> of Schema.org). This means that the descriptive infoset properties
-						are mapped to one or several Schema.org properties (inheriting their syntax and semantics). </p>
+					<p> Desciptive Properties in the Web Publication Manifest are based, wherever possible, on the terms
+						defined by <a href="https://schema.org">Schema.org</a>&#160;[[!schema.org]] (including <a
+							href="http://schema.org/docs/schemas.html">hosted extensions</a> of Schema.org). This means
+						that the descriptive infoset properties are mapped to one or several Schema.org properties
+						(inheriting their syntax and semantics). </p>
 
 					<p class="note"> Schema.org includes a large number of terms that, though relevant for publishing,
 						are not mentioned in this Recommendation. Web Publication authors may use any of those; this
@@ -591,7 +590,7 @@
 						</table>
 
 						<p>Note that the author MAY also provide a reference to a more detailed <a
-								href="#wp-a11y-report-wpm">Accessibility Report</a>, beyond the accessibility
+								href="#wp-a11y-report-manifest">Accessibility Report</a>, beyond the accessibility
 							information expressed by these terms.</p>
 
 						<pre class="example" title="Example for accessiblity metadata of a purely textual document">
@@ -1068,7 +1067,7 @@
 }
 </pre>
 							<p>The value of the language tag must be set to the language code as defined in [[!bcp47]].
-								If not set, the default value is the <a href="#manifest-language-and-dir">default value
+								If not set, the default value is the <a href="#wp-language-and-dir-manifest">default value
 									of the manifest</a>.</p>
 
 							<p class="issue" data-number="219"></p>
@@ -1332,9 +1331,9 @@
 					<h4>Introduction</h4>
 
 					<p>
-						<a href="infoset-structure">Structural Properties</a> in the Web Publication Manifest use terms
-						that refer to one or more external resources (images, script files, separate metadata files,
-						etc.). These terms do not necessarily have a counterpart in Schema.org, and are therefore
+						<a href="#wp-structural-properties">Structural Properties</a> in the Web Publication Manifest
+						use terms that refer to one or more external resources (images, script files, separate metadata
+						files, etc.). These terms do not necessarily have a counterpart in Schema.org, and are therefore
 						defined separately by this specification. </p>
 
 					<p> Values of structural properties are usually links to external resources, or an array thereof.
@@ -1465,11 +1464,12 @@
 						<p>As described in <a href="#wp-a11y"></a> the authors MAY provide an accessibility report
 							providing information about the suitability of a <a>Web Publication</a> for consumption by
 							users with varying preferred reading modalities. This report may be complementary to the
-							information expressed by the descriptive properties as described in <a href="#wp-a11y-wpm"
-							></a>. This report is accessed via an external resource (e.g., and HTML file). When present,
-							link to such resource MUST be expressed using a <a href="#publication-link-def"
-									><code>PublicationLink</code></a> object. The <code>rel</code> value of the <a
-								href="#publication-link-def"><code>PublicationLink</code></a> MUST include the
+							information expressed by the descriptive properties as described in <a
+								href="#wp-a11y-manifest"></a>. This report is accessed via an external resource (e.g.,
+							and HTML file). When present, link to such resource MUST be expressed using a <a
+								href="#publication-link-def"><code>PublicationLink</code></a> object. The
+								<code>rel</code> value of the <a href="#publication-link-def"
+									><code>PublicationLink</code></a> MUST include the
 								<code>https://www.w3.org/ns/wpub#accessibility-report</code> identifier.</p>
 
 						<p class="note">The Working Group will attempt to define the <code>accessibility-report</code>
@@ -1509,7 +1509,7 @@
 
 						<p>User agents SHOULD NOT use the cover image as the sole means of selecting or accessing Web
 							Publications. A user agent SHOULD use the Web Publication's <a href="#wp-title">title</a>
-							and <a href="#wp-creators">creators</a> as text alternatives for such interfaces.</p>
+							and <a href="#wp-creator">creators</a> as text alternatives for such interfaces.</p>
 
 						<p>More than one cover image MAY be referenced from the infoset to provide alternative sizes and
 							resolutions for different device screens.</p>
@@ -2153,7 +2153,7 @@
 
 			<p class="issue" data-number="143"></p>
 
-			<section id="aff-publication-mode">
+			<section id="feature-publication-mode">
 				<h3>Switch to publication mode</h3>
 
 				<p>When a user agent <a>obtains a manifest</a> it SHOULD provide the option to switch the display to
@@ -2169,11 +2169,11 @@
 				</ol>
 
 				<p><dfn>Publication mode</dfn> is a display mode implemented by the user agent that follows the
-					conventions listed in <a href="#aff-presentation">presentation</a> and <a href="#navigation"
+					conventions listed in <a href="#feature-presentation">presentation</a> and <a href="#feature-navigation"
 						>navigation</a>.</p>
 			</section>
 
-			<section id="aff-presentation">
+			<section id="feature-presentation">
 				<h3>Presentation</h3>
 
 				<section id="layout">
@@ -2225,7 +2225,7 @@
 
 				</section>
 
-				<section id="aff-user-settings">
+				<section id="feature-user-settings">
 					<h4>User Settings</h4>
 
 					<p>When a user agent renders a <a>Web Publication</a>, it SHOULD provide user settings to customize
@@ -2277,7 +2277,7 @@
 					<p class="issue" data-number="137"></p>
 				</section>
 
-				<section id="aff-pagination">
+				<section id="feature-pagination">
 					<h4>Paginated Layout</h4>
 
 					<p>When a user agent renders a <a>Web Publication</a> in a paginated layout, it MUST lay out each
@@ -2321,12 +2321,12 @@
 				</section>
 			</section>
 
-			<section id="aff-nav">
+			<section id="feature-navigation">
 				<h3>Navigation</h3>
 
 				<p class="issue" data-number="86"></p>
 
-				<section id="aff-reading-order">
+				<section id="feature-reading-order">
 					<h4>Reading Order</h4>
 
 					<p>Hyperlinks are the means by which multiple resources are linked together on the Web. When users
@@ -2348,7 +2348,7 @@
 					<p class="issue" data-number="38"></p>
 				</section>
 
-				<section id="aff-progression">
+				<section id="feature-progression">
 					<h4>Progression</h4>
 
 					<p>While reading a <a>Web Publication</a>, the user follows a natural progression within a resource
@@ -2368,7 +2368,7 @@
 					<p class="issue" data-number="145"></p>
 				</section>
 
-				<section id="aff-toc">
+				<section id="feature-toc">
 					<h4>Table of Contents</h4>
 					<p class="issue" data-number="146"></p>
 
@@ -2385,7 +2385,7 @@
 								href="#wp-table-of-contents"></a>
 						</p>
 						<p> The table of content is referred to in the Web Publication Manifest (see <a
-								href="#wp-table-of-contents-pwm"></a>) and is expressed using and HTML element; see <a
+								href="#wp-table-of-contents-manifest"></a>) and is expressed using and HTML element; see <a
 								href="#wp-table-of-contents"></a> for further details. </p>
 						<p> User agents MAY use the <a>default reading order</a> in the case a Table of Contents is not
 							explicitly specified to create a table of contents. </p>
@@ -2407,20 +2407,20 @@
 				</section>
 			</section>
 
-			<section id="aff-offline-access">
+			<section id="feature-offline-access">
 				<h3>Offline Access</h3>
 
 				<p class="issue" data-number="141"></p>
 			</section>
 
-			<section id="aff-search">
+			<section id="feature-search">
 				<h3>Search</h3>
 
 				<p class="ednote">Detail on inter-publication search across multiple resources will be included in a
 					future draft.</p>
 			</section>
 
-			<section id="aff-reading-state">
+			<section id="feature-reading-state">
 				<h4>Reading State</h4>
 
 				<p class="issue" data-number="145"></p>
@@ -2574,7 +2574,7 @@
 					<dt>
 						<dfn>lang</dfn>
 					</dt>
-					<dd>Contains the default value <a href="#wp-language">language</a>.</dd>
+					<dd>Contains the default value <a href="#wp-language-and-dir">language</a>.</dd>
 					<dt>
 						<dfn>direction</dfn>
 					</dt>
@@ -2594,7 +2594,7 @@
 					<dt>
 						<dfn>authors</dfn>
 					</dt>
-					<dd>Contains one or more <a href="#wp-creators">creators</a>.</dd>
+					<dd>Contains one or more <a href="#wp-creator">creators</a>.</dd>
 					<dt>
 						<dfn>dateModified</dfn>
 					</dt>
@@ -2625,7 +2625,7 @@
 			<section id="contributor-idl">
 				<h3><code>authors</code> member </h3>
 
-				<p class="ednote">The <a href="#wp-creators">current infoset for creators</a> is not fully defined; this
+				<p class="ednote">The <a href="#wp-creator">current infoset for creators</a> is not fully defined; this
 					dictionary might be further improved once there is agreement on how they should be handled.</p>
 
 				<pre class="idl">
@@ -2682,7 +2682,7 @@
 					<dt>
 						<dfn>lang</dfn>
 					</dt>
-					<dd>Contains the <a href="#wp-language">language</a>.</dd>
+					<dd>Contains the <a href="#wp-language-and-dir">language</a>.</dd>
 					<dt>
 						<dfn>dir</dfn>
 					</dt>


### PR DESCRIPTION
Despite the branch name, what started as an editorial review turned into a restructuring. I found it complicated to have separate sections for the infoset and manifest, with the manifest continually quoting and referrring back to the infoset, so I started a re-org to combine the two.

This PR takes all the properties and creates a new section for them. Each property begins with its definition and is followed by a subsection that contains the infoset requirements and another with the manifest expression requirements. The section on constructing a web publication is moved up ahead of this section, and will explain the relationship between the infoset and manifest and also contain the preliminary sections on constructing the json.

I'm opening this now as I'd like to merge the new structure -- if everyone is okay with it -- so that the ongoing work doesn't diverge further and require manual patching. There is definitely more editorial work that I need to do even on this revised structure (it ain't perfect), but I plan to do that next.

(We can also look at linking from the properties to the feature(s) that they enable as an additional next clarifying step, as well as back-linking from features to the properties that afford them. The features don't all map 1:1 with a property, so merging might create a mess.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/238.html" title="Last updated on Jun 21, 2018, 4:22 PM GMT (2c8ecdd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/238/8dd6539...2c8ecdd.html" title="Last updated on Jun 21, 2018, 4:22 PM GMT (2c8ecdd)">Diff</a>