### PR TITLE
Reduced the font size for examples and notes

### DIFF
--- a/common/css/common.css
+++ b/common/css/common.css
@@ -66,3 +66,11 @@ table.zebra tr:nth-child(even) {
 
 table.zebra th{border-bottom:1px solid #bbb;padding:.2em 1em;}
 table.zebra td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+
+.example {
+    font-size: .8em;
+}
+.note, .ednote, .issue {
+    font-size: .9em;
+}
+

--- a/index.html
+++ b/index.html
@@ -84,6 +84,14 @@
           };
           // ]]>
       </script>
+      <style type="text/css">
+      	.example {
+      		font-size: .8em;
+      	}
+      	.note, .ednote, .issue {
+      		font-size: .9em;
+      	}
+      </style>
 	</head>
 	<body>
 		<section id="abstract">


### PR DESCRIPTION
@mattgarrish 

we have a lot of examples and (ed)notes in the document. It is good, but I found that, visually, it breaks to "flow" to the reader. I have tried to reduce the font size of the examples and the (ed)notes a little bit, to keep the reader's attention on the main text.

WDYT?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/278.html" title="Last updated on Jul 25, 2018, 1:16 PM GMT (bffc2e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/278/5b3651f...bffc2e7.html" title="Last updated on Jul 25, 2018, 1:16 PM GMT (bffc2e7)">Diff</a>