### PR TITLE
No self referencing of manifests

### DIFF
--- a/index.html
+++ b/index.html
@@ -433,6 +433,14 @@
 						>HTML</abbr> document&#160;[[!html]] that <a href="#wp-linking">links to the manifest</a>. This
 						page is referred to as the <dfn>primary entry page</dfn> of the Web Publication.</p>
 
+				<p>
+					The manifest may be <a href="manifest-embedding">embedded</a> into the <a>primary entry page</a>; in this case the link element MUST use a relative URL to refer to the manifest.
+				</p>
+
+				<p>
+					The manifest itself MUST NOT include a reference to itself, i.e., the reference to the manifest MUST NOT appear as part of the <a href="#wp-resource-categorization-properties"></a>.
+				</p>
+
 				<p>There are no restrictions on a Web Publication beyond this requirement. The Web Publication MAY
 					include references to resources of any media type, both in the <a>default reading order</a> and as
 					dependencies of other resources.</p>


### PR DESCRIPTION
Fix #192


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/250.html" title="Last updated on Jun 27, 2018, 2:55 PM GMT (26e2c5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/250/20ec26d...26e2c5e.html" title="Last updated on Jun 27, 2018, 2:55 PM GMT (26e2c5e)">Diff</a>