### PR TITLE
Table of contents clarifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,7 +444,7 @@
 					this case the link element MUST use a relative URL to refer to the manifest. </p>
 
 				<p> The manifest itself MUST NOT include a reference to itself, i.e., the reference to the manifest MUST
-					NOT appear as part of the <a href="#wp-resource-categorization-properties"></a>. </p>
+					NOT appear as part of the <a href="#resource-categorization-properties"></a>. </p>
 
 				<p>There are no restrictions on a Web Publication beyond this requirement. The Web Publication MAY
 					include references to resources of any media type, both in the <a>default reading order</a> and as
@@ -625,7 +625,7 @@
 					<h2><code>PublicationLink</code> Definition</h2>
 
 					<p id="publication-link-def">This specification defines a new type for links called
-								<dfn><code>PublicationLink</code></dfn>. It consists of the following properties:</p>
+							<code>PublicationLink</code>. It consists of the following properties:</p>
 
 					<table class="zebra">
 						<thead>

--- a/index.html
+++ b/index.html
@@ -643,7 +643,8 @@
 									<code>url</code>
 								</td>
 								<td>Location of the resource.</td>
-								<td>A URL with no or empty fragment identifier&#160;[[!url]].</td>
+								<td>A URL&#160;[[!url]]. Refer to the property definitions that accept this type for
+									additional restrictions.</td>
 								<td>
 									<a href="https://schema.org/url"><code>url</code></a>
 								</td>
@@ -1786,9 +1787,11 @@
 					<section id="cover-manifest">
 						<h5>Manifest Expression</h5>
 
-						<p>If present in the manifest, the cover MUST be expressed using a <a
-								href="#publication-link-def"><code>PublicationLink</code></a> object. The
-								<code>rel</code> value of the <a href="#publication-link-def"
+						<p>If present in the manifest, the cover MUST be expressed as a <a href="#publication-link-def"
+									><code>PublicationLink</code></a>. The URL expressed in the <code>url</code> term
+							MUST NOT include a fragment identifier.</p>
+
+						<p>The <code>rel</code> value of the <a href="#publication-link-def"
 									><code>PublicationLink</code></a> MUST include the
 								<code>https://www.w3.org/ns/wp#cover-page</code> identifier.</p>
 
@@ -1833,7 +1836,8 @@
 								value of <code>contents</code>&#160;[[!iana-link-relations]], use the <code>url</code>
 								value of the specified resource as the link leading to the table of contents.</li>
 							<li>If the <a>primary entry page</a> contains an HTML element with the
-								<code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria-1.0]], use that element as the tabke of contents.</li>
+								<code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria-1.0]], use
+								that element as the tabke of contents.</li>
 						</ul>
 
 						<p>If neither of the above cases results in a link to the table of contents, the Web Publication
@@ -1847,10 +1851,13 @@
 					<section id="table-of-contents-manifest">
 						<h5>Manifest Expression</h5>
 
-						<p>If present in the manifest, the table of content MUST be expressed using a <a
-								href="#publication-link-def"><code>PublicationLink</code></a>. The <code>rel</code>
-							value of the <a href="#publication-link-def"><code>PublicationLink</code></a> MUST include
-							the <code>contents</code> identifier&#160;[[!iana-link-relations]].</p>
+						<p>If present in the manifest, the table of content MUST be expressed as a <a
+								href="#publication-link-def"><code>PublicationLink</code></a>. The URL expressed in the
+								<code>url</code> term MUST NOT include a fragment identifier.</p>
+
+						<p>The <code>rel</code> value of the <a href="#publication-link-def"
+									><code>PublicationLink</code></a> MUST include the <code>contents</code>
+							identifier&#160;[[!iana-link-relations]].</p>
 
 						<p>The link to the table of contents MAY be specified in either the <a
 								href="#default-reading-order">default reading order</a> or <a href="#resource-list"
@@ -1937,6 +1944,7 @@
 
 						<p>If present in the Web Publication Manifest, this item MUST be mapped on the
 								<code>readingOrder</code> term, defined specifically for Web Publications.</p>
+
 						<table class="zebra">
 							<thead>
 								<tr>
@@ -1959,7 +1967,8 @@
 											<li>an instance of a <a href="#publication-link-def"
 														><code>PublicationLink</code></a> object</li>
 										</ul>
-										<p>The order in the array is <em>significant</em>.</p>
+										<p>The order in the array is <em>significant</em>. The URLs MUST NOT include
+											fragment identifiers.</p>
 									</td>
 									<td>(none)</td>
 								</tr>
