### PR TITLE
remove the note about a11y metadata in external records

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,11 @@
 				consideration within the Publishing Working Group and are subject to change. The most prominent known
 				issues have been identified in this document and links provided to comment on them.</p>
 
-			<p>The work the past few month has been focused on sections <a href="#wp-construction"></a> and <a href="#wp-properties"></a>, which include the definition of a <a>manifest</a> making use of terms in <a href="https://schema.org">schema.org</a>. Later sections, in particular <a href="#wp-features"></a> and the corresponding <a href="#webidl"></a> are out of sync with this version. Subsequent drafts will focus on updating those sections.</p>
+			<p>The work the past few month has been focused on sections <a href="#wp-construction"></a> and <a
+					href="#wp-properties"></a>, which include the definition of a <a>manifest</a> making use of terms in
+					<a href="https://schema.org">schema.org</a>. Later sections, in particular <a href="#wp-features"
+				></a> and the corresponding <a href="#webidl"></a> are out of sync with this version. Subsequent drafts
+				will focus on updating those sections.</p>
 		</section>
 		<section id="intro">
 			<h2>Introduction</h2>
@@ -323,9 +327,10 @@
 					<h4>Relative URLs</h4>
 
 					<p>
-
-						<a href="https://url.spec.whatwg.org/#relative-url-string">Relative URL strings</a> MAY be used in the manifest. These URLs are resolved into <a href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL strings</a> using a <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a>&nbsp;[[!url]].
-						</p>
+						<a href="https://url.spec.whatwg.org/#relative-url-string">Relative URL strings</a> MAY be used
+						in the manifest. These URLs are resolved into <a
+							href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL strings</a> using a <a
+							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a>&#160;[[!url]]. </p>
 
 					<p>The base URL for relative URLs is determined as follows:</p>
 
@@ -689,7 +694,7 @@
 						properties typically supplement an evaluation against established accessibility criteria, such
 						as those provided in [[WCAG20]]. (For linking to a detailed accessibility report, see <a
 							href="#accessibility-report"></a>.)</p>
-					
+
 					<section id="accessibility-infoset">
 						<h5>Infoset Requirements</h5>
 
@@ -705,9 +710,9 @@
 							<li>accessibilitySummary</li>
 						</ul>
 
-						<p>The more detailed descriptions of these properties, as well as the possible values,
-							are described on the <a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas
-								Wiki site</a>.</p>
+						<p>The more detailed descriptions of these properties, as well as the possible values, are
+							described on the <a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas Wiki
+								site</a>.</p>
 
 					</section>
 
@@ -866,9 +871,10 @@
 						<p>If the document is not a Web Publication resource, user agents SHOULD load the first document
 							in the <a>default reading order</a> when initiating the Web Publication.</p>
 
-						<p class="note">
-							To improve the usability of Web Publications, particularly in user agents that do not support Web Publications, authors are encouraged to include navigation aids in the referenced document that facilitate consumption of the content, (e.g., provide a table of contents or a link to one).
-						</p>
+						<p class="note"> To improve the usability of Web Publications, particularly in user agents that
+							do not support Web Publications, authors are encouraged to include navigation aids in the
+							referenced document that facilitate consumption of the content, (e.g., provide a table of
+							contents or a link to one). </p>
 
 						<div class="note">The Web Publication's address can also be used as value for an identifier link
 							relation&#160;[[link-relation]].</div>
@@ -1009,9 +1015,10 @@
 				<section id="creators">
 					<h4>Creators</h4>
 
-					<p>
-						A <dfn>creator</dfn> is an individual or entity responsible for the creation of the <a>Web Publication</a>. Creators are represented by <a href="https://schema.org/Person"><code>Person</code></a> and <a href="https://schema.org/Ortanization"><code>Organization</code></a> objects, respectively.
-					</p>
+					<p> A <dfn>creator</dfn> is an individual or entity responsible for the creation of the <a>Web
+							Publication</a>. Creators are represented by <a href="https://schema.org/Person"
+								><code>Person</code></a> and <a href="https://schema.org/Ortanization"
+								><code>Organization</code></a> objects, respectively. </p>
 
 
 					<section id="wp-creator-infoset">
@@ -1808,7 +1815,7 @@
 							</blockquote>
 							<p>This was not decided on the Toronto F2F, and is still open.</p>
 						</div>
-						<p class=issue data-number=205></p>
+						<p class="issue" data-number="205"></p>
 					</section>
 
 					<section id="resource-list-manifest">
