### PR TITLE
add significant authoring/editing contributions as acknowledgement

### DIFF
--- a/common/html/acknowledgements.html
+++ b/common/html/acknowledgements.html
@@ -1,7 +1,23 @@
 <section id="ack" class="appendix informative">
     <h2>Acknowledgements</h2>
+	
+	<p>The editors would like to specially thank the following individuals for making significant
+		contributions to the authoring and editing of this specification:</p>
+	
+	<ul class="ack">
+		<li>Baldur Bjarnason (The Rebus Foundation)</li>
+		<li>Dave Cramer (Hachette Livre)</li>
+		<li>Timothy Cole (University of Illinois at Urbana-Champaign)</li>
+		<li>Rachel Comerford (Macmillan Higher Education)</li>
+		<li>Romain Deltour (DAISY Consortium)</li>
+		<li>Hadrien Gardeur (Feedbooks)</li>
+		<li>Deborah Kaplan (W3C Invited Experts)</li>
+		<li>Laurent Le Meur (EDRLab)</li>
+		<li>Tzviya Siegman (Wiley)</li>
+		<li>Benjamin Young (Wiley)</li>
+	</ul>
 
-    <p>The following people contributed to the development of this specification:</p>
+    <p>The following people were active in the Working Group at the time of publication:</p>
 
     <ul class="ack">
         <li>Greg Albers (J. Paul Getty Trust)</li>
@@ -10,21 +26,16 @@
         <li>Christopher Auclair (VitalSource | Ingram Content Group)</li>
         <li>Luc Audrain (Hachette Livre)</li>
         <li>Mike Baker (Houghton Mifflin Harcourt (HMH))</li>
-        <li>Baldur Bjarnason (The Rebus Foundation)</li>
         <li>Laura Brady (W3C Invited Experts)</li>
         <li>Steve Breault (Scenarex Inc.)</li>
         <li>Nick Brown (VitalSource | Ingram Content Group)</li>
         <li>Jeff Buehler (Metrodigi, Inc.)</li>
         <li>Kaylin Bugbee (Earth Science Data Systems Program)</li>
         <li>Fred Chasen (W3C Invited Experts)</li>
-        <li>Timothy Cole (University of Illinois at Urbana-Champaign)</li>
-        <li>Rachel Comerford (Macmillan Higher Education)</li>
         <li>Garth Conboy (Google, Inc.)</li>
         <li>Juan Corona (Evident Point Software Corp.)</li>
         <li>Christopher Cosner (Stanford University)</li>
-        <li>Dave Cramer (Hachette Livre)</li>
         <li>Greg Davis (Pearson plc)</li>
-        <li>Romain Deltour (DAISY Consortium)</li>
         <li>Marisa DeMeglio (DAISY Consortium)</li>
         <li>Vagner Diniz (NIC.br - Brazilian Network Information Center)</li>
         <li>Brady Duga (Google, Inc.)</li>
@@ -34,7 +45,6 @@
         <li>Heather Flanagan (RFC Editor)</li>
         <li>Teenya Franklin (Pearson plc)</li>
         <li>Jun Gamo (Voyager Japan, Inc.)</li>
-        <li>Hadrien Gardeur (Feedbooks)</li>
         <li>Matt Garrish (DAISY Consortium)</li>
         <li>Caitlin Gebhard (Harvard Business Publishing)</li>
         <li>Michael Goodman (Wiley)</li>
@@ -45,7 +55,6 @@
         <li>Leslie Hulse (HarperCollins Publishers)</li>
         <li>Derek Jackson (Harvard Business Publishing)</li>
         <li>Rick Johnson (VitalSource | Ingram Content Group)</li>
-        <li>Deborah Kaplan (W3C Invited Experts)</li>
         <li>Jean Kaplansky (Deque Systems, Inc.)</li>
         <li>Bill Kasdorf (Book Industry Study Group)</li>
         <li>George Kerscher (DAISY Consortium)</li>
@@ -54,7 +63,6 @@
         <li>Matt Kuznicki (Datalogics, Inc.)</li>
         <li>Charles LaPierre (Benetech)</li>
         <li>Mustapha Lazrek (Microsoft Corp.)</li>
-        <li>Laurent Le Meur (EDRLab)</li>
         <li>Vladimir Levantovsky (Monotype)</li>
         <li>Mia Lipner (Pearson plc)</li>
         <li>Edwina Lui (Kaplan Publishing)</li>
@@ -87,7 +95,6 @@
         <li>Wolfgang Schindler (PONS GmbH)</li>
         <li>Jodi Schneider (University of Illinois at Urbana-Champaign)</li>
         <li>Ben Schroeter (Pearson plc)</li>
