### PR TITLE
allow person or organization

### DIFF
--- a/index.html
+++ b/index.html
@@ -1072,7 +1072,7 @@
 										<code>author</code>
 									</td>
 									<td>The author of the publication.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> or <a
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or <a
 											href="https://schema.org/Organization"><code>Organization</code></a>.</td>
 									<td>
 										<a href="https://schema.org/author"><code>author</code></a>
@@ -1094,7 +1094,7 @@
 									</td>
 									<td>Contributor whose role does not fit to one of the other roles in this
 										table.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> or <a
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or <a
 											href="https://schema.org/Organization"><code>Organization</code></a>.</td>
 									<td>
 										<a href="https://schema.org/contributor"><code>contributor</code></a>
@@ -1105,7 +1105,7 @@
 										<code>creator</code>
 									</td>
 									<td>The creator of the publication.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> or <a
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or <a
 											href="https://schema.org/Organization"><code>Organization</code></a>.</td>
 									<td>
 										<a href="https://schema.org/creator"><code>creator</code></a>
@@ -1157,7 +1157,7 @@
 										<code>publisher</code>
 									</td>
 									<td>The publisher of the publication.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> or <a
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or <a
 											href="https://schema.org/Organization"><code>Organization</code></a>.</td>
 									<td>
 										<a href="https://schema.org/publisher"><code>publisher</code></a>
@@ -1178,7 +1178,7 @@
 										<code>translator</code>
 									</td>
 									<td>The translator of the publication.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> or <a
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or <a
 											href="https://schema.org/Organization"><code>Organization</code></a>. </td>
 									<td>
 										<a href="https://bib.schema.org/translator"><code>translator</code></a>


### PR DESCRIPTION
Per #284, this makes clear that person and/or org are allowed for those properties that accept both. I didn't change any of the properties that only allow person to also allow org, as if we're strictly adhering to schema.org definitions then we shouldn't be adding to them.

Fix #296.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/296.html" title="Last updated on Aug 10, 2018, 5:10 AM GMT (2513682)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/296/c073565...2513682.html" title="Last updated on Aug 10, 2018, 5:10 AM GMT (2513682)">Diff</a>