@@ -2071,7 +2080,8 @@
 											<li>an instance of a <a href="#publication-link-def"
 														><code>PublicationLink</code></a> object</li>
 										</ul>
-										<p>The order in the array is <em>not significant</em>.</p>
+										<p>The order in the array is <em>not significant</em>. The URLs MUST NOT include
+											fragment identifiers.</p>
 									</td>
 									<td>(none)</td>
 								</tr>
@@ -2109,22 +2119,22 @@
 					</section>
 				</section>
 
-				<section id="extra-resources">
-					<h4>List of extra resources</h4>
+				<section id="links">
+					<h4>Links</h4>
 
-					<p>The <dfn>list of extra resources</dfn> enumerates all <a href="#wp-resources">resources</a> that
-						are used in the processing and rendering of a <a>Web Publication</a> but are <em>not</em> within
-						its bounds (i.e., are not listed in the <a>default reading order</a> or the <a>resource
-						list</a>) but are, rather, external to the Web Publication. </p>
+					<p>The <dfn>links</dfn> property enumerates all <a href="#wp-resources">resources</a> that are used
+						in the processing and rendering of a <a>Web Publication</a> but are <em>not</em> within its
+						bounds (i.e., are not listed in the <a>default reading order</a> or the <a>resource list</a>)
+						but are, rather, external to the Web Publication.</p>
 
-					<section id="extra-resources-infoset">
+					<section id="links-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The completeness of the list of extra resources will affect the usability of the Web
+						<p>The completeness of the <code>links</code> list will affect the usability of the Web
 							Publication in certain scenarios (e.g., the ability to access privacy policy information).
 							For this reason, it is strongly RECOMMENDED to provide a comprehensive list of all of the
-							Web Publication's extra resources beyond those listed in the <a>default reading order</a> or
-								<a>resource list</a>.</p>
+							Web Publication's extra resources (i.e., beyond those listed in the <a>default reading
+								order</a> or <a>resource list</a>).</p>
 
 						<p>In some cases, a comprehensive list of these resources might not be easily achieved (e.g.,
 							third-party scripts that reference resources from deep within their source), but a user
@@ -2133,7 +2143,7 @@
 							them).</p>
 					</section>
 
-					<section id="extra-resources-manifest">
+					<section id="links-manifest">
 						<h5>Manifest Expression</h5>
 
 						<p>If present in the Web Publication Manifest, this item MUST be mapped on the

--- a/index.html
+++ b/index.html
@@ -461,13 +461,13 @@
 			<section id="wp-table-of-contents">
 				<h3>Table of Contents</h3>
 
-				<p>The <dfn>table of contents</dfn> provides a hierarchical list of links that reflects the structural
-					outline of the major sections of the Web Publication.</p>
+				<p>The table of contents provides a hierarchical list of links that reflects the structural outline of
+					the major sections of the Web Publication.</p>
 
 				<p>The table of contents is expressed via an HTML element in one of the <a href="#wp-resources"
 						>resources</a> (typically a <code>nav</code> element&#160;[[!html]]). This element MUST be
 					identified by the <code>role</code> attribute&#160;[[!html]] value
-					"<code>doc-toc</code>"&#160;[[!dpub-aria]], and MUST be the first element in the document so
+					"<code>doc-toc</code>"&#160;[[!dpub-aria-1.0]], and MUST be the first element in the document so
 					designated.</p>
 
 				<p>The table of contents SHOULD be located in the <a>primary entry page</a> of the Web Publication. If
@@ -1833,8 +1833,8 @@
 								value of <code>contents</code>&#160;[[!iana-link-relations]], use the <code>href</code>
 								value of the specified resource as the link to the table of contents.</li>
 							<li>If the <a>primary entry page</a> contains an HTML element with the
-								<code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria]], use the
-									<code>href</code> value of that document as the link to the table of contents.</li>
+								<code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria-1.0]], use
+								the <code>href</code> value of that document as the link to the table of contents.</li>
 						</ul>
 
 						<p>If neither of the above cases results in a link to the table of contents, the Web Publication

--- a/index.html
+++ b/index.html
@@ -457,6 +457,34 @@
 						agent.</p>
 				</div>
 			</section>