@@ -2181,32 +2188,35 @@
 						<p>User agents MUST compute the <code>table-of-contents</code> as follows:</p>
 
 						<ol>
-							<li>Identify the table of content resource:
-								<ul>
-									<li>
-										If a resource in either the <a href="#default-reading-order">default reading order</a>
-										or <a href="#resource-list">resource-list</a> is identified with a <code>rel</code>
-										value including <code>contents</code>&#160;[[!iana-link-relations]], the corresponding <code>url</code> value identifies the table of content resource.
-									</li> 
-									<li>
-										Otherwise, the <a>primary entry page</a> is the table of content resource.
+							<li>Identify the table of content resource: <ul>
+									<li> If a resource in either the <a href="#default-reading-order">default reading
+											order</a> or <a href="#resource-list">resource-list</a> is identified with a
+											<code>rel</code> value including
+										<code>contents</code>&#160;[[!iana-link-relations]], the corresponding
+											<code>url</code> value identifies the table of content resource. </li>
+									<li> Otherwise, the <a>primary entry page</a> is the table of content resource.
 									</li>
 								</ul>
 							</li>
-							<li>
-								If the table of content resource contains an HTML element with the <code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria-1.0]], the user agent MUST use that element as the table of contents.
-							</li>
+							<li> If the table of content resource contains an HTML element with the
+								<code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria-1.0]], the
+								user agent MUST use that element as the table of contents. </li>
 						</ol>
 
-						<p>If identifying the Table of Content is ambiguous (e.g., several table of content resources are identified, or several elements with a <code>role</code> value <code>doc-toc</code> is found within the table of content resource), the user agent MAY choose among them. This specification does not mandate how this choice is made. The user agent might:</p>
+						<p>If identifying the Table of Content is ambiguous (e.g., several table of content resources
+							are identified, or several elements with a <code>role</code> value <code>doc-toc</code> is
+							found within the table of content resource), the user agent MAY choose among them. This
+							specification does not mandate how this choice is made. The user agent might:</p>
 
 						<ul>
 							<li>choose the first table of content resource by some heuristics</li>
-							<li>choose the first table of content element within the same resource in <a href="https://dom.spec.whatwg.org/#concept-tree-order">document tree order</a>&nbsp;[[!dom]]</li>
+							<li>choose the first table of content element within the same resource in <a
+									href="https://dom.spec.whatwg.org/#concept-tree-order">document tree
+								order</a>&#160;[[!dom]]</li>
 						</ul>
 
-						<p>If this process does not result in a link to the table of contents, the Web Publication
-							does not have a table of contents and this property MUST NOT be included in the infoset.</p>
+						<p>If this process does not result in a link to the table of contents, the Web Publication does
+							not have a table of contents and this property MUST NOT be included in the infoset.</p>
 
 					</section>
 

--- a/index.html
+++ b/index.html
@@ -689,7 +689,7 @@
 						properties typically supplement an evaluation against established accessibility criteria, such
 						as those provided in [[WCAG20]]. (For linking to a detailed accessibility report, see <a
 							href="#accessibility-report"></a>.)</p>
-
+					
 					<section id="accessibility-infoset">
 						<h5>Infoset Requirements</h5>
 
@@ -1972,11 +1972,6 @@
 							such as <abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[html]]. Augmenting these
 							reports with machine-processable metadata, such as provided in Schema.org [[schema.org]], is
 							also RECOMMENDED.</p>
-
-						<p class="note">Machine-readable accessibility metadata may be recommended in whatever format
-							is used to externalize publication metadata (e.g., to ensure availability for search).
-							Depending how this externalizing is done, adding machine-processable accessibility metadata
-							to such a record could take precedence over, or complement, the accessibility record.</p>
 					</section>
 
 					<section id="accessibility-report-manifest">


### PR DESCRIPTION
I've changed my mind on this note, and suggest that we drop it entirely for now. It's really nothing more than a statement of a problem that we potentially have with all infoset metadata: just because the information is in the infoset doesn't mean it might not be expressed in a linked record or have to be embedded in a publication resource for other reasons. And when any such metadata is encoded outside the manifest, it's possible that metadata might take precedence depending on what is processing it.

We might want to make a note of this more generally for all infoset properties, but it might also stand to reason that this will be true.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/281.html" title="Last updated on Jul 25, 2018, 5:12 PM GMT (766baf1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/281/cdf04cf...766baf1.html" title="Last updated on Jul 25, 2018, 5:12 PM GMT (766baf1)">Diff</a>