### PR TITLE
WebIDL update

### DIFF
--- a/experiments/w3c_rec/full_version.html
+++ b/experiments/w3c_rec/full_version.html
@@ -65,6 +65,11 @@
                 "url"   : "https://www.w3.org"
             }
         }],
+         "publisher" : {
+            "@type" : "Organization",
+            "name" : "World Wide Web Consortium",
+            "@id"  : "https://www.w3.org/"
+        },
         "datePublished"         : "2015-12-17",
         "dateModified"          : "2015-12-17",
         "resources"             : [

--- a/experiments/w3c_rec/simple_version.html
+++ b/experiments/w3c_rec/simple_version.html
@@ -26,7 +26,12 @@
                 "name"          : "Ivan Herman"
             }
         ],
-        "datePublished"         : "2015-12-17",
+         "publisher" : {
+            "@type" : "Organization",
+            "name" : "World Wide Web Consortium",
+            "@id"  : "https://www.w3.org/"
+        },
+       "datePublished"         : "2015-12-17",
         "resources"             : [
             "datatypes.html",
             "datatypes.svg",

--- a/index.html
+++ b/index.html
@@ -1215,7 +1215,7 @@
     },{
         "@type" : "Person",
         "name" : "Ivan Herman",
-        "url"  : "https://www.w3.org/People/Ivan/"
+        "@id"  : "https://www.w3.org/People/Ivan/"
     }],
     "editor"    : [{
         "@type" : "Person",
@@ -1227,7 +1227,7 @@
     "publisher" : {
         "@type" : "Organization",
         "name" : "World Wide Web Consortium",
-        "url"  : "https://www.w3.org/"
+        "@id"  : "https://www.w3.org/"
     }
     &#8230;
 }

--- a/index.html
+++ b/index.html
@@ -2914,9 +2914,6 @@
 		<section id="webidl" class="appendix">
 			<h2>WebIDL</h2>
 
-			<p class="ednote">The WebIDL is not yet fully aligned with the infoset. This section will be updated in a
-				future release.</p>
-
 			<section id="webidl-intro" class="informative">
 				<h3>Introduction</h3>
 
@@ -2935,7 +2932,7 @@
 
 				<pre class="idl" data-include="webidl/manifest.webidl" data-include-format="text"></pre>
 
-				<p>The <a>WebPublicationManifest</a> has the following members:</p>
+				<p>The <a><code>WebPublicationManifest</code></a> has the following members:</p>
 
 				<dl data-dfn-for="WebPublicationManifest">
 					<dt>
@@ -3043,11 +3040,11 @@
 					<dt>
 						<dfn>inLanguage</dfn>
 					</dt>
-					<dd>Contains the default value the <a>language</a>.</dd>
+					<dd>Contains the default <a>language</a> of the publication.&nbsp;[[bcp47]]</dd>
 					<dt>
 						<dfn>inDirection</dfn>
 					</dt>
-					<dd>Contains the default value for <a>base direction</a>.</dd>
+					<dd>Contains the default <a>base direction</a> of the publication.</dd>
 
 					<dt>
 						<dfn>dateModified</dfn>
@@ -3067,8 +3064,7 @@
 					<dt>
 						<dfn>name</dfn>
 					</dt>
-					<dd>Contains the <a href="#wptitle">title</a>.</dd>
-
+					<dd>Contains one or more <a href="#wptitle">title(s)</a> for the publication.</dd>
 
 					<dt>
 						<dfn>readingOrder</dfn>
@@ -3089,34 +3085,34 @@
 						<dfn>accessibilityReport</dfn>
 					</dt>
 
-					<dd>Contains the URL reference to the <a href="#accessibility-report">accessibility report</a>.</dd>
+					<dd>Contains the URL reference to the <a href="#accessibility-report">accessibility report</a>.&nbsp;[[!url]]</dd>
 
 					<dt>
 						<dfn>privacyPolicy</dfn>
 					</dt>
 
-					<dd>Contains the URL reference to the <a href="#privacy-policy">privacy policy</a>.</dd>
+					<dd>Contains the URL reference to the <a href="#privacy-policy">privacy policy</a>.&nbsp;[[!url]]</dd>
 
 					<dt>
 						<dfn>cover</dfn>
 					</dt>
 
-					<dd>Contains the URL reference(s) to one or more <a href="#cover">cover(s)</a>.</dd>
+					<dd>Contains the URL reference(s) to one or more <a href="#cover">cover(s)</a>.&nbsp;[[!url]]</dd>
 
 					<dt>
 						<dfn>toc</dfn>
 					</dt>
-					<dd>Contains the URL reference to the <a>table of contents</a>.</dd>
+					<dd>Contains the URL reference to the <a>table of contents</a>.&nbsp;[[!url]]</dd>
 				</dl>
 			</section>
 
 			<section id="contributor-idl">
-				<h3><code>Person</code> and <code>Organization</code> members</h3>
+				<h3><dfn>Person</dfn> and <dfn>Organization</dfn> members</h3>
 
-				<p>These definitions reflect the basic information derived from the schema.org <a href="https://schema.org/Person">Person</a> and <a href="https://schema.org/Organization">Organization</a> class, reflectively. The WebIDL definitions only contain the minimal information that are considered for the Web Publication Manifest.</p>
+				<p>These definitions reflect the basic information derived from the schema.org <a href="https://schema.org/Person">Person</a> and <a href="https://schema.org/Organization">Organization</a> classes, respectively. The WebIDL definitions only contain the minimal information for the <a>infoset</a>; user agents MAY interpret a wider range of properties, as defined by schema.org.</p>
 
 
-				<p>The <a href="#dom-webpublicationmanifest-artist">artist</a>, <a href="#dom-webpublicationmanifest-author">author</a>, etc., members are each a sequence of <dfn>Person</dfn> or <dfn>Organization</dfn> dictionaries with the following members:</p>
+				<p>The <a href="#dom-webpublicationmanifest-artist">artist</a>, <a href="#dom-webpublicationmanifest-author">author</a>, etc., members are each a sequence of <a><code>Person</code></a> or <a><code>Organization</code></a> dictionaries with the following members:</p>
 
 				<pre class="idl" data-include="webidl/person.webidl" data-include-format="text">
                 </pre>
@@ -3129,12 +3125,12 @@
 					<dt>
 						<dfn>id</dfn>
 					</dt>
-					<dd>Contains a canonical identifier of the person as a URL.</dd>
+					<dd>Contains a canonical identifier of the person as a URL.&nbsp;[[!url]]</dd>
 
 					<dt>
 						<dfn>url</dfn>
 					</dt>
-					<dd>Contains an address for the person in the form of a URL.</dd>
+					<dd>Contains an address for the person in the form of a URL.&nbsp;[[!url]]</dd>
 				</dl>
 
 				<pre class="idl" data-include="webidl/organization.webidl" data-include-format="text">
@@ -3147,12 +3143,12 @@
 					<dt>
 						<dfn>id</dfn>
 					</dt>
-					<dd>Contains a canonical identifier of the organization as a URL.</dd>
+					<dd>Contains a canonical identifier of the organization as a URL.&nbsp;[[url]]</dd>
 
 					<dt>
 						<dfn>url</dfn>
 					</dt>
-					<dd>Contains an address for the organization in the form of a URL.</dd>
+					<dd>Contains an address for the organization in the form of a URL.&nbsp;[[url]]</dd>
 				</dl>
 
 
@@ -3163,10 +3159,10 @@
 
 				<pre class="idl" data-include="webidl/localizable_string.webidl" data-include-format="text"></pre>
 
-				<p>When the <code>lang</code> is specified in <a>LocalizableString</a>, this value
-					overrides the default language specified in <a>WebPublicationManifest</a>.</p>
+				<p>When the <code>lang</code> is specified in <a><code>LocalizableString</code></a>, this value
+					overrides the default language specified in <a><code>WebPublicationManifest</code></a>.</p>
 
-				<p><a>LocalizableString</a> has the following members:</p>
+				<p><a><code>LocalizableString</code></a> has the following members:</p>
 
 				<dl data-dfn-for="LocalizableString">
 					<dt>
@@ -3176,7 +3172,7 @@
 					<dt>
 						<dfn>lang</dfn>
 					</dt>
-					<dd>Contains the <a href="#language-and-dir">language</a>.</dd>
+					<dd>Contains the <a href="#language-and-dir">language</a> value.&nbsp;[[bcp47]]</dd>
 				</dl>
 			</section>
 
@@ -3185,7 +3181,7 @@
 
 				<pre class="idl" data-include="webidl/publication_link.webidl" data-include-format="text"></pre>
 
-				<p>The PublicationLink dictionary contains the following members:</p>
+				<p>The <a><code>PublicationLink</code></a> dictionary contains the following members:</p>
 
 				<dl data-dfn-for="PublicationLink">
 					<dt>
@@ -3214,11 +3210,11 @@
 			</section>
 
 			<section id="textdirection-idl">
-				<h3><code>TextDirection</code> enum </h3>
+				<h3><dfn>TextDirection</dfn> enum </h3>
 
 				<pre class="idl" data-include="webidl/text_direction.webidl" data-include-format="text"></pre>
 
-				<p>The <dfn>TextDirection</dfn> enum can contain the following values:</p>
+				<p>The <a><code>TextDirection</code></a> enum can contain the following values:</p>
 				<dl data-dfn-for="TextDirection">
 					<dt>
 						<dfn>ltr</dfn>
@@ -3236,11 +3232,11 @@
 			</section>
 
 			<section id="textdirection-idl">
-				<h3><code>ProgressionDirection</code> enum </h3>
+				<h3><dfn>ProgressionDirection</dfn> enum </h3>
 
 				<pre class="idl" data-include="webidl/progression_direction.webidl" data-include-format="text"></pre>
 
-				<p>The <dfn>ProgressionDirection</dfn> enum can contain the following values:</p>
+				<p>The <a><code>ProgressionDirection</code></a> enum can contain the following values:</p>
 				<dl data-dfn-for="ProgressionDirection">
 					<dt>
 						<dfn>ltr</dfn>
@@ -3252,8 +3248,6 @@
 					<dd>Right-to-left text.</dd>
 				</dl>
 			</section>
-
-
 
 		</section>
 		<section id="app-manifest-examples" class="appendix informative">

--- a/index.html
+++ b/index.html
@@ -1651,8 +1651,8 @@
 									<td>
 										<code>name</code>
 									</td>
-									<td>Human-readable name of the Web Publication.</td>
-									<td>Text.</td>
+									<td>Human-readable title of the Web Publication.</td>
+									<td>One or more text items for the title.</td>
 									<td>
 										<a href="https://schema.org/name"><code>name</code></a>
 									</td>
@@ -2943,29 +2943,112 @@
 					</dt>
 					<dd>Contains the <a href="#address">address</a>. Required.</dd>
 					<dt>
-						<dfn>lang</dfn>
+						<dfn>type</dfn>
 					</dt>
-					<dd>Contains the default value <a href="#language-and-dir">language</a>.</dd>
+					<dd>Contains the <a href="#manifest-pub-types">publication type</a>; the value is the name of the relevant schema.org type. Required.</dd>
+
 					<dt>
-						<dfn>direction</dfn>
+						<dfn>accessMode</dfn>
 					</dt>
-					<dd>Contains the default value for <a>base direction</a>.</dd>
+					<dd>Contains the value of the <a href="#accessibility">accessMode</a> property.</dd>
+
 					<dt>
-						<dfn>readingProgression</dfn>
+						<dfn>accessModeSufficient</dfn>
 					</dt>
-					<dd>Contains the value for the <a>reading progression direction</a>.</dd>
+					<dd>Contains the value of the <a href="#accessibility">accessModeSufficient</a> property.</dd>
+
 					<dt>
-						<dfn>name</dfn>
+						<dfn>accessibilityAPI</dfn>
 					</dt>
-					<dd>Contains the <a href="#wptitle">title</a>.</dd>
+					<dd>Contains the value of the <a href="#accessibility">accessibilityAPI</a> property.</dd>
+
+					<dt>
+						<dfn>accessibilityControl</dfn>
+					</dt>
+					<dd>Contains the value of the <a href="#accessibility">accessibilityControl</a> property.</dd>
+
+					<dt>
+						<dfn>accessibilityFeature</dfn>
+					</dt>
+					<dd>Contains the value of the <a href="#accessibility">accessibilityFeature</a> property.</dd>
+
+					<dt>
+						<dfn>accessibilityHazard</dfn>
+					</dt>
+					<dd>Contains the value of the <a href="#accessibility">accessibilityHazard</a> property.</dd>
+
+
+					<dt>
+						<dfn>accessibilitySummary</dfn>
+					</dt>
+					<dd>Contains the value of the <a href="#accessibility">accessibilitySummary</a> property.</dd>
+
 					<dt>
 						<dfn>id</dfn>
 					</dt>
 					<dd>Contains the <a>canonical identifier</a>.</dd>
+
+
 					<dt>
-						<dfn>authors</dfn>
+						<dfn>artist</dfn>
+					</dt>
+					<dd>Contains one or more <a href="#creators">artists</a>.</dd>
+
+					<dt>
+						<dfn>author</dfn>
+					</dt>
+					<dd>Contains one or more <a href="#creators">authors</a>.</dd>
+					<dt>
+						<dfn>colorist</dfn>
+					</dt>
+					<dd>Contains one or more <a href="#creators">colorists</a>.</dd>
+					<dt>
+						<dfn>contributor</dfn>
+					</dt>
+					<dd>Contains one or more <a href="#creators">contributors</a>.</dd>
+					<dt>
+						<dfn>creator</dfn>
 					</dt>
 					<dd>Contains one or more <a href="#creators">creators</a>.</dd>
+					<dt>
+						<dfn>editor</dfn>
+					</dt>
+					<dd>Contains one or more <a href="#creators">editors</a>.</dd>
+					<dt>
+						<dfn>illustrator</dfn>
+					</dt>
+					<dd>Contains one or more <a href="#creators">illustrators</a>.</dd>
+					<dt>
+						<dfn>letterer</dfn>
+					</dt>
+					<dd>Contains one or more <a href="#creators">letterers</a>.</dd>
+
+					<dt>
+						<dfn>penciler</dfn>
+					</dt>
+					<dd>Contains one or more <a href="#creators">pencilers</a>.</dd>
+					<dt>
+						<dfn>publisher</dfn>
+					</dt>
+					<dd>Contains one or more <a href="#creators">publisher</a>.</dd>
+					<dt>
+						<dfn>readby</dfn>
+					</dt>
+					<dd>Contains one or more <a href="#creators">readers</a>.</dd>
+					<dt>
+						<dfn>translator</dfn>
+					</dt>
+					<dd>Contains one or more <a href="#creators">translators</a>.</dd>
+
+					<dt>
+						<dfn>inLanguage</dfn>
+					</dt>
+					<dd>Contains the default value the <a>language</a>.</dd>
+					<dt>
+						<dfn>inDirection</dfn>
+					</dt>
+					<dd>Contains the default value for <a>base direction</a>.</dd>
+
 					<dt>
 						<dfn>dateModified</dfn>
 					</dt>
@@ -2974,64 +3057,114 @@
 						<dfn>datePublished</dfn>
 					</dt>
 					<dd>Contains the <a>publication date</a>.</dd>
+
 					<dt>
-						<dfn>links</dfn>
+						<dfn>readingProgression</dfn>
 					</dt>
-					<dd>Contains links to external resources.</dd>
+
+					<dd>Contains the value for the <a>reading progression direction</a>.</dd>
+
+					<dt>
+						<dfn>name</dfn>
+					</dt>
+					<dd>Contains the <a href="#wptitle">title</a>.</dd>
+
+
 					<dt>
 						<dfn>readingOrder</dfn>
 					</dt>
 					<dd>Contains the <a>default reading order</a>.</dd>
+
 					<dt>
 						<dfn>resources</dfn>
 					</dt>
 					<dd>Contains the <a>resource list</a>.</dd>
+
+					<dt>
+						<dfn>links</dfn>
+					</dt>
+					<dd>Contains <a href="#links">links to external resources</a>.</dd>
+
+					<dt>
+						<dfn>accessibilityReport</dfn>
+					</dt>
+
+					<dd>Contains the URL reference to the <a href="#accessibility-report">accessibility report</a>.</dd>
+
+					<dt>
+						<dfn>privacyPolicy</dfn>
+					</dt>
+
+					<dd>Contains the URL reference to the <a href="#privacy-policy">privacy policy</a>.</dd>
+
+					<dt>
+						<dfn>cover</dfn>
+					</dt>
+
+					<dd>Contains the URL reference(s) to one or more <a href="#cover">cover(s)</a>.</dd>
+
 					<dt>
 						<dfn>toc</dfn>
 					</dt>
-					<dd>Contains the <a>table of contents</a>.</dd>
+					<dd>Contains the URL reference to the <a>table of contents</a>.</dd>
 				</dl>
 			</section>
 
 			<section id="contributor-idl">
-				<h3><code>authors</code> member </h3>
+				<h3><code>Person</code> and <code>Organization</code> members</h3>
 
-				<p class="ednote">The <a href="#creators">current infoset for creators</a> is not fully defined; this
-					dictionary might be further improved once there is agreement on how they should be handled.</p>
+				<p>These definitions reflect the basic information derived from the schema.org <a href="https://schema.org/Person">Person</a> and <a href="https://schema.org/Organization">Organization</a> class, reflectively. The WebIDL definitions only contain the minimal information that are considered for the Web Publication Manifest.</p>
 
-				<pre class="idl" data-include="webidl/contributor.webidl" data-include-format="text">
+
+				<p>The <a href="#dom-webpublicationmanifest-artist">artist</a>, <a href="#dom-webpublicationmanifest-author">author</a>, etc., members are each a sequence of <dfn>Person</dfn> or <dfn>Organization</dfn> dictionaries with the following members:</p>
+
+				<pre class="idl" data-include="webidl/person.webidl" data-include-format="text">
                 </pre>
 
-				<p>The <code>author</code> member is a sequence of <dfn>Contributor</dfn> dictionaries where each
-					dictionary has the following members:</p>
-
-				<dl data-dfn-for="Contributor">
+				<dl data-dfn-for="Person">
 					<dt>
 						<dfn>name</dfn>
 					</dt>
-					<dd>Contains one or more localizable string for the contributor's name.</dd>
+					<dd>Contains one or more localizable strings for the contributor's name.</dd>
 					<dt>
 						<dfn>id</dfn>
 					</dt>
-					<dd>Contains a canonical identifier for the contributor.</dd>
+					<dd>Contains a canonical identifier of the person as a URL.</dd>
+
+					<dt>
+						<dfn>url</dfn>
+					</dt>
+					<dd>Contains an address for the person in the form of a URL.</dd>
 				</dl>
+
+				<pre class="idl" data-include="webidl/organization.webidl" data-include-format="text">
+                </pre>
+				<dl data-dfn-for="Organization">
+					<dt>
+						<dfn>name</dfn>
+					</dt>
+					<dd>Contains one or more localizable strings for the organization's name.</dd>
+					<dt>
+						<dfn>id</dfn>
+					</dt>
+					<dd>Contains a canonical identifier of the organization as a URL.</dd>
+
+					<dt>
+						<dfn>url</dfn>
+					</dt>
+					<dd>Contains an address for the organization in the form of a URL.</dd>
+				</dl>
+
+
 			</section>
 
 			<section id="localizable-idl">
 				<h3><dfn>LocalizableString</dfn> dictionary</h3>
 
-				<p class="ednote">This definition includes a slightly tweaked version of the i18n recommendation that
-					also includes a string value in addition to a language and a direction.</p>
-
-				<p>Some metadata in the <abbr title="information set"><a>infoset</a></abbr> have strong requirements for
-					internationalization. For those members, this specification relies on the <a
-						href="https://w3c.github.io/string-meta/#bestPractices">best practices established by the i18n
-						WG</a> and on the <a>LocalizableString</a> dictionary.</p>
-
 				<pre class="idl" data-include="webidl/localizable_string.webidl" data-include-format="text"></pre>
 
-				<p>When <code>lang</code> or <code>dir</code> are specified in <a>LocalizableString</a>, these values
-					override the default language and base direction specificed in <a>WebPublicationManifest</a>.</p>
+				<p>When the <code>lang</code> is specified in <a>LocalizableString</a>, this value
+					overrides the default language specified in <a>WebPublicationManifest</a>.</p>
 
 				<p><a>LocalizableString</a> has the following members:</p>
 
@@ -3044,10 +3177,6 @@
 						<dfn>lang</dfn>
 					</dt>
 					<dd>Contains the <a href="#language-and-dir">language</a>.</dd>
-					<dt>
-						<dfn>dir</dfn>
-					</dt>
-					<dd>Contains the <a>base direction</a>.</dd>
 				</dl>
 			</section>
 
@@ -3072,14 +3201,14 @@
 					</dt>
 					<dd>Text label for the linked resource.</dd>
 					<dt>
+						<dfn>description</dfn>
+					</dt>
+					<dd>Description of the linked resource.</dd>
+					<dt>
 						<dfn>rel</dfn>
 					</dt>
 					<dd>Contains one or more relations based on the IANA link
 						registry.&#160;[[!iana-link-relations]]</dd>
-					<dt>
-						<dfn>children</dfn>
-					</dt>
-					<dd>Contains one or more child resources for the current resource.</dd>
 				</dl>
 
 			</section>
@@ -3105,6 +3234,26 @@
 					<dd>Determined by the user agent.</dd>
 				</dl>
 			</section>
+
+			<section id="textdirection-idl">
+				<h3><code>ProgressionDirection</code> enum </h3>
+
+				<pre class="idl" data-include="webidl/progression_direction.webidl" data-include-format="text"></pre>
+
+				<p>The <dfn>ProgressionDirection</dfn> enum can contain the following values:</p>
+				<dl data-dfn-for="ProgressionDirection">
+					<dt>
+						<dfn>ltr</dfn>
+					</dt>
+					<dd>Left-to-right text.</dd>
+					<dt>
+						<dfn>rtl</dfn>
+					</dt>
+					<dd>Right-to-left text.</dd>
+				</dl>
+			</section>
+
+
 
 		</section>
 		<section id="app-manifest-examples" class="appendix informative">

--- a/webidl/contributor.webidl
+++ b/webidl/contributor.webidl
@@ -1,4 +1,0 @@
-dictionary Contributor {
-    required    LocalizableString       name;
-                DOMString               id;
-};

--- a/webidl/localizable_string.webidl
+++ b/webidl/localizable_string.webidl
@@ -1,5 +1,4 @@
 dictionary LocalizableString {
     required DOMString       value;
              DOMString       lang;
-             TextDirection   dir = "auto";
 };

--- a/webidl/manifest.webidl
+++ b/webidl/manifest.webidl
@@ -40,7 +40,7 @@ dictionary WebPublicationManifest {
              sequence<PublicationLink>          links;
 
              DOMString                          accessibilityReport;
-             DOMString                           privacyPolicy;
+             DOMString                          privacyPolicy;
              sequence<DOMString>                cover;
              DOMString                          toc;
 };

--- a/webidl/manifest.webidl
+++ b/webidl/manifest.webidl
@@ -39,8 +39,8 @@ dictionary WebPublicationManifest {
              sequence<PublicationLink>          resources;
              sequence<PublicationLink>          links;
 
-             DOMString                          accessibilityReport;
-             DOMString                          privacyPolicy;
-             sequence<DOMString>                cover;
+             PublicationLink                    accessibilityReport;
+             PublicationLink                    privacyPolicy;
+             sequence<PublicationLink>          cover;
              DOMString                          toc;
 };

--- a/webidl/manifest.webidl
+++ b/webidl/manifest.webidl
@@ -2,13 +2,13 @@ dictionary WebPublicationManifest {
     required DOMString                          url;
     required DOMString                          type;
 
-             DOMString                          accessMode;
-             DOMString                          accessModeSufficient;
+             sequence<DOMString>                accessMode;
+             sequence<DOMString>                accessModeSufficient;
              DOMString                          accessibilityAPI;
-             DOMString                          accessibilityControl;
-             DOMString                          accessibilityFeature;
-             DOMString                          accessibilityHazard;
-             DOMString                          accessibilitySummary;
+             sequence<DOMString>                accessibilityControl;
+             sequence<DOMString>                accessibilityFeature;
+             sequence<DOMString>                accessibilityHazard;
+             LocalizableString                  accessibilitySummary;
 
              DOMString                          id;
 

--- a/webidl/manifest.webidl
+++ b/webidl/manifest.webidl
@@ -40,7 +40,7 @@ dictionary WebPublicationManifest {
              sequence<PublicationLink>          links;
 
              DOMString                          accessibilityReport;
-             DOMSring                           privacyPolicy;
+             DOMString                           privacyPolicy;
              sequence<DOMString>                cover;
              DOMString                          toc;
 };

--- a/webidl/manifest.webidl
+++ b/webidl/manifest.webidl
@@ -1,15 +1,46 @@
 dictionary WebPublicationManifest {
-    required DOMString                         url;
-             DOMString                         lang;
-             TextDirection                     direction = "auto";
-             TextDirection                     readingProgression = "auto";
-             sequence<LocalizableString>       name;
-             DOMString                         id;
-             sequence<Contributor>             authors;
-             DOMString                         dateModified;
-             DOMString                         datePublished;
-             sequence<PublicationLink>         links;
-             sequence<PublicationLink>         readingOrder;
-             sequence<PublicationLink>         resources;
-             sequence<PublicationLink>         toc;
+    required DOMString                          url;
+    required DOMString                          type;
+
+             DOMString                          accessMode;
+             DOMString                          accessModeSufficient;
+             DOMString                          accessibilityAPI;
+             DOMString                          accessibilityControl;
+             DOMString                          accessibilityFeature;
+             DOMString                          accessibilityHazard;
+             DOMString                          accessibilitySummary;
+
+             DOMString                          id;
+
+             sequence<Person>                   artist;
+             sequence<(Person or Organization)> author;
+             sequence<Person>                   colorist;
+             sequence<(Person or Organization)> contributor;
+             sequence<(Person or Organization)> creator;
+             sequence<Person>                   editor;
+             sequence<Person>                   illustrator;
+             sequence<Person>                   letterer;
+             sequence<Person>                   penciler;
+             sequence<(Person or Organization)> publisher;
+             sequence<Person>                   readby;
+             sequence<(Person or Organization)> translator;
+
+             DOMString                          inLanguage;
+             TextDirection                      inDirection;
+
+             DOMString                          dateModified;
+             DOMString                          datePublished;
+
+             ProgressionDirection               readingProgression = "ltr";
+
+             sequence<LocalizableString>        name;
+
+             sequence<PublicationLink>          readingOrder;
+             sequence<PublicationLink>          resources;
+             sequence<PublicationLink>          links;
+
+             DOMString                          accessibilityReport;
+             DOMSring                           privacyPolicy;
+             sequence<DOMString>                cover;
+             DOMString                          toc;
 };

--- a/webidl/organization.webidl
+++ b/webidl/organization.webidl
@@ -1,0 +1,7 @@
+
+dictionary Organization {
+    required sequence<LocalizableString> name;
+             DOMString                   id;
+             DOMString                   url;
+};
+

--- a/webidl/person.webidl
+++ b/webidl/person.webidl
@@ -1,0 +1,6 @@
+
+dictionary Person {
+    required sequence<LocalizableString> name;
+             DOMString                   id;
+             DOMString                   url;
+};

--- a/webidl/progression_direction.webidl
+++ b/webidl/progression_direction.webidl
@@ -1,0 +1,4 @@
+enum ProgressionDirection {
+	"ltr",
+	"rtl"
+};

--- a/webidl/publication_link.webidl
+++ b/webidl/publication_link.webidl
@@ -1,7 +1,7 @@
 dictionary PublicationLink {
-    required DOMString                  url;
-             DOMString                  encodingFormat;
-             DOMString                  name;
-             sequence<DOMString>        rel;
-             sequence<PublicationLink>  children;
+    required DOMString           url;
+             DOMString           encodingFormat;
+             DOMString           name;
+             DOMString           description;
+             sequence<DOMString> rel;
 };

--- a/webidl/publication_link.webidl
+++ b/webidl/publication_link.webidl
@@ -1,7 +1,7 @@
 dictionary PublicationLink {
     required DOMString           url;
              DOMString           encodingFormat;
-             DOMString           name;
-             DOMString           description;
+             LocalizableString   name;
+             LocalizableString   description;
              sequence<DOMString> rel;
 };


### PR DESCRIPTION
My first attempt to bring the WebIDL part in sync with the current manifest. Some of the significant changes (some of those may be subject to further discussions!)

- The previous IDL referred to "title" as an array of strings, which was correct. I have made a slight update on the manifest definition emphasizing the fact that the 'name' value may be an array, too.
- The previous IDL included a "children" tag, which did not have a direct counterpart in the manifest. I believe the main reason for its presence was to handle hierarchical TOC-s. However, the manifest as of today extracts/contains a _link_ to a TOC, itself encoded in HTML, and not the list of resources themselves. Of course, a user agent may want to extract those (or may choose to simply display the HTML) but I am not sure it is a matter of the IDL to have this.
- I was wondering about having a single "Contributors" dictionary item for all the authors, editors, etc., with an extra flag providing the categorization, but I thought spelling things out, ie, reflecting what is in the manifest, is cleaner...

There are also some other, minor changes, mostly editorial.


See also #284


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/285.html" title="Last updated on Aug 1, 2018, 12:01 PM GMT (bcf7927)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/285/9b7c71e...bcf7927.html" title="Last updated on Aug 1, 2018, 12:01 PM GMT (bcf7927)">Diff</a>