### PR TITLE
Accessibility terms update

### DIFF
--- a/index.html
+++ b/index.html
@@ -826,11 +826,7 @@
 									</td>
 									<td> The human sensory perceptual system or cognitive faculty through which a person
 										may process or perceive information. </td>
-<<<<<<< HEAD
 									<td> One or more text(s). <a
-=======
-									<td> One or more text. <a
->>>>>>> 5638e01386ce49f9e2933aefd07a4a8a6d12bac9
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>
@@ -857,11 +853,7 @@
 									</td>
 									<td>Indicates that the resource is compatible with the referenced accessibility
 										APIs. </td>
-<<<<<<< HEAD
 									<td>One or more text(s).<a
-=======
-									<td> One or more text. <a
->>>>>>> 5638e01386ce49f9e2933aefd07a4a8a6d12bac9
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>
@@ -874,11 +866,7 @@
 									</td>
 									<td>Identifies input methods that are sufficient to fully control the described
 										resource. </td>
-<<<<<<< HEAD
 									<td> One or more text(s). <a
-=======
-									<td> One or more text. <a
->>>>>>> 5638e01386ce49f9e2933aefd07a4a8a6d12bac9
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>
@@ -892,11 +880,7 @@
 									</td>
 									<td> Content features of the resource, such as accessible media, alternatives and
 										supported enhancements for accessibility. </td>
-<<<<<<< HEAD
 									<td> One or more text(s). <a
-=======
-									<td> One or more text. <a
->>>>>>> 5638e01386ce49f9e2933aefd07a4a8a6d12bac9
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>
@@ -910,11 +894,7 @@
 									</td>
 									<td> A characteristic of the described resource that is physiologically dangerous to
 										some users. </td>
-<<<<<<< HEAD
 									<td> One or more text(s).<a
-=======
-									<td> One or more text. <a
->>>>>>> 5638e01386ce49f9e2933aefd07a4a8a6d12bac9
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>

--- a/index.html
+++ b/index.html
@@ -839,7 +839,7 @@
 									</td>
 									<td> A list of single or combined accessModes that are sufficient to understand all
 										the intellectual content of a resource. </td>
-									<td> One or more text comma-separated values. <a
+									<td> One or more texts, each a comma-separated list of terms. <a
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>

--- a/webidl/manifest.webidl
+++ b/webidl/manifest.webidl
@@ -3,7 +3,7 @@ dictionary WebPublicationManifest {
     required DOMString                          type;
 
              sequence<DOMString>                accessMode;
-             sequence<sequence<DOMString>>      accessModeSufficient;
+             sequence<DOMString>                accessModeSufficient;
              sequence<DOMString>                accessibilityAPI;
              sequence<DOMString>                accessibilityControl;
              sequence<DOMString>                accessibilityFeature;

--- a/webidl/manifest.webidl
+++ b/webidl/manifest.webidl
@@ -3,7 +3,7 @@ dictionary WebPublicationManifest {
     required DOMString                          type;
 
              sequence<DOMString>                accessMode;
-             sequence<DOMString>                accessModeSufficient;
+             sequence<sequence<DOMString>>      accessModeSufficient;
              sequence<DOMString>                accessibilityAPI;
              sequence<DOMString>                accessibilityControl;
              sequence<DOMString>                accessibilityFeature;


### PR DESCRIPTION
Hopefully final version of the accessibilityModeSufficient. Is defined as an array of terms, each a comma-separated list of allowed terms. The WebIDL has also been modified accordingly as a sequence of sequences.

It implements https://github.com/w3c/wpub/issues/300#issue-349488387

fix #300


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/310.html" title="Last updated on Aug 21, 2018, 3:51 AM GMT (ef469a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/310/2e4a924...ef469a5.html" title="Last updated on Aug 21, 2018, 3:51 AM GMT (ef469a5)">Diff</a>