-        <li>Tzviya Siegman (Wiley)</li>
         <li>Avneesh Singh (DAISY Consortium)</li>
         <li>Adam Sisco (Earth Science Data Systems Program)</li>
         <li>Susanna Skinner (HarperCollins Publishers)</li>
@@ -97,8 +104,7 @@
         <li>Mateus Teixeira (W. W. Norton)</li>
         <li>Jonathan Thurston (Pearson plc)</li>
         <li>Ben Walters (Microsoft Corp.)</li>
-        <li>Daniel Weck (EDRLab)</li>
-        <li>Daniel Weck (DAISY Consortium)</li>
+        <li>Daniel Weck (EDRLab and DAISY Consortium)</li>
         <li>John Weise (University of Michigan Library)</li>
         <li>Jason White (Educational Testing Service)</li>
         <li>David Wood (ConsenSys)</li>

--- a/common/html/acknowledgements.html
+++ b/common/html/acknowledgements.html
@@ -5,6 +5,7 @@
 		contributions to the authoring and editing of this specification:</p>
 	
 	<ul class="ack">
+		<li>Luc Audrain (Hachette Livre)</li>
 		<li>Baldur Bjarnason (The Rebus Foundation)</li>
 		<li>Dave Cramer (Hachette Livre)</li>
 		<li>Timothy Cole (University of Illinois at Urbana-Champaign)</li>
@@ -14,6 +15,7 @@
 		<li>Deborah Kaplan (W3C Invited Experts)</li>
 		<li>Laurent Le Meur (EDRLab)</li>
 		<li>Tzviya Siegman (Wiley)</li>
+		<li>Avneesh Singh (DAISY Consortium)</li>
 		<li>Benjamin Young (Wiley)</li>
 	</ul>
 
@@ -24,7 +26,6 @@
         <li>Franco Alvarado (Macmillan Higher Education)</li>
         <li>Boris Anthony (The Rebus Foundation)</li>
         <li>Christopher Auclair (VitalSource | Ingram Content Group)</li>
-        <li>Luc Audrain (Hachette Livre)</li>
         <li>Mike Baker (Houghton Mifflin Harcourt (HMH))</li>
         <li>Laura Brady (W3C Invited Experts)</li>
         <li>Steve Breault (Scenarex Inc.)</li>
@@ -95,7 +96,6 @@
         <li>Wolfgang Schindler (PONS GmbH)</li>
         <li>Jodi Schneider (University of Illinois at Urbana-Champaign)</li>
         <li>Ben Schroeter (Pearson plc)</li>
-        <li>Avneesh Singh (DAISY Consortium)</li>
         <li>Adam Sisco (Earth Science Data Systems Program)</li>
         <li>Susanna Skinner (HarperCollins Publishers)</li>
         <li>Kathryn Stewart (Metrodigi, Inc.)</li>

--- a/index.html
+++ b/index.html
@@ -33,40 +33,6 @@
 					"orcid": "0000-0003-0782-2704",
                     "companyURL": "https://www.w3.org",
                   }
-              ],
-			  authors: [
-			      {
-                    "name": "Baldur Bjarnason",
-                    "company": "The Rebus Foundation",
-                    "companyURL": "https://reb.us/",
-					"w3cid": 92101
-                  },
-			  	  {
-                    "name": "Timothy W. Cole",
-                    "url": "https://www.library.illinois.edu/people/bios/t-cole3/",
-                    "company": "University of Illinois at Urbana-Champaign",
-                    "companyURL": "https://illinois.edu",
-					"w3cid": 53965,
-					"orcid": "0000-0002-5906-4581"
-                  },
-			      {
-                    "name": "Dave Cramer",
-                    "company": "Hachette Livre",
-                    "companyURL": "https://hachette.com/",
-                    "w3cid": 65283
-                  },
-			      {
-                    "name": "Hadrien Gardeur",
-                    "company": "Feedbooks",
-                    "companyURL": "https://www.feedbooks.com/",
-                    "w3cid": 97094
-                  },
-			      {
-                    "name": "Florian Rivoal",
-                    "company": "Invited Expert",
-                    "companyURL": "https://florian.rivoal.net/",
-                    "w3cid": 43241
-                  }
 			  ],
               processVersion: 2018,
               includePermalinks: false,


### PR DESCRIPTION
Propose we identify significant authoring/editing contributions in the acknowledgements section, as an authoring list does disservice to those providing significant editorial contributions and examples.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/280.html" title="Last updated on Jul 25, 2018, 3:02 PM GMT (e842e2c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/280/5b3651f...e842e2c.html" title="Last updated on Jul 25, 2018, 3:02 PM GMT (e842e2c)">Diff</a>