### PR TITLE
base direction cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1268,7 +1268,6 @@
 						<ul>
 							<li><code>ltr</code>: left-to-right;</li>
 							<li><code>rtl</code>: right-to-left;</li>
-							<li><code>auto</code>: direction is determined from the value of the property.</li>
 						</ul>
 
 						<p>When specified, these properties are used as defaults for textual values in the <abbr
@@ -1283,10 +1282,30 @@
 								<strong>not</strong> override similar declarations in any resource, nor do they serve as
 							global defaults when such information is not provided in a resource.</p>
 
+						<p>If the base direction is not specified, is invalid, or is set to "<code>auto</code>" in the
+							manifest, user agents MUST calculate the value as follows:</p>
+
+						<ul>
+							<li>If the direction is not specified or an invalid value is specified, use the value
+									"<code>ltr</code>".</li>
+							<li>
+								<p>If the value "<code>auto</code>" is specified, attempt to determine the
+									directionality as follows:</p>
+								<ul>
+									<li>If the manifst contains items with text values, inspecting those items for
+										directionality. It is RECOMMENDED that the <a href="#title">title(s)</a> be
+										checked first, when present.</li>
+									<li>If the manifest does not contain any items with text values, use the value
+											"<code>ltr</code>".</li>
+								</ul>
+							</li>
+						</ul>
+
 						<p>If a user agent requires the language and one is not available in the <abbr
 								title="information set">infoset</abbr> (globally or specifically for a property), or the
-							obtained value is invalid, the user agent MAY attempt to determine the language. This
-							specification does not mandate how such a language tag is created. The user agent might:</p>
+							obtained value is invalid, has been specified, the user agent MAY attempt to determine the
+							language. This specification does not mandate how such a language tag is created. The user
+							agent might:</p>
 
 						<ul>
 							<li>use the <a>non-empty</a> language declaration of the manifest;</li>
@@ -1296,8 +1315,7 @@
 						</ul>
 
 						<p>If a language tag cannot be determined, user agents MUST use the value "<code>und</code>"
-							(undetermined). If the base direction cannot be determined, user agents MUST assume the
-							value <code>auto</code>.</p>
+							(undetermined).</p>
 					</section>
 
 
@@ -1332,7 +1350,12 @@
 </pre>
 
 							<p>The value of the language tag MUST be set to a language code as defined
-								in&#160;[[!bcp47]]. If not set, the default value is <code>en</code>.</p>
+								in&#160;[[!bcp47]].</p>
+
+							<p>Authors SHOULD set the base direction to either the value "<code>ltr</code>" or
+									"<code>rtl</code>", as appropriate, but MAY also specify the value
+									"<code>auto</code>". Use of the value "<code>auto</code>" is strongly discouraged,
+								however, as the algorithm used to calculate the base direction is not reliable.</p>
 
 							<p class="issue" data-number="218"></p>
 						</section>
@@ -1344,6 +1367,7 @@
 								manifest. This information MUST be set for each item separately using the <a
 									href="https://www.w3.org/TR/2014/REC-json-ld-20140116/#string-internationalization"
 										><code>@value</code> and <code>@language</code> keywords</a>&#160;[[!json-ld]]: </p>
+
 							<pre class="example" title="Setting the default language of an author name to French">
 {
     "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
@@ -1361,7 +1385,12 @@
 							<p>The value of the language tag MUST be set to a language code as defined in [[!bcp47]]. If
 								not set, the default value is the <a href="#language-and-dir-manifest">default value of
 									the manifest</a>.</p>
-
+							
+							<p>Authors SHOULD set the base direction to either the value "<code>ltr</code>" or
+								"<code>rtl</code>", as appropriate, but MAY also specify the value
+								"<code>auto</code>". Use of the value "<code>auto</code>" is strongly discouraged,
+								however, as the algorithm used to calculate the base direction is not reliable.</p>
+							
 							<p class="issue" data-number="219"></p>
 						</section>
 


### PR DESCRIPTION
Not sure this is ready for a commit, but offering up for comments to continue the discussion in #259.

Another oddity I found is that there are steps to calculate the language for the language, ending in undetermined, but the manifest says the default is always English. Should the manifest define defaults, or should it be the infoset? Might be good to get consensus so we don't end up mixing.

More to the point, I've removed the manifest default language for now. I recall we already went through not using "en" as a default earlier in the revision and that's how we got to "und", but if it's changing back again we have to swap out the other specification.