### PR TITLE
Note on links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1775,7 +1775,7 @@
 														><code>PublicationLink</code></a> object</li>
 										</ul>
 										<p>The order in the array is <em>significant</em>. The URLs MUST NOT include
-											fragment identifiers.</p>
+											fragment identifiers. Non-HTML resources SHOULD be expressed as <code>PublicationLink</code> objects with their <code>encodingFormat</code> values set.</p>
 									</td>
 									<td>(None)</td>
 								</tr>
@@ -1848,7 +1848,7 @@
 							agent SHOULD still be able to render a Web Publication even if some of these resources are
 							not identified as belonging to the Web Publication (e.g., when it is taken offline without
 							them).</p>
-
+						
 						<div class="ednote"> The previous version of the draft included: <blockquote>
 								<p>If a user agent encounters a resource that it cannot locate in the resource list, it
 									MUST treat the resource as external to the Web Publication (e.g., it might alert the
@@ -1889,7 +1889,8 @@
 														><code>PublicationLink</code></a> object</li>
 										</ul>
 										<p>The order in the array is <em>not significant</em>. The URLs MUST NOT include
-											fragment identifiers.</p>
+											fragment identifiers. It is RECOMMENDED to use <code>PublicationLink</code> objects with their <code>encodingFormat</code> values set.</p>
+										</p>
 									</td>
 									<td>(None)</td>
 								</tr>
@@ -1988,7 +1989,7 @@
 											<li>an instance of a <a href="#publication-link-def"
 														><code>PublicationLink</code></a> object</li>
 										</ul>
-										<p>The order in the array is <em>not significant</em>.</p>
+										<p>The order in the array is <em>not significant</em>. It is RECOMMENDED to use <code>PublicationLink</code> objects with their <code>encodingFormat</code> and <code>rel</code> values set.</p>
 									</td>
 									<td>(None)</td>
 								</tr>


### PR DESCRIPTION
Added notes to resource lists, as proposed by 
https://github.com/w3c/wpub/issues/290#issuecomment-412038562

Fix #290


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/298.html" title="Last updated on Aug 10, 2018, 10:53 AM GMT (090203e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/298/b29428a...090203e.html" title="Last updated on Aug 10, 2018, 10:53 AM GMT (090203e)">Diff</a>