+
+			<section id="wp-table-of-contents">
+				<h3>Table of Contents</h3>
+
+				<p>The <dfn>table of contents</dfn> provides a hierarchical list of links that reflects the structural
+					outline of the major sections of the Web Publication.</p>
+
+				<p>The table of contents is expressed via an HTML element in one of the <a href="#wp-resources"
+						>resources</a> (typically a <code>nav</code> element&#160;[[!html]]). This element MUST be
+					identified by the <code>role</code> attribute&#160;[[!html]] value
+					"<code>doc-toc</code>"&#160;[[!dpub-aria]], and MUST be the first element in the document so
+					designated.</p>
+
+				<p>The table of contents SHOULD be located in the <a>primary entry page</a> of the Web Publication. If
+					not, the manifest SHOULD <a href="#table-of-contents-manifest">identify the resource</a> that
+					contains the structure.</p>
+
+				<p>There are no requirements on the table of contents iteself, except that, when specified, it MUST
+					include a link to at least one <a href="#wp-resources">resource</a>.</p>
+
+				<p>Refer to the <a href="#table-of-contents">table of contents property definition</a> for more
+					information on how to identify in the infoset and manifest which resource contains the table of
+					contents.</p>
+
+				<p class="issue">This question arises only if the table of contents is accepted: can a table of contents
+					navigation element refer, via links, to any resource that is <em>not</em> listed in the <a>default
+						reading order</a>?</p>
+			</section>
 		</section>
 		<section id="wp-properties">
 			<h2>Web Publication Properties</h2>
@@ -1791,25 +1819,26 @@
 				<section id="table-of-contents">
 					<h4>Table of Contents</h4>
 
-					<p>The <dfn>table of contents</dfn> is a hierarchical list of links that reflects the structural
-						outline of the major sections of the Web Publication.</p>
+					<p>The <dfn>table of contents</dfn> property identifies the resource that contains the Web
+						Publication's <a href="#wp-table-of-contents">table of contents</a>.</p>
 
 					<section id="table-of-contents-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>There are no requirements on the completeness of the table of contents, except that, when
-							specified, it MUST include a link to at least one <a href="#wp-resources">resource</a>.</p>
+						<p>User agents MUST compute the <code>table-of-contents</code> as follows:</p>
 
-						<p>The table of contents is not specified directly in the manifest. Instead, it is expressed via
-							an HTML element in one of the <a href="#wp-resources">resources</a> (most likely a
-								<code>nav</code> element&#160;[[!html]]), with a <code>role</code> attribute value set
-							to <code>doc-toc</code>. This element SHOULD be in the <a>primary entry page</a> of the Web
-							Publication; if that is not the case, a <a href="#table-of-contents-manifest">manifest
-								expression</a> SHOULD identify the element in another resource. </p>
+						<ul>
+							<li>If a resource in either the <a href="#default-reading-order">default reading order</a>
+								or <a href="#resource-list">resource-list</a> is identified with a <code>rel</code>
+								value of <code>contents</code>&#160;[[!iana-link-relations]], use the <code>href</code>
+								value of the specified resource as the link to the table of contents.</li>
+							<li>If the <a>primary entry page</a> contains an HTML element with the
+								<code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria]], use the
+									<code>href</code> value of that document as the link to the table of contents.</li>
+						</ul>
 
-						<p class="issue">This question arises only if the table of contents is accepted: can a table of
-							contents navigation element refer, via links, to any resource that is <em>not</em> listed in
-							the <a>default reading order</a>?</p>
+						<p>If neither of the above cases results in a link to the table of contents, the Web Publication
+							does not have a table of contents and this property MUST NOT be included in the infoset.</p>
 					</section>
 
 					<section id="table-of-contents-manifest">
@@ -1818,7 +1847,11 @@
 						<p>If present in the manifest, the table of content MUST be expressed using a <a
 								href="#publication-link-def"><code>PublicationLink</code></a>. The <code>rel</code>
 							value of the <a href="#publication-link-def"><code>PublicationLink</code></a> MUST include
