### PR TITLE
Accessibility API should also be a (possible) list values as opposed to a single one

### DIFF
--- a/index.html
+++ b/index.html
@@ -762,7 +762,7 @@
 									</td>
 									<td> Indicates that the resource is compatible with the referenced accessibility
 										API-s. </td>
-									<td> Comma-separated values. <a
+									<td> Text. <a
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>

--- a/index.html
+++ b/index.html
@@ -761,8 +761,8 @@
 										<code>accessibilityAPI</code>
 									</td>
 									<td> Indicates that the resource is compatible with the referenced accessibility
-										API. </td>
-									<td> Text. <a
+										API-s. </td>
+									<td> Comma-separated values. <a
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>

--- a/webidl/manifest.webidl
+++ b/webidl/manifest.webidl
@@ -4,7 +4,7 @@ dictionary WebPublicationManifest {
 
              sequence<DOMString>                accessMode;
              sequence<DOMString>                accessModeSufficient;
-             DOMString                          accessibilityAPI;
+             sequence<DOMString>                accessibilityAPI;
              sequence<DOMString>                accessibilityControl;
              sequence<DOMString>                accessibilityFeature;
              sequence<DOMString>                accessibilityHazard;


### PR DESCRIPTION
The Accessibility API is the only a11y term that had, as a possible value, a single string, as opposed to a comma separated list. If my understanding is correct, the meaning of this attribute is that the publication is compatible with a number of API-s, ie, it is only meaningful if a comma separated set of values are allowed (just like all the other properties). This PR makes this change.

@avneeshsingh @rdeltour @danielweck  is that correct?

(Note that neither the schema.org description more the a11y wiki page is really clear on this...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/293.html" title="Last updated on Aug 9, 2018, 11:54 AM GMT (337c02a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/293/8a8c7d0...337c02a.html" title="Last updated on Aug 9, 2018, 11:54 AM GMT (337c02a)">Diff</a>