### PR TITLE
The default reading order should be required in the WebIDL

### DIFF
--- a/index.html
+++ b/index.html
@@ -2974,7 +2974,6 @@
 					</dt>
 					<dd>Contains the value of the <a href="#accessibility">accessibilityHazard</a> property.</dd>
 
-
 					<dt>
 						<dfn>accessibilitySummary</dfn>
 					</dt>
@@ -2984,7 +2983,6 @@
 						<dfn>id</dfn>
 					</dt>
 					<dd>Contains the <a>canonical identifier</a>.</dd>
-
 
 					<dt>
 						<dfn>artist</dfn>
@@ -3069,7 +3067,7 @@
 					<dt>
 						<dfn>readingOrder</dfn>
 					</dt>
-					<dd>Contains the <a>default reading order</a>.</dd>
+					<dd>Contains the <a>default reading order</a>. Required.</dd>
 
 					<dt>
 						<dfn>resources</dfn>

--- a/webidl/manifest.webidl
+++ b/webidl/manifest.webidl
@@ -35,7 +35,7 @@ dictionary WebPublicationManifest {
 
              sequence<LocalizableString>        name;
 
-             sequence<PublicationLink>          readingOrder;
+   required  sequence<PublicationLink>          readingOrder;
              sequence<PublicationLink>          resources;
              sequence<PublicationLink>          links;
 


### PR DESCRIPTION
The spec says that if the default reading order is not present in the manifest, then it should be set to the URL of the primary entry page as a sole item.

This should mean that, in the WebIDL, this entry is _required_


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/292.html" title="Last updated on Aug 3, 2018, 3:11 PM GMT (3f1ee84)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/292/b276a48...3f1ee84.html" title="Last updated on Aug 3, 2018, 3:11 PM GMT (3f1ee84)">Diff</a>