-							the <code>contents</code> (IANA) identifier.</p>
+							the <code>contents</code> identifier&#160;[[!iana-link-relations]].</p>
+
+						<p>The link to the table of contents MAY be specified in either the <a
+								href="#default-reading-order">default reading order</a> or <a href="#resource-list"
+								>resource-list</a>, but MUST NOT be specified in both.</p>
 
 						<pre class="example" title="Table of content identified in another resource of the Web Publication">
 {
@@ -2946,17 +2979,17 @@
 		</section>
 		<section id="app-manifest-examples" class="appendix informative">
 			<h2>Manifest Examples</h2>
-			
+
 			<section>
 				<h3>Basic Book</h3>
 				<pre class="example" data-include="experiments/separate_manifest/mobydick.json" data-include-format="text"></pre>
 			</section>
-			
+
 			<section>
 				<h3>Single-Document Publication</h3>
 				<pre class="example" data-include="experiments/w3c_rec/simple_version.html" data-include-format="text"></pre>
 			</section>
-			
+
 			<section>
 				<h3>Audiobook</h3>
 				<pre class="example" data-include="experiments/audiobook/flatland.json" data-include-format="text"></pre>

--- a/index.html
+++ b/index.html
@@ -643,7 +643,7 @@
 									<code>url</code>
 								</td>
 								<td>Location of the resource.</td>
-								<td>A URL&#160;[[url]].</td>
+								<td>A URL with no or empty fragment identifier&#160;[[!url]].</td>
 								<td>
 									<a href="https://schema.org/url"><code>url</code></a>
 								</td>
@@ -1839,6 +1839,10 @@
 
 						<p>If neither of the above cases results in a link to the table of contents, the Web Publication
 							does not have a table of contents and this property MUST NOT be included in the infoset.</p>
+
+						<p>If the table of contents resource contains more than one element identified by the
+								<code>role</code> "<code>doc-toc</code>", user agents MUST use the first element in
+							document order as the table of contents.</p>
 					</section>
 
 					<section id="table-of-contents-manifest">
@@ -1862,7 +1866,7 @@
     "name"       : "Moby Dick",
     "resources"  : [{
         "@type"      : "PublicationLink",
-        "url"        : "toc_file.html#toc",
+        "url"        : "toc_file.html",
         "rel"        : "contents"
     },{
         &#8230;
@@ -1900,6 +1904,14 @@
 
 			<section id="resource-categorization-properties">
 				<h3>Resource Categorization Properties</h3>
+
+				<p><a>Web Publication</a> resources MAY be specified via the <a>default reading order</a>, the
+						<a>resource list</a>, or the <a>list of extra resources</a>, defined in this section. These
+					lists can contain, for example, references to <a href="#informative-properties">informative
+						properties</a> like the <a href="#privacy-policy">privacy policy</a>, or <a
+						href="#structural-properties">structural properties</a> like the <a>table of contents</a>. A
+					particular resource's URL MUST NOT appear in more than one of these lists, and a URL MUST NOT be
+					repeated within a list.</p>
 
 				<section id="default-reading-order">
 					<h4>Default Reading Order</h4>

--- a/index.html
+++ b/index.html
@@ -474,7 +474,7 @@
 					not, the manifest SHOULD <a href="#table-of-contents-manifest">identify the resource</a> that
 					contains the structure.</p>
 
-				<p>There are no requirements on the table of contents iteself, except that, when specified, it MUST
+				<p>There are no requirements on the table of contents itself, except that, when specified, it MUST
 					include a link to at least one <a href="#wp-resources">resource</a>.</p>
 
 				<p>Refer to the <a href="#table-of-contents">table of contents property definition</a> for more
@@ -1830,11 +1830,10 @@
 						<ul>
 							<li>If a resource in either the <a href="#default-reading-order">default reading order</a>
 								or <a href="#resource-list">resource-list</a> is identified with a <code>rel</code>
-								value of <code>contents</code>&#160;[[!iana-link-relations]], use the <code>href</code>
-								value of the specified resource as the link to the table of contents.</li>
+								value of <code>contents</code>&#160;[[!iana-link-relations]], use the <code>url</code>
+								value of the specified resource as the link leading to the table of contents.</li>
 							<li>If the <a>primary entry page</a> contains an HTML element with the
-								<code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria-1.0]], use
-								the <code>href</code> value of that document as the link to the table of contents.</li>
+								<code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria-1.0]], use that element as the tabke of contents.</li>
 						</ul>
 
 						<p>If neither of the above cases results in a link to the table of contents, the Web Publication


### PR DESCRIPTION
This PR addresses the concern I raised in #251 by removing the fragment identifier for table of contents, as recommended by @iherman.

In trying to rewrite the section, I also noticed that we were mixing a lot of toc construction requirements into the property definition, when all the property does is identify the resource containing the toc. To fix this, I've created a new subsection under "Creation" to detail how to make the table of contents, and rewritten the infoset to specify how to obtain the link.

Of note is that it disallows a fragment identifier on PublicationLinks, and also explicitly disallows a resource from being listed in both the resource list and default reading order, or listed two or more times within either of those lists.

Comments welcome.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/254.html" title="Last updated on Jun 29, 2018, 12:47 PM GMT (7e2c2ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/254/2582155...7e2c2ea.html" title="Last updated on Jun 29, 2018, 12:47 PM GMT (7e2c2ea)">Diff</a>