### PR TITLE
clarify resource list

### DIFF
--- a/index.html
+++ b/index.html
@@ -825,7 +825,6 @@
 						<ul>
 							<li><a href="#address">address</a></li>
 							<li><a href="#default-reading-order">default reading order</a></li>
-							<li><a href="#resource-list">resource list</a></li>
 						</ul>
 					</dd>
 					<dt>RECOMMENDED:</dt>
@@ -844,6 +843,7 @@
 							<li><a href="#privacy-policy">privacy policy</a></li>
 							<li><a href="#reading-progression-direction">reading progression
 									direction</a></li>
+							<li><a href="#resource-list">resource list</a></li>
 							<li><a href="#table-of-contents">table of contents</a></li>
 							<li><a href="#wptitle">title</a></li>
 						</ul>
@@ -2118,10 +2118,10 @@
 				<section id="resource-list">
 					<h4>Resource List</h4>
 
-					<p>The <dfn>resource list</dfn> enumerates all <a href="#wp-resources"
-							>resources</a> that are used in the processing and rendering of a <a>Web
-							Publication</a> (i.e., that are within its bounds) and that are not
-						listed in the <a>default reading order</a>.</p>
+					<p>The <dfn>resource list</dfn> enumerates any additional <a
+							href="#wp-resources">resources</a> used in the processing and rendering
+						of a <a>Web Publication</a> that are not already listed in the <a>default
+							reading order</a>.</p>
 
 					<p class="note">The union of the resource list and default reading order
 						represents the definitive list of resources that belong to the Web

--- a/index.html
+++ b/index.html
@@ -53,20 +53,24 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This specification defines a collection of information that describes the structure of Web Publications
-				so that user agents can provide user experiences tailored to reading publications, such as sequential
-				navigation and offline reading. This information includes the default reading order, a list of
-				resources, and publication-wide metadata.</p>
+			<p>This specification defines a collection of information that describes the structure
+				of Web Publications so that user agents can provide user experiences tailored to
+				reading publications, such as sequential navigation and offline reading. This
+				information includes the default reading order, a list of resources, and
+				publication-wide metadata.</p>
 		</section>
 		<section id="sotd">
-			<p>This draft provides a preliminary outline of a Web Publication. Many details are under active
-				consideration within the Publishing Working Group and are subject to change. The most prominent known
-				issues have been identified in this document and links provided to comment on them.</p>
+			<p>This draft provides a preliminary outline of a Web Publication. Many details are
+				under active consideration within the Publishing Working Group and are subject to
+				change. The most prominent known issues have been identified in this document and
+				links provided to comment on them.</p>
 
-			<p>The work the past few month has been focused on sections <a href="#wp-construction"></a> and <a
-					href="#wp-properties"></a>, which include the definition of a <a>manifest</a> making use of terms in
-					<a href="https://schema.org">schema.org</a>. Later sections, in particular <a href="#wp-lifecycle"
-				></a> (and the corresponding diagrams) may be out of sync with this version. Subsequent drafts will focus on updating those sections.</p>
+			<p>The work the past few month has been focused on sections <a href="#wp-construction"
+				></a> and <a href="#wp-properties"></a>, which include the definition of a
+					<a>manifest</a> making use of terms in <a href="https://schema.org"
+					>schema.org</a>. Later sections, in particular <a href="#wp-lifecycle"></a> (and
+				the corresponding diagrams) may be out of sync with this version. Subsequent drafts
+				will focus on updating those sections.</p>
 		</section>
 		<section id="intro">
 			<h2>Introduction</h2>
@@ -74,118 +78,138 @@
 			<section id="what-is-wp" class="informative">
 				<h3>What is a Web Publication</h3>
 
-				<p>A <a>Web Publication</a> is a discoverable and identifiable collection of resources. Information
-					about the Web Publication is expressed in a machine-readable document called a <a>manifest</a>,
-					which is what enables user agents to understand the bounds of the Web Publication and the connection
+				<p>A <a>Web Publication</a> is a discoverable and identifiable collection of
+					resources. Information about the Web Publication is expressed in a
+					machine-readable document called a <a>manifest</a>, which is what enables user
+					agents to understand the bounds of the Web Publication and the connection
 					between its resources.</p>
 
-				<p>The manifest includes metadata that describe the Web Publication, as a publication has an identity
-					and nature beyond its constituent resources. The manifest also provides a list of all the resources
-					that belong to the Web Publication and a default reading order, which is how it connects resources
-					into a single contiguous work.</p>
+				<p>The manifest includes metadata that describe the Web Publication, as a
+					publication has an identity and nature beyond its constituent resources. The
+					manifest also provides a list of all the resources that belong to the Web
+					Publication and a default reading order, which is how it connects resources into
+					a single contiguous work.</p>
 
-				<p>A Web Publication is discoverable in one of two ways: resources either include a link to the manifest
-					(via an HTTP Link header or an HTML <code>link</code> element&#160;[[!html]]), or the manifest can
-					be loaded directly by a compatible user agent.</p>
+				<p>A Web Publication is discoverable in one of two ways: resources either include a
+					link to the manifest (via an HTTP Link header or an HTML <code>link</code>
+					element&#160;[[!html]]), or the manifest can be loaded directly by a compatible
+					user agent.</p>
 
-				<p>With the establishment of Web Publications, user agents can build new experiences tailored
-					specifically for their unique reading needs.</p>
+				<p>With the establishment of Web Publications, user agents can build new experiences
+					tailored specifically for their unique reading needs.</p>
 
 				<figure id="WP-diagram">
-					<object data="images/WP-diagram.svg" type="image/svg+xml" aria-describedby="wp-diagram-alt">
-						<p id="wp-diagram-alt">Flowchart depicts the resources of a Web Publication, their attachment to
-							a manifest, and its relationship to the infoset.</p>
+					<object data="images/WP-diagram.svg" type="image/svg+xml"
+						aria-describedby="wp-diagram-alt">
+						<p id="wp-diagram-alt">Flowchart depicts the resources of a Web Publication,
+							their attachment to a manifest, and its relationship to the infoset.</p>
 					</object>
 					<figcaption>Simplified Diagram of the Structure of Web Publications. <br />A <a
-							href="#WP-diagram-descr">description of the structure diagram</a> is available in the
-						Appendix. Image available in <a href="images/WP-diagram.svg"
+							href="#WP-diagram-descr">description of the structure diagram</a> is
+						available in the Appendix. Image available in <a
+							href="images/WP-diagram.svg"
 							title="SVG image of the structure of Web Publications">SVG</a> and <a
-							title="PNG image of the structure of Web Publications" href="images/WP-diagram.png">PNG</a>
-						formats.</figcaption>
+							title="PNG image of the structure of Web Publications"
+							href="images/WP-diagram.png">PNG</a> formats.</figcaption>
 				</figure>
 			</section>
 
 			<section id="scope" class="informative">
 				<h3>Scope</h3>
 
-				<p>This specification only defines requirements for the production and rendering of valid <a>Web
-						Publications</a>. As much as possible, it leverages existing Open Web Platform technologies to
-					achieve its goal—that being to allow for a measure of boundedness on the Web without changing the
-					way that the Web itself operates.</p>
+				<p>This specification only defines requirements for the production and rendering of
+					valid <a>Web Publications</a>. As much as possible, it leverages existing Open
+					Web Platform technologies to achieve its goal—that being to allow for a measure
+					of boundedness on the Web without changing the way that the Web itself
+					operates.</p>
 
-				<p>Moreover, the specification is designed to adapt automatically to updates to Open Web Platform
-					technologies in order to ensure that Web Publications continue to interoperate seamlessly as the Web
-					evolves (e.g., by referencing the latest published versions instead of specific dated versions).</p>
+				<p>Moreover, the specification is designed to adapt automatically to updates to Open
+					Web Platform technologies in order to ensure that Web Publications continue to
+					interoperate seamlessly as the Web evolves (e.g., by referencing the latest
+					published versions instead of specific dated versions).</p>
 
-				<p>Further, this specification does not attempt to constrain the nature of a Web Publication: any type
-					of work that can be represented on the Web constitutes a potential Web Publication.</p>
+				<p>Further, this specification does not attempt to constrain the nature of a Web
+					Publication: any type of work that can be represented on the Web constitutes a
+					potential Web Publication.</p>
 
-				<p>The specification is also intended to facilitate different user agent architectures for the
-					consumption of Web Publications. While a primary goal is that traditional Web user agents (browsers)
-					will be able to consume Web Publications, this should not limit the capabilities of any other
-					possible type of user agent (e.g., applications, whether standalone or running within a user agent,
-					or even Web Publications that include their own user interface). As a result, the specification does
-					not attempt to architect required solutions for situations whose expected outcome will vary
-					depending on the nature of the user agent and the expectations of the user (e.g., how to prompt to
-					initiate a Web Publication, or at what point or how much of a Web Publication to cache for offline
-					use).</p>
+				<p>The specification is also intended to facilitate different user agent
+					architectures for the consumption of Web Publications. While a primary goal is
+					that traditional Web user agents (browsers) will be able to consume Web
+					Publications, this should not limit the capabilities of any other possible type
+					of user agent (e.g., applications, whether standalone or running within a user
+					agent, or even Web Publications that include their own user interface). As a
+					result, the specification does not attempt to architect required solutions for
+					situations whose expected outcome will vary depending on the nature of the user
+					agent and the expectations of the user (e.g., how to prompt to initiate a Web
+					Publication, or at what point or how much of a Web Publication to cache for
+					offline use).</p>
 			</section>
 
 			<section id="terminology">
 				<h3>Terminology</h3>
 
-				<p>This document uses terminology defined by the W3C Note "Publishing and Linking on the
-					Web"&#160;[[publishing-linking]], including, in particular, <a class="externalDFN"
-						href="https://www.w3.org/TR/publishing-linking/#dfn-user">user</a>, <a class="externalDFN"
-						href="https://www.w3.org/TR/publishing-linking/#dfn-user-agent">user agent</a>, <a
-						class="externalDFN" href="https://www.w3.org/TR/publishing-linking/#dfn-browser">browser</a>,
-					and <a class="externalDFN" href="https://www.w3.org/TR/publishing-linking/#dfn-address"
+				<p>This document uses terminology defined by the W3C Note "Publishing and Linking on
+					the Web"&#160;[[publishing-linking]], including, in particular, <a
+						class="externalDFN"
+						href="https://www.w3.org/TR/publishing-linking/#dfn-user">user</a>, <a
+						class="externalDFN"
+						href="https://www.w3.org/TR/publishing-linking/#dfn-user-agent">user
+						agent</a>, <a class="externalDFN"
+						href="https://www.w3.org/TR/publishing-linking/#dfn-browser">browser</a>,
+					and <a class="externalDFN"
+						href="https://www.w3.org/TR/publishing-linking/#dfn-address"
 					>address</a>.</p>
 
 				<dl>
 					<dt><dfn data-lt="identifiers">Identifier</dfn></dt>
 					<dd>
-						<p>An identifier is metadata that can be used to refer to <a class="externalDFN"
-								href="https://www.w3.org/TR/publishing-linking/#dfn-web-content">Web Content</a> in a
-							persistent and unambiguous manner. <abbr title="Uniform Resource Locators">URLs</abbr>,
-								<abbr title="Uniform Resource Names">URNs</abbr>, <abbr
+						<p>An identifier is metadata that can be used to refer to <a
+								class="externalDFN"
+								href="https://www.w3.org/TR/publishing-linking/#dfn-web-content">Web
+								Content</a> in a persistent and unambiguous manner. <abbr
+								title="Uniform Resource Locators">URLs</abbr>, <abbr
+								title="Uniform Resource Names">URNs</abbr>, <abbr
 								title="Digital Object Identifiers">DOIs</abbr>, <abbr
 								title="International Standard Book Numbers">ISBNs</abbr>, and <abbr
-								title="Persistent Uniform Resource Locators">PURLs</abbr> are all examples of persistent
-							identifiers frequently used in publishing.</p>
+								title="Persistent Uniform Resource Locators">PURLs</abbr> are all
+							examples of persistent identifiers frequently used in publishing.</p>
 					</dd>
 
 					<dt><dfn data-lt="Manifests">Manifest</dfn></dt>
 					<dd>
-						<p>A manifest represents structured information about a <a>Web Publication</a>, such as
-							informative metadata, a <a href="#resource-list">list of all resources</a>, and a <a>default
+						<p>A manifest represents structured information about a <a>Web
+								Publication</a>, such as informative metadata, a <a
+								href="#resource-list">list of all resources</a>, and a <a>default
 								reading order</a>.</p>
 					</dd>
 
 					<dt><dfn>Non-empty</dfn></dt>
 					<dd>
-						<p>For the purposes of this specification, non-empty is used to refer to an element, attribute
-							or property whose text content or value consists of one or more characters after whitespace
-							normalization, where whitespace normalization rules are defined per the host format.</p>
+						<p>For the purposes of this specification, non-empty is used to refer to an
+							element, attribute or property whose text content or value consists of
+							one or more characters after whitespace normalization, where whitespace
+							normalization rules are defined per the host format.</p>
 					</dd>
 
 					<dt><dfn data-lt="URLs">URL</dfn></dt>
 					<dd>
-						<p>The general term <abbr title="Uniform Resource Locator">URL</abbr> is defined by the URL
-							Standard&#160;[[!url]]. It is used as in other <abbr title="World Wide Web Consortium"
-								>W3C</abbr> specifications, like <abbr title="Hypertext Markup Language"
-							>HTML</abbr>&#160;[[!html]]. In particular, a <abbr title="Uniform Resource Locator"
-								>URL</abbr> allows for the usage of characters from Unicode following&#160;[[!rfc3987]].
-							See <a href="https://www.w3.org/TR/html/references.html#biblio-url">the note in the HTML5
-								specification</a> for further details.</p>
+						<p>The general term <abbr title="Uniform Resource Locator">URL</abbr> is
+							defined by the URL Standard&#160;[[!url]]. It is used as in other <abbr
+								title="World Wide Web Consortium">W3C</abbr> specifications, like
+								<abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[!html]].
+							In particular, a <abbr title="Uniform Resource Locator">URL</abbr>
+							allows for the usage of characters from Unicode
+							following&#160;[[!rfc3987]]. See <a
+								href="https://www.w3.org/TR/html/references.html#biblio-url">the
+								note in the HTML5 specification</a> for further details.</p>
 					</dd>
 
 					<dt><dfn data-lt="Web Publications|Web Publication's">Web Publication</dfn></dt>
 					<dd>
-						<p>A Web Publication is a collection of one or more resources, organized together through a
-								<a>manifest</a> into a single logical work with a <a>default reading order</a>. The Web
-							Publication is uniquely identifiable and presentable using Open Web Platform
-							technologies.</p>
+						<p>A Web Publication is a collection of one or more resources, organized
+							together through a <a>manifest</a> into a single logical work with a
+								<a>default reading order</a>. The Web Publication is uniquely
+							identifiable and presentable using Open Web Platform technologies.</p>
 					</dd>
 				</dl>
 			</section>
@@ -194,23 +218,26 @@
 			<section id="conformance-classes">
 				<h2>Conformance Classes</h2>
 
-				<p>This specification defines two conformance classes: one for <a>Web Publications</a> and one for user
-					agents that process them.</p>
+				<p>This specification defines two conformance classes: one for <a>Web
+						Publications</a> and one for user agents that process them.</p>
 
-				<p id="wp-conformance">A Web Publication conforms to this specification if it meets the following
-					criteria:</p>
+				<p id="wp-conformance">A Web Publication conforms to this specification if it meets
+					the following criteria:</p>
 
 				<ul>
-					<li>it has a <a>manifest</a> that conforms to <a href="#wp-properties-req"></a>;</li>
-					<li>it adheres to the construction requirements defined in <a href="#wp-construction"></a>.</li>
+					<li>it has a <a>manifest</a> that conforms to <a href="#wp-properties-req"
+						></a>;</li>
+					<li>it adheres to the construction requirements defined in <a
+							href="#wp-construction"></a>.</li>
 				</ul>
 
-				<p id="ua-conformance">A user agent conforms to this specification if it meets the following
-					criteria:</p>
+				<p id="ua-conformance">A user agent conforms to this specification if it meets the
+					following criteria:</p>
 
 				<ul>
-					<li>it is capable of generating a conforming <a href="#wp-properties"><abbr title="information set"
-								>infoset</abbr></a> for a Web Publication.</li>
+					<li>it is capable of generating a conforming <a href="#wp-properties"><abbr
+								title="information set">infoset</abbr></a> for a Web
+						Publication.</li>
 				</ul>
 			</section>
 		</section>
@@ -220,26 +247,30 @@
 			<section id="wp-infoset-manifest" class="informative">
 				<h3>Infoset and Manifest</h3>
 
-				<p>A <a>Web Publication</a> is defined by a set of items known as its <dfn data-lt="infoset">information
-						set</dfn> (<abbr title="information set">infoset</abbr>). The <abbr title="information set"
-						>infoset</abbr> is both abstract and concrete. It is abstract in the sense that it represents a
-					set of information that a user agent has to compile about the Web Publication, but it also becomes
-					concrete when the user agent creates an internal representation of that information.</p>
+				<p>A <a>Web Publication</a> is defined by a set of items known as its <dfn
+						data-lt="infoset">information set</dfn> (<abbr title="information set"
+						>infoset</abbr>). The <abbr title="information set">infoset</abbr> is both
+					abstract and concrete. It is abstract in the sense that it represents a set of
+					information that a user agent has to compile about the Web Publication, but it
+					also becomes concrete when the user agent creates an internal representation of
+					that information.</p>
 
-				<p>A <a>manifest</a>, on the other hand, is a serialization of an <abbr title="information set"
-							><a>infoset</a></abbr> created by the author of a <a>Web Publication</a>. The manifest is
-					expressed using the JSON-LD&#160;[[!json-ld]] format &#8212; a variant of JSON&#160;[[ecma-404]] for
-					expressing linked data. The manifest can be created as a standalone resource or it can be embedded
-					within an HTML document.</p>
+				<p>A <a>manifest</a>, on the other hand, is a serialization of an <abbr
+						title="information set"><a>infoset</a></abbr> created by the author of a
+						<a>Web Publication</a>. The manifest is expressed using the
+					JSON-LD&#160;[[!json-ld]] format &#8212; a variant of JSON&#160;[[ecma-404]] for
+					expressing linked data. The manifest can be created as a standalone resource or
+					it can be embedded within an HTML document.</p>
 
-				<p>Although the <abbr title="information set">infoset</abbr> is primarily compiled from a Web
-					Publication's <a>manifest</a>, some information is obtained outside the manifest. The table of
-					contents, for example, may be referenced from the manifest but is serialized in an HTML
-					document.</p>
+				<p>Although the <abbr title="information set">infoset</abbr> is primarily compiled
+					from a Web Publication's <a>manifest</a>, some information is obtained outside
+					the manifest. The table of contents, for example, may be referenced from the
+					manifest but is serialized in an HTML document.</p>
 
-				<p>This specification describes the requirements for creating both the infoset and manifest. This
-					section, in particular, details how to create a manifest, and <a href="#wp-properties">the next</a>
-					lists the various properties common to infosets and manifests.</p>
+				<p>This specification describes the requirements for creating both the infoset and
+					manifest. This section, in particular, details how to create a manifest, and <a
+						href="#wp-properties">the next</a> lists the various properties common to
+					infosets and manifests.</p>
 			</section>
 
 			<section id="wp-manifest">
@@ -248,12 +279,13 @@
 				<section id="manifest-context">
 					<h4>Manifest Contexts</h4>
 
-					<p> A Web Publication Manifest MUST start by setting the JSON-LD context [[!json-ld]]. The context
-						has the following two major components:</p>
+					<p> A Web Publication Manifest MUST start by setting the JSON-LD context
+						[[!json-ld]]. The context has the following two major components:</p>
 
 					<ul>
 						<li>the [[!schema.org]] context: <code>https://schema.org</code></li>
-						<li>the Web Publication context: <code>https://www.w3.org/ns/wp-context</code></li>
+						<li>the Web Publication context:
+								<code>https://www.w3.org/ns/wp-context</code></li>
 					</ul>
 
 					<pre class="example" title="The context declaration.">
@@ -263,18 +295,22 @@
 }
 </pre>
 
-					<p>The Web Publication context file MAY add features to the properties defined in Schema.org (e.g.,
-						the requirement for the <a href="https://schema.org/creator">creator</a> property to be order
+					<p>The Web Publication context file MAY add features to the properties defined
+						in Schema.org (e.g., the requirement for the <a
+							href="https://schema.org/creator">creator</a> property to be order
 						preserving).</p>
 
 
-					<p class="ednote">As part of the continuous contacts with Schema.org the additional features defined
-						in the Web Publication context file could migrate to the core Schema.org vocabulary.</p>
+					<p class="ednote">As part of the continuous contacts with Schema.org the
+						additional features defined in the Web Publication context file could
+						migrate to the core Schema.org vocabulary.</p>
 
-					<p class="note">Although Schema.org is often referenced using the <code>http</code> URI scheme, <a
-							href="https://schema.org/docs/faq.html#19">the vocabulary is being migrated</a> to use the
-						secure <code>https</code> scheme as its default. This specification requires the use
-							<code>https</code> when referencing Schema.org in the manifest.</p>
+					<p class="note">Although Schema.org is often referenced using the
+							<code>http</code> URI scheme, <a
+							href="https://schema.org/docs/faq.html#19">the vocabulary is being
+							migrated</a> to use the secure <code>https</code> scheme as its default.
+						This specification requires the use <code>https</code> when referencing
+						Schema.org in the manifest.</p>
 
 				</section>
 
@@ -284,13 +320,14 @@
 					<section id="arrays-and-single-values">
 						<h5>Arrays and Single Values</h5>
 
-						<p>Various manifest properties can have one or more values. As a general rule, these values can
-							be expressed as [[!json]]&#160; arrays. When the property value is an array with a single
-							element, however, the array syntax can be omitted.</p>
+						<p>Various manifest properties can have one or more values. As a general
+							rule, these values can be expressed as [[!json]]&#160; arrays. When the
+							property value is an array with a single element, however, the array
+							syntax can be omitted.</p>
 
 						<aside class="example" title="Using a text string instead of an array">
-							<p>As a Web Publication typically contains many resources, this declaration of a single
-								resource:</p>
+							<p>As a Web Publication typically contains many resources, this
+								declaration of a single resource:</p>
 
 							<pre>
 {
@@ -310,12 +347,15 @@
 					<section id="strings-vs-objects">
 						<h5>Text Values or Objects</h5>
 
-						<p>Various manifest properties are expected to be expressed as [[!json]]&#160;objects. Although
-							the use of objects is usually RECOMMENDED, it is also acceptable to use string values that
-							are interpreted as objects depending on the context. The exact mapping of text values to
-							objects is part of the property or object definitions.</p>
+						<p>Various manifest properties are expected to be expressed as
+							[[!json]]&#160;objects. Although the use of objects is usually
+							RECOMMENDED, it is also acceptable to use string values that are
+							interpreted as objects depending on the context. The exact mapping of
+							text values to objects is part of the property or object
+							definitions.</p>
 
-						<aside class="example" title="Using a text string instead of a Person object.">
+						<aside class="example"
+							title="Using a text string instead of a Person object.">
 							<p>The following author name is expressed as a text string:</p>
 
 							<pre>
@@ -323,7 +363,8 @@
     "author" : "Herman Melville",
     &#8230;
 }</pre>
-							<p>but, in the context of <a href="#creators">creators</a>, it is equivalent to:</p>
+							<p>but, in the context of <a href="#creators">creators</a>, it is
+								equivalent to:</p>
 
 							<pre>
 {
@@ -340,21 +381,24 @@
 					<section id="link-values">
 						<h5>Link Values</h5>
 
-						<p>With the exception of the <a href="#descriptive-properties">descriptive properties</a>, the
-							Web Publication properties typically link to one or more resources. When a property requires
-							a link value, the link MUST be expressed in one of the following two ways:</p>
+						<p>With the exception of the <a href="#descriptive-properties">descriptive
+								properties</a>, the Web Publication properties typically link to one
+							or more resources. When a property requires a link value, the link MUST
+							be expressed in one of the following two ways:</p>
 
 						<ol>
-							<li>as a string encoding the (absolute or relative) URL of the resources&#160;[[!url]];
-								or</li>
-							<li>as an instance of a <a href="#publication-link-def"><code>PublicationLink</code>
-									object</a> that can be used to express the URL, the media type, and other
-								characteristics of the target resource.</li>
+							<li>as a string encoding the (absolute or relative) URL of the
+								resources&#160;[[!url]]; or</li>
+							<li>as an instance of a <a href="#publication-link-def"
+										><code>PublicationLink</code> object</a> that can be used to
+								express the URL, the media type, and other characteristics of the
+								target resource.</li>
 						</ol>
 
-						<p>In other words, a single string value is a shorthand for a <code>PublicationLink</code>
-							object whose <code>url</code> property is set to that string value. (See also <a
-								href="#strings-vs-objects"></a>.)</p>
+						<p>In other words, a single string value is a shorthand for a
+								<code>PublicationLink</code> object whose <code>url</code> property
+							is set to that string value. (See also <a href="#strings-vs-objects"
+							></a>.)</p>
 
 						<pre class="example" title="Resource list that includes one link using a relative URL as a string ('datatypes.svg') and two that display the various properties of the a PublicationLink object">
 {
@@ -381,8 +425,9 @@
 						<section id="publicationLink">
 							<h6><code>PublicationLink</code> Definition</h6>
 
-							<p id="publication-link-def">This specification defines a new type for links called
-									<code>PublicationLink</code>. It consists of the following properties:</p>
+							<p id="publication-link-def">This specification defines a new type for
+								links called <code>PublicationLink</code>. It consists of the
+								following properties:</p>
 
 							<table class="zebra">
 								<thead>
@@ -400,8 +445,8 @@
 											<code>url</code>
 										</td>
 										<td>Location of the resource.</td>
-										<td>A URL&#160;[[!url]]. Refer to the property definitions that accept this type
-											for additional restrictions.</td>
+										<td>A URL&#160;[[!url]]. Refer to the property definitions
+											that accept this type for additional restrictions.</td>
 										<td>
 											<a href="https://schema.org/url"><code>url</code></a>
 										</td>
@@ -411,10 +456,12 @@
 										<td>
 											<code>encodingFormat</code>
 										</td>
-										<td>Media type of the resource (e.g., <code>text/html</code>).</td>
+										<td>Media type of the resource (e.g.,
+											<code>text/html</code>).</td>
 										<td>MIME Media Type&#160;[[!rfc2046]].</td>
 										<td>
-											<a href="https://schema.org/encodingFormat"><code>encodingFormat</code></a>
+											<a href="https://schema.org/encodingFormat"
+												><code>encodingFormat</code></a>
 										</td>
 										<td>OPTIONAL</td>
 									</tr>
@@ -436,7 +483,8 @@
 										<td>Description of the item.</td>
 										<td>Text.</td>
 										<td>
-											<a href="https://schema.org/description"><code>description</code></a>
+											<a href="https://schema.org/description"
+												><code>description</code></a>
 										</td>
 										<td>OPTIONAL</td>
 									</tr>
@@ -444,11 +492,14 @@
 										<td>
 											<code>rel</code>
 										</td>
-										<td>The relationship of the resource to the Web Publication.</td>
+										<td>The relationship of the resource to the Web
+											Publication.</td>
 										<td>
-											<p>One or more relations. The values are either the relevant relationship
-												terms of the IANA link registry&#160;[[!iana-link-relations]], or
-												specially-defined URLs if no suitable link registry item exists.</p>
+											<p>One or more relations. The values are either the
+												relevant relationship terms of the IANA link
+												registry&#160;[[!iana-link-relations]], or
+												specially-defined URLs if no suitable link registry
+												item exists.</p>
 										</td>
 										<td>(None)</td>
 										<td>OPTIONAL</td>
@@ -463,10 +514,10 @@
 				<section id="manifest-pub-types">
 					<h4>Publication Types</h4>
 
-					<p> The Web Publication Manifest MUST include a <dfn>Publication Type</dfn> using the
-							<code>@type</code> keyword&#160;[[!json-ld]]. The type MAY be mapped onto the <a
-							href="https://schema.org/CreativeWork"><code>CreativeWork</code></a>
-						type&#160;[[!schema.org]].</p>
+					<p> The Web Publication Manifest MUST include a <dfn>Publication Type</dfn>
+						using the <code>@type</code> keyword&#160;[[!json-ld]]. The type MAY be
+						mapped onto the <a href="https://schema.org/CreativeWork"
+								><code>CreativeWork</code></a> type&#160;[[!schema.org]].</p>
 
 					<pre class="example" title="Setting a Web Publication's type to CreativeWork.">
 {
@@ -477,9 +528,10 @@
 </pre>
 
 					<p>Schema.org also includes a number of more specific types, all subtypes of
-							<code>CreativeWork</code>, such as <a href="https://schema.org/Article">Article</a>, <a
-							href="https://schema.org/Book">Book</a>, and <a href="https://schema.org/Course">Course</a>.
-						These MAY be used instead of <code>CreativeWork</code>. </p>
+							<code>CreativeWork</code>, such as <a href="https://schema.org/Article"
+							>Article</a>, <a href="https://schema.org/Book">Book</a>, and <a
+							href="https://schema.org/Course">Course</a>. These MAY be used instead
+						of <code>CreativeWork</code>. </p>
 
 					<pre class="example" title="Setting a Web Publication's type to Book.">
 {
@@ -489,12 +541,13 @@
 }
 </pre>
 
-					<p>Each schema.org type defines a set of properties that are valid for use with it. To ensure that
-						the manifest can be validated and processed by schema.org aware processors, the manifest SHOULD
-						contain only the properties associated with the selected type.</p>
+					<p>Each schema.org type defines a set of properties that are valid for use with
+						it. To ensure that the manifest can be validated and processed by schema.org
+						aware processors, the manifest SHOULD contain only the properties associated
+						with the selected type.</p>
 
-					<p>If properties from more than one type are needed, the manifest MAY include multiple type
-						declarations.</p>
+					<p>If properties from more than one type are needed, the manifest MAY include
+						multiple type declarations.</p>
 
 					<pre class="example" title="A Web Publication that combines properties from both Book and VisualArtwork.">
 {
@@ -504,46 +557,53 @@
 }
 </pre>
 
-					<p>User agents SHOULD NOT fail to process manifests that are not valid to their declared schema.org
-						type(s).</p>
+					<p>User agents SHOULD NOT fail to process manifests that are not valid to their
+						declared schema.org type(s).</p>
 
 					<p class="note">Refer to the Schema.org site for the complete <a
-							href="https://schema.org/CreativeWork">list of <code>CreativeWork</code> subtypes</a>.</p>
+							href="https://schema.org/CreativeWork">list of <code>CreativeWork</code>
+							subtypes</a>.</p>
 				</section>
 
 				<section id="manifest-properties">
 					<h4>Properties</h4>
 
-					<p>The naming, syntax, and requirements for manifest properties are defined in <a
-							href="#wp-properties"></a>.</p>
+					<p>The naming, syntax, and requirements for manifest properties are defined in
+							<a href="#wp-properties"></a>.</p>
 
-					<p class="note">Although authors only have to understand the serialization requirements for manifest
-						terms, they are encouraged to read through the infoset definitions for each property, as well.
-						The infoset definitions describe, in some cases, how items are compiled in the absence of
-						explicit information in the manifest.</p>
+					<p class="note">Although authors only have to understand the serialization
+						requirements for manifest terms, they are encouraged to read through the
+						infoset definitions for each property, as well. The infoset definitions
+						describe, in some cases, how items are compiled in the absence of explicit
+						information in the manifest.</p>
 				</section>
 
 				<section id="manifest-relative-urls">
 					<h4>Relative URLs</h4>
 
 					<p>
-						<a href="https://url.spec.whatwg.org/#relative-url-string">Relative URL strings</a> MAY be used
-						in the manifest. These URLs are resolved into <a
-							href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL strings</a> using a <a
-							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a>&#160;[[!url]]. </p>
+						<a href="https://url.spec.whatwg.org/#relative-url-string">Relative URL
+							strings</a> MAY be used in the manifest. These URLs are resolved into <a
+							href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL
+							strings</a> using a <a
+							href="https://url.spec.whatwg.org/#concept-base-url">base
+						URL</a>&#160;[[!url]]. </p>
 
 					<p>The base URL for relative URLs is determined as follows:</p>
 
 					<ul>
-						<li>In the case of an <a href="#manifest-embedding">embedded manifest</a>, it is the <a
-								href="https://www.w3.org/TR/html/infrastructure.html#document-base-url">document base
-								URL</a>&#160;[[!html]] of the <a>primary entry page</a> of the Web Publication;</li>
-						<li>In the case of a <a href="#wp-linking">linked manifest</a>, it is URL of the manifest
-							resource.</li>
+						<li>In the case of an <a href="#manifest-embedding">embedded manifest</a>,
+							it is the <a
+								href="https://www.w3.org/TR/html/infrastructure.html#document-base-url"
+								>document base URL</a>&#160;[[!html]] of the <a>primary entry
+								page</a> of the Web Publication;</li>
+						<li>In the case of a <a href="#wp-linking">linked manifest</a>, it is URL of
+							the manifest resource.</li>
 					</ul>
 
-					<p>For embedded manifests, this means that relative URLs are resolved against the URL of the primary
-						entry page <em>unless</em> the page declares a base direction (i.e., in a <a
+					<p>For embedded manifests, this means that relative URLs are resolved against
+						the URL of the primary entry page <em>unless</em> the page declares a base
+						direction (i.e., in a <a
 							href="https://www.w3.org/TR/html/document-metadata.html#the-base-element"
 								><code>&lt;base&gt;</code> element</a> in its header or via an <a
 							href="https://www.w3.org/TR/html/dom.html#the-xmlbase-attribute-xml-only"
@@ -558,12 +618,13 @@
 						href="https://www.w3.org/TR/html5/semantics-scripting.html#the-script-element"
 							><code>script</code> element</a>&#160;[[!html]].</p>
 
-				<p>When embedding a manifest, the <code>type</code> attribute of the containing <code>script</code>
-					element MUST be set to <code>application/ld+json</code>.</p>
+				<p>When embedding a manifest, the <code>type</code> attribute of the containing
+						<code>script</code> element MUST be set to
+					<code>application/ld+json</code>.</p>
 
-				<p>Additionally, the <code>script</code> element MUST include a unique identifier in an <code>id</code>
-					attribute&#160;[[!html]]. This identifier ensures that the manifest <a href="#wp-linking">can be
-						referenced</a>.</p>
+				<p>Additionally, the <code>script</code> element MUST include a unique identifier in
+					an <code>id</code> attribute&#160;[[!html]]. This identifier ensures that the
+					manifest <a href="#wp-linking">can be referenced</a>.</p>
 
 				<pre class="example" title="A Web Publication Manifest included in an HTML document">
 &lt;script id="example_manifest" type="application/ld+json"&gt;
@@ -577,23 +638,25 @@
 			<section id="wp-linking">
 				<h2>Linking to a Manifest</h2>
 
-				<p>Resources SHOULD provide a link to the manifest of the Web Publication to which they belong to enable
-					discovery. Links MUST take one or both of the following forms:</p>
+				<p>Resources SHOULD provide a link to the manifest of the Web Publication to which
+					they belong to enable discovery. Links MUST take one or both of the following
+					forms:</p>
 
 				<ul>
-					<li><p>An HTTP <code>Link</code> header field&#160;[[!rfc5988]] with its <code>rel</code> parameter
-							set to the value "<code>publication</code>".</p>
+					<li><p>An HTTP <code>Link</code> header field&#160;[[!rfc5988]] with its
+								<code>rel</code> parameter set to the value
+								"<code>publication</code>".</p>
 						<pre class="example">Link: &lt;https://example.com/webpub/manifest>; rel=publication</pre>
 					</li>
-					<li><p>A <code>link</code> element&#160;[[!html]] with its <code>rel</code> attribute set to the
-							value "<code>publication</code>".</p>
+					<li><p>A <code>link</code> element&#160;[[!html]] with its <code>rel</code>
+							attribute set to the value "<code>publication</code>".</p>
 						<pre class="example">&lt;link href="https://example.com/webpub/manifest" rel="publication"/></pre>
 					</li>
 				</ul>
 
-				<p>When a manifest is embedded within an HTML document, the link MUST include a fragment identifier that
-					references the <code>script</code> element that contains the manifest (see <a
-						href="#manifest-embedding"></a>). </p>
+				<p>When a manifest is embedded within an HTML document, the link MUST include a
+					fragment identifier that references the <code>script</code> element that
+					contains the manifest (see <a href="#manifest-embedding"></a>). </p>
 
 				<pre class="example" title="Link to a manifest within the same HTML resource">
 	&lt;link href="#example_manifest" rel="publication"&gt;
@@ -606,67 +669,77 @@
 	&lt;/script&gt;
 </pre>
 
-				<p class="issue" data-number="132">The exact value of <code>rel</code> is still to be agreed upon and
-					should be registered by IANA.</p>
+				<p class="issue" data-number="132">The exact value of <code>rel</code> is still to
+					be agreed upon and should be registered by IANA.</p>
 
-				<p class="ednote">The following details might be moved to the lifecycle section in a future draft.</p>
+				<p class="ednote">The following details might be moved to the lifecycle section in a
+					future draft.</p>
 
-				<p>When a resource links to multiple manifests, a user agent MAY choose to present one or more
-					alternatives to the end user, or choose a single alternative on its own. The user agent MAY choose
-					to present any manifest based upon information that it possesses, even one that is not explicitly
-					listed as a parent (e.g., based upon information it calculates or acquires out of band). In the
-					absence of a preference by user agent implementers, selection of the first manifest listed is
-					suggested as a default.</p>
+				<p>When a resource links to multiple manifests, a user agent MAY choose to present
+					one or more alternatives to the end user, or choose a single alternative on its
+					own. The user agent MAY choose to present any manifest based upon information
+					that it possesses, even one that is not explicitly listed as a parent (e.g.,
+					based upon information it calculates or acquires out of band). In the absence of
+					a preference by user agent implementers, selection of the first manifest listed
+					is suggested as a default.</p>
 
 			</section>
 
 			<section id="wp-resources">
 				<h2>Resources</h2>
 
-				<p>A <a>Web Publication</a> MUST include at least one <abbr title="Hypertext Markup Language"
-						>HTML</abbr> document&#160;[[!html]] that <a href="#wp-linking">links to the manifest</a>. This
-					page is referred to as the <dfn>primary entry page</dfn> of the Web Publication.</p>
+				<p>A <a>Web Publication</a> MUST include at least one <abbr
+						title="Hypertext Markup Language">HTML</abbr> document&#160;[[!html]] that
+						<a href="#wp-linking">links to the manifest</a>. This page is referred to as
+					the <dfn>primary entry page</dfn> of the Web Publication.</p>
 
-				<p> The manifest may be <a href="#manifest-embedding">embedded</a> into the <a>primary entry page</a>;
-					in this case the link element MUST use a relative URL to refer to the manifest. </p>
+				<p> The manifest may be <a href="#manifest-embedding">embedded</a> into the
+						<a>primary entry page</a>; in this case the link element MUST use a relative
+					URL to refer to the manifest. </p>
 
-				<p> The manifest itself MUST NOT include a reference to itself, i.e., the reference to the manifest MUST
-					NOT appear as part of the <a href="#resource-categorization-properties"></a>. </p>
+				<p> The manifest itself MUST NOT include a reference to itself, i.e., the reference
+					to the manifest MUST NOT appear as part of the <a
+						href="#resource-categorization-properties"></a>. </p>
 
-				<p>There are no restrictions on a Web Publication beyond this requirement. The Web Publication MAY
-					include references to resources of any media type, both in the <a>default reading order</a> and as
-					dependencies of other resources.</p>
+				<p>There are no restrictions on a Web Publication beyond this requirement. The Web
+					Publication MAY include references to resources of any media type, both in the
+						<a>default reading order</a> and as dependencies of other resources.</p>
 
-				<p class="note">When adding resources to a Web Publication, consider support in user agents. The use of
-					progressive enhancement techniques and the provision of fallback content, as appropriate, will
-					ensure a more consistent reading experience for users regardless of their preferred user agent.</p>
+				<p class="note">When adding resources to a Web Publication, consider support in user
+					agents. The use of progressive enhancement techniques and the provision of
+					fallback content, as appropriate, will ensure a more consistent reading
+					experience for users regardless of their preferred user agent.</p>
 			</section>
 
 			<section id="wp-table-of-contents">
 				<h3>Table of Contents</h3>
 
-				<p>The table of contents provides a hierarchical list of links that reflects the structural outline of
-					the major sections of the Web Publication.</p>
+				<p>The table of contents provides a hierarchical list of links that reflects the
+					structural outline of the major sections of the Web Publication.</p>
 
-				<p>The table of contents is expressed via an HTML element in one of the <a href="#wp-resources"
-						>resources</a> (typically a <code>nav</code> element&#160;[[!html]]). This element MUST be
-					identified by the <code>role</code> attribute&#160;[[!html]] value
-					"<code>doc-toc</code>"&#160;[[!dpub-aria-1.0]], and MUST be the first element in the document so
-					designated.</p>
+				<p>The table of contents is expressed via an HTML element in one of the <a
+						href="#wp-resources">resources</a> (typically a <code>nav</code>
+					element&#160;[[!html]]). This element MUST be identified by the
+						<code>role</code> attribute&#160;[[!html]] value
+					"<code>doc-toc</code>"&#160;[[!dpub-aria-1.0]], and MUST be the first element in
+					the document so designated.</p>
 
-				<p>The table of contents SHOULD be located in the <a>primary entry page</a> of the Web Publication. If
-					not, the manifest SHOULD <a href="#table-of-contents-manifest">identify the resource</a> that
-					contains the structure.</p>
+				<p>The table of contents SHOULD be located in the <a>primary entry page</a> of the
+					Web Publication. If not, the manifest SHOULD <a
+						href="#table-of-contents-manifest">identify the resource</a> that contains
+					the structure.</p>
 
-				<p>There are no requirements on the table of contents itself, except that, when specified, it MUST
-					include a link to at least one <a href="#wp-resources">resource</a>.</p>
+				<p>There are no requirements on the table of contents itself, except that, when
+					specified, it MUST include a link to at least one <a href="#wp-resources"
+						>resource</a>.</p>
 
-				<p>Refer to the <a href="#table-of-contents">table of contents property definition</a> for more
-					information on how to identify in the infoset and manifest which resource contains the table of
-					contents.</p>
+				<p>Refer to the <a href="#table-of-contents">table of contents property
+						definition</a> for more information on how to identify in the infoset and
+					manifest which resource contains the table of contents.</p>
 
 				<p class="issue" data-number="276"></p>
-				<p class="issue" data-number="291">Do we need a more detailed definition for the HTML TOC format?</p>
+				<p class="issue" data-number="291">Do we need a more detailed definition for the
+					HTML TOC format?</p>
 			</section>
 		</section>
 		<section id="wp-properties">
@@ -675,68 +748,76 @@
 			<section id="properties-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>Both the Web Publication infoset and manifest are defined by a common set of properties that describe
-					the basic information a user agent requires to process and render a Web Publication. These
-					properties are categorized as followed:</p>
+				<p>Both the Web Publication infoset and manifest are defined by a common set of
+					properties that describe the basic information a user agent requires to process
+					and render a Web Publication. These properties are categorized as followed:</p>
 
 				<dl>
 					<dt><a href="#descriptive-properties">descriptive properties</a></dt>
 					<dd>
-						<p>Descriptive properties describe aspects of a Web Publication, such as its <a href="#wptitle"
-								>title</a>, <a href="#creators">creator</a>, and <a href="#language-and-dir"
-								>language</a>. These properties are primarily drawn from <a href="https://schema.org"
-								>Schema.org</a> and its <a href="https://schema.org/docs/schemas.html">hosted
-								extensions</a>&#160;[[schema.org]], so they map to one or several Schema.org properties
-							and inherit their syntax and semantics. (The following property categories typically do not
-							have Schema.org equivalents, so are defined specifically for Web Publications.)</p>
+						<p>Descriptive properties describe aspects of a Web Publication, such as its
+								<a href="#wptitle">title</a>, <a href="#creators">creator</a>, and
+								<a href="#language-and-dir">language</a>. These properties are
+							primarily drawn from <a href="https://schema.org">Schema.org</a> and its
+								<a href="https://schema.org/docs/schemas.html">hosted
+							extensions</a>&#160;[[schema.org]], so they map to one or several
+							Schema.org properties and inherit their syntax and semantics. (The
+							following property categories typically do not have Schema.org
+							equivalents, so are defined specifically for Web Publications.)</p>
 					</dd>
-					<dt><a href="#resource-categorization-properties">resource categorization</a></dt>
+					<dt><a href="#resource-categorization-properties">resource
+						categorization</a></dt>
 					<dd>
-						<p>Resource categorization properties describe or identify common sets of resources, such as the
-								<a href="#resource-list">resource list</a> and <a href="#default-reading-order">default
-								reading order</a>. These properties refer to one or more external resources (images,
-							script files, separate metadata files, etc.).</p>
+						<p>Resource categorization properties describe or identify common sets of
+							resources, such as the <a href="#resource-list">resource list</a> and <a
+								href="#default-reading-order">default reading order</a>. These
+							properties refer to one or more external resources (images, script
+							files, separate metadata files, etc.).</p>
 					</dd>
 					<dt><a href="#informative-properties">informative properties</a></dt>
 					<dd>
-						<p>Informative properties identify resources that contain additional information about the Web
-							Publication, such as its <a href="#privacy-policy">privacy policy</a> or an <a
+						<p>Informative properties identify resources that contain additional
+							information about the Web Publication, such as its <a
+								href="#privacy-policy">privacy policy</a> or an <a
 								href="#accessibility-report">accessibility report</a>.</p>
 					</dd>
 					<dt><a href="#structural-properties">structural properties</a></dt>
 					<dd>
-						<p>Structural properties identify key meta structures of the Web Publication, such as the <a
-								href="#cover">cover image</a> or the the location of the <a href="#table-of-contents"
-								>table of contents</a>.</p>
+						<p>Structural properties identify key meta structures of the Web
+							Publication, such as the <a href="#cover">cover image</a> or the the
+							location of the <a href="#table-of-contents">table of contents</a>.</p>
 					</dd>
 				</dl>
 
 
-				<p class="note">The categorization of properties is done to simplify comprehension of their purpose; the
-					groupings have no relevance outside this specification (i.e., the groupings do not exist in the
-					infoset or manifest).</p>
+				<p class="note">The categorization of properties is done to simplify comprehension
+					of their purpose; the groupings have no relevance outside this specification
+					(i.e., the groupings do not exist in the infoset or manifest).</p>
 
 
 				<div class="note">
-					<p>Each manifest item drawn from schema.org identifies the property it maps to and includes its
-						defining type in parentheses. Properties are often available in many types, however, as a result
-						of the schema.org inheritance model. Refer to each property definition for more detailed
-						information about where it is valid to use.</p>
+					<p>Each manifest item drawn from schema.org identifies the property it maps to
+						and includes its defining type in parentheses. Properties are often
+						available in many types, however, as a result of the schema.org inheritance
+						model. Refer to each property definition for more detailed information about
+						where it is valid to use.</p>
 
-					<p>Schema.org additionally includes a large number of properties that, though relevant for
-						publishing, are not mentioned in this specification &#8212; Web Publication authors can use any
-						of these properties. This document defines only the minimal set of infoset items.</p>
+					<p>Schema.org additionally includes a large number of properties that, though
+						relevant for publishing, are not mentioned in this specification &#8212; Web
+						Publication authors can use any of these properties. This document defines
+						only the minimal set of infoset items.</p>
 				</div>
 
-				<p class="ednote">There are discussion on whether a best practices document would be created, referring
-					to more schema.org terms. If so, it should be linked from here. </p>
+				<p class="ednote">There are discussion on whether a best practices document would be
+					created, referring to more schema.org terms. If so, it should be linked from
+					here. </p>
 			</section>
 
 			<section id="wp-properties-req">
 				<h3>Requirements</h3>
 
-				<p>The requirements for the expression of Web Publication properties are defined by the <abbr
-						title="information set"><a>infoset</a></abbr> as follows:</p>
+				<p>The requirements for the expression of Web Publication properties are defined by
+					the <abbr title="information set"><a>infoset</a></abbr> as follows:</p>
 
 				<dl>
 					<dt>REQUIRED:</dt>
@@ -761,16 +842,18 @@
 							<li><a href="#last-modification-date">last modification date</a></li>
 							<li><a href="#publication-date">publication date</a></li>
 							<li><a href="#privacy-policy">privacy policy</a></li>
-							<li><a href="#reading-progression-direction">reading progression direction</a></li>
+							<li><a href="#reading-progression-direction">reading progression
+									direction</a></li>
 							<li><a href="#table-of-contents">table of contents</a></li>
 							<li><a href="#wptitle">title</a></li>
 						</ul>
 					</dd>
 				</dl>
 
-				<p>As the infoset properties do not all have to be serialized in the manifest, the requirements for the
-					manifest will differ in some cases. Refer to each property's definition to determine whether it is
-					required in the manifest or can be compiled from other information.</p>
+				<p>As the infoset properties do not all have to be serialized in the manifest, the
+					requirements for the manifest will differ in some cases. Refer to each
+					property's definition to determine whether it is required in the manifest or can
+					be compiled from other information.</p>
 			</section>
 
 			<section id="descriptive-properties">
@@ -779,16 +862,18 @@
 				<section id="accessibility">
 					<h4>Accessibility</h4>
 
-					<p>The accessibility properties provides information about the suitability of a <a>Web
-							Publication</a> for consumption by users with varying preferred reading modalities. These
-						properties typically supplement an evaluation against established accessibility criteria, such
-						as those provided in [[WCAG20]]. (For linking to a detailed accessibility report, see <a
+					<p>The accessibility properties provides information about the suitability of a
+							<a>Web Publication</a> for consumption by users with varying preferred
+						reading modalities. These properties typically supplement an evaluation
+						against established accessibility criteria, such as those provided in
+						[[WCAG20]]. (For linking to a detailed accessibility report, see <a
 							href="#accessibility-report"></a>.)</p>
 
 					<section id="accessibility-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The following infoset items are categorized as accessibility properties:</p>
+						<p>The following infoset items are categorized as accessibility
+							properties:</p>
 
 						<ul>
 							<li>accessMode</li>
@@ -800,9 +885,10 @@
 							<li>accessibilitySummary</li>
 						</ul>
 
-						<p>The more detailed descriptions of these properties, as well as the possible values, are
-							described on the <a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas Wiki
-								site</a>.</p>
+						<p>The more detailed descriptions of these properties, as well as the
+							possible values, are described on the <a
+								href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas
+								Wiki site</a>.</p>
 
 					</section>
 
@@ -823,105 +909,116 @@
 									<td>
 										<code>accessMode</code>
 									</td>
-									<td> The human sensory perceptual system or cognitive faculty through which a person
-										may process or perceive information. </td>
+									<td> The human sensory perceptual system or cognitive faculty
+										through which a person may process or perceive information. </td>
 									<td> One or more text(s). <a
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>
-										<a href="https://meta.schema.org/accessMode"><code>accessMode</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+										<a href="https://meta.schema.org/accessMode"
+												><code>accessMode</code></a> (<a
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>accessModeSufficient</code>
 									</td>
-									<td> A list of single or combined accessModes that are sufficient to understand all
-										the intellectual content of a resource. </td>
+									<td> A list of single or combined accessModes that are
+										sufficient to understand all the intellectual content of a
+										resource. </td>
 									<td> One or more texts, each a comma-separated list of terms. <a
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>
 										<a href="https://meta.schema.org/accessModeSufficient"
 												><code>accessModeSufficient</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>accessibilityAPI</code>
 									</td>
-									<td>Indicates that the resource is compatible with the referenced accessibility
-										APIs. </td>
+									<td>Indicates that the resource is compatible with the
+										referenced accessibility APIs. </td>
 									<td>One or more text(s).<a
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>
-										<a href="https://schema.org/accessibilityAPI"><code>accessibilityAPI</code></a>
-											(<a href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+										<a href="https://schema.org/accessibilityAPI"
+												><code>accessibilityAPI</code></a> (<a
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>accessibilityControl</code>
 									</td>
-									<td>Identifies input methods that are sufficient to fully control the described
-										resource. </td>
+									<td>Identifies input methods that are sufficient to fully
+										control the described resource. </td>
 									<td> One or more text(s). <a
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>
 										<a href="https://meta.schema.org/accessibilityControl"
 												><code>accessibilityControl</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>accessibilityFeature</code>
 									</td>
-									<td> Content features of the resource, such as accessible media, alternatives and
-										supported enhancements for accessibility. </td>
+									<td> Content features of the resource, such as accessible media,
+										alternatives and supported enhancements for accessibility. </td>
 									<td> One or more text(s). <a
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>
 										<a href="https://meta.schema.org/accessibilityFeature"
 												><code>accessibilityFeature</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>accessibilityHazard</code>
 									</td>
-									<td> A characteristic of the described resource that is physiologically dangerous to
-										some users. </td>
+									<td> A characteristic of the described resource that is
+										physiologically dangerous to some users. </td>
 									<td> One or more text(s).<a
 											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
 											>Expected values</a>. </td>
 									<td>
 										<a href="https://meta.schema.org/accessibilityHazard"
 												><code>accessibilityHazard</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>accessibilitySummary</code>
 									</td>
-									<td>A human-readable summary of specific accessibility features or deficiencies,
-										consistent with the other accessibility metadata but expressing subtleties such
-										as “short descriptions are present but long descriptions will be needed for
-										non-visual users” or “short descriptions are present and no long descriptions
-										are needed.” </td>
+									<td>A human-readable summary of specific accessibility features
+										or deficiencies, consistent with the other accessibility
+										metadata but expressing subtleties such as “short
+										descriptions are present but long descriptions will be
+										needed for non-visual users” or “short descriptions are
+										present and no long descriptions are needed.” </td>
 									<td>Text.</td>
 									<td>
 										<a href="https://meta.schema.org/accessibilitySummary"
 												><code>accessibilitySummary</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 							</tbody>
 						</table>
 
 						<p>Note that the author MAY also provide a reference to a more detailed <a
-								href="#accessibility-report-manifest">Accessibility Report</a>, beyond the accessibility
-							information expressed by these properties.</p>
+								href="#accessibility-report-manifest">Accessibility Report</a>,
+							beyond the accessibility information expressed by these properties.</p>
 
 						<pre class="example" title="Example for accessiblity metadata of a purely textual document">
 {
@@ -942,33 +1039,38 @@
 					<h4>Address</h4>
 
 					<p>A <a>Web Publication's</a>
-						<dfn>address</dfn> is a <abbr title="Uniform Resource Locator">URL</abbr>&#160;[[!url]] that
-						represents the <a>primary entry page</a> for the Web Publication.</p>
+						<dfn>address</dfn> is a <abbr title="Uniform Resource Locator"
+						>URL</abbr>&#160;[[!url]] that represents the <a>primary entry page</a> for
+						the Web Publication.</p>
 
 					<section id="address-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>If the address does not resolve to an <abbr title="Hypertext Markup Language">HTML</abbr>
-							document&#160;[[!html]], user agents SHOULD NOT provide access to it to users. A Web
-							Publication MAY have more than one address, but all the addresses MUST resolve to the same
-							document.</p>
+						<p>If the address does not resolve to an <abbr
+								title="Hypertext Markup Language">HTML</abbr>
+							document&#160;[[!html]], user agents SHOULD NOT provide access to it to
+							users. A Web Publication MAY have more than one address, but all the
+							addresses MUST resolve to the same document.</p>
 
-						<p>The referenced document SHOULD be a resource of the Web Publication. It can be any resource,
-							including one that is not listed in the <a>default reading order</a>. This document MUST
-							include a <a href="#wp-linking">link to the manifest</a> to ensure a bidirectional linking
-							relationship (i.e., that user agents can also locate the manifest from the document at the
-							address).</p>
+						<p>The referenced document SHOULD be a resource of the Web Publication. It
+							can be any resource, including one that is not listed in the <a>default
+								reading order</a>. This document MUST include a <a
+								href="#wp-linking">link to the manifest</a> to ensure a
+							bidirectional linking relationship (i.e., that user agents can also
+							locate the manifest from the document at the address).</p>
 
-						<p>If the document is not a Web Publication resource, user agents SHOULD load the first document
-							in the <a>default reading order</a> when initiating the Web Publication.</p>
+						<p>If the document is not a Web Publication resource, user agents SHOULD
+							load the first document in the <a>default reading order</a> when
+							initiating the Web Publication.</p>
 
-						<p class="note"> To improve the usability of Web Publications, particularly in user agents that
-							do not support Web Publications, authors are encouraged to include navigation aids in the
-							referenced document that facilitate consumption of the content, (e.g., provide a table of
+						<p class="note"> To improve the usability of Web Publications, particularly
+							in user agents that do not support Web Publications, authors are
+							encouraged to include navigation aids in the referenced document that
+							facilitate consumption of the content, (e.g., provide a table of
 							contents or a link to one). </p>
 
-						<div class="note">The Web Publication's address can also be used as value for an identifier link
-							relation&#160;[[link-relation]].</div>
+						<div class="note">The Web Publication's address can also be used as value
+							for an identifier link relation&#160;[[link-relation]].</div>
 					</section>
 
 					<section id="address-manifest">
@@ -1013,20 +1115,23 @@
 					<h4>Canonical Identifier</h4>
 
 					<p>A <a>Web Publication's</a>
-						<dfn>canonical identifier</dfn> is a unique identifier that resolves to the preferred version of
-						the Web Publication.</p>
+						<dfn>canonical identifier</dfn> is a unique identifier that resolves to the
+						preferred version of the Web Publication.</p>
 
-					<p class="note">Ensuring uniqueness of canonical identifiers is outside the scope of this
-						specification. The actual achievable uniqueness depends on such factors as the conventions of
-						the identifier scheme used and the degree of control over assignment of identifiers.</p>
+					<p class="note">Ensuring uniqueness of canonical identifiers is outside the
+						scope of this specification. The actual achievable uniqueness depends on
+						such factors as the conventions of the identifier scheme used and the degree
+						of control over assignment of identifiers.</p>
 
-					<p>The canonical identifier is intended to provide a measure of permanence above and beyond the Web
-						Publication's <a href="#address">address(es)</a>. If a Web Publication is permanently relocated
-						to a new URL, for example, the canonical identifier provides a way of discovering the new
-						location (e.g., a <abbr title="Digital Object Identifier">DOI</abbr> registry could be updated
-						with the new <abbr title="Uniform Resource Locator">URL</abbr>, or a redirect could be added to
-						the <abbr title="Uniform Resource Locator">URL</abbr> of the canonical identifier). It is also
-						intended to provide a means of identifying instances of the same Web Publication hosted at
+					<p>The canonical identifier is intended to provide a measure of permanence above
+						and beyond the Web Publication's <a href="#address">address(es)</a>. If a
+						Web Publication is permanently relocated to a new URL, for example, the
+						canonical identifier provides a way of discovering the new location (e.g., a
+							<abbr title="Digital Object Identifier">DOI</abbr> registry could be
+						updated with the new <abbr title="Uniform Resource Locator">URL</abbr>, or a
+						redirect could be added to the <abbr title="Uniform Resource Locator"
+							>URL</abbr> of the canonical identifier). It is also intended to provide
+						a means of identifying instances of the same Web Publication hosted at
 						different URLs.</p>
 
 					<section id="canonical-identifier-infoset">
@@ -1034,19 +1139,22 @@
 
 						<p>The canonical identifier MUST be a URL&#160;[[!url]].</p>
 
-						<p>If a URL is not provided in the manifest, or the value is an invalid URL, the Web Publication
-							does not have a canonical identifier. User agents MUST NOT attempt to construct a canonical
-							identifier from any other identifiers provided in the manifest.</p>
+						<p>If a URL is not provided in the manifest, or the value is an invalid URL,
+							the Web Publication does not have a canonical identifier. User agents
+							MUST NOT attempt to construct a canonical identifier from any other
+							identifiers provided in the manifest.</p>
 
-						<p class="note">The canonical identifier can be used as the target of a "canonical"
-							link&#160;[[rfc6596]] (e.g., a <code>link</code> element&#160;[[html]] whose
-								<code>rel</code> attribute has the value <code>canonical</code> or an <abbr
+						<p class="note">The canonical identifier can be used as the target of a
+							"canonical" link&#160;[[rfc6596]] (e.g., a <code>link</code>
+							element&#160;[[html]] whose <code>rel</code> attribute has the value
+								<code>canonical</code> or an <abbr
 								title="Hypertext Transfer Protocol">HTTP</abbr>
-							<code>Link</code> header field&#160;[[rfc5988]] similarly identified).</p>
+							<code>Link</code> header field&#160;[[rfc5988]] similarly
+							identified).</p>
 
-						<p class="issue" data-number="58">Is a canonical identifier necessary to call out explicitly in
-							the <abbr title="information set">infoset</abbr>, or can it be handled by other
-							metadata.</p>
+						<p class="issue" data-number="58">Is a canonical identifier necessary to
+							call out explicitly in the <abbr title="information set">infoset</abbr>,
+							or can it be handled by other metadata.</p>
 					</section>
 
 					<section id="canonical-identifier-manifest">
@@ -1073,10 +1181,11 @@
 							</tbody>
 						</table>
 
-						<p>The specification of the canonical identifier MAY be complemented by the inclusion of
-							additional types of identifiers for the Web Publication using the <a
-								href="https://schema.org/identifier"><code>identifier</code>
-							property</a>&#160;[[!schema.org]] and/or its subtypes.</p>
+						<p>The specification of the canonical identifier MAY be complemented by the
+							inclusion of additional types of identifiers for the Web Publication
+							using the <a href="https://schema.org/identifier"
+									><code>identifier</code> property</a>&#160;[[!schema.org]]
+							and/or its subtypes.</p>
 
 						<pre class="example" title="Example for setting both the canonical identifier as URL and the address of the same document">
 {
@@ -1107,19 +1216,21 @@
 					<h4>Creators</h4>
 
 
-					<p> A <dfn>creator</dfn> is an individual or entity responsible for the creation of the <a>Web
-							Publication</a>. Creators are represented in one of the following two ways:</p>
+					<p> A <dfn>creator</dfn> is an individual or entity responsible for the creation
+						of the <a>Web Publication</a>. Creators are represented in one of the
+						following two ways:</p>
 
 					<ol>
 						<li>as a string encoding the name of a Person; or</li>
-						<li>as an instance of a <a href="https://schema.org/Person"><code>Person</code></a> and <a
-								href="https://schema.org/Organization"><code>Organization</code></a> objects,
-							respectively. </li>
+						<li>as an instance of a <a href="https://schema.org/Person"
+									><code>Person</code></a> and <a
+								href="https://schema.org/Organization"><code>Organization</code></a>
+							objects, respectively. </li>
 					</ol>
 
-					<p>In other words, a single string value is a shorthand for a <code>Person</code> object whose
-							<code>name</code> property is set to that string value. (See also <a
-							href="#strings-vs-objects"></a>.)</p>
+					<p>In other words, a single string value is a shorthand for a
+							<code>Person</code> object whose <code>name</code> property is set to
+						that string value. (See also <a href="#strings-vs-objects"></a>.)</p>
 
 					<section id="wp-creator-infoset">
 						<h5>Infoset Requirements</h5>
@@ -1141,7 +1252,8 @@
 							<li>translator</li>
 						</ul>
 
-						<p>A Web Publication MAY have more than one of each of these types of creators.</p>
+						<p>A Web Publication MAY have more than one of each of these types of
+							creators.</p>
 					</section>
 
 					<section id="wp-creator-manifest">
@@ -1161,143 +1273,181 @@
 									<td>
 										<code>artist</code>
 									</td>
-									<td>The primary artist for the publication, in a medium other than pencils or
-										digital line art.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>The primary artist for the publication, in a medium other
+										than pencils or digital line art.</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a>.</td>
 									<td>
-										<a href="https://bib.schema.org/artist"><code>artist</code></a> (<a
-											href="https://www.schema.org/VisualArtwork">VisualArtwork</a>) </td>
+										<a href="https://bib.schema.org/artist"
+											><code>artist</code></a> (<a
+											href="https://www.schema.org/VisualArtwork"
+											>VisualArtwork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>author</code>
 									</td>
 									<td>The author of the publication.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
-											<a href="https://schema.org/Organization"
-										><code>Organization</code></a>.</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a> and/or <a
+											href="https://schema.org/Organization"
+												><code>Organization</code></a>.</td>
 									<td>
-										<a href="https://schema.org/author"><code>author</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+										<a href="https://schema.org/author"><code>author</code></a>
+											(<a href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>colorist</code>
 									</td>
 									<td>The individual who adds color to inked drawings.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a>.</td>
 									<td>
-										<a href="https://bib.schema.org/colorist"><code>colorist</code></a> (<a
-											href="https://www.schema.org/VisualArtwork">VisualArtwork</a>) </td>
+										<a href="https://bib.schema.org/colorist"
+												><code>colorist</code></a> (<a
+											href="https://www.schema.org/VisualArtwork"
+											>VisualArtwork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>contributor</code>
 									</td>
-									<td>Contributor whose role does not fit to one of the other roles in this
-										table.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
-											<a href="https://schema.org/Organization"
-										><code>Organization</code></a>.</td>
+									<td>Contributor whose role does not fit to one of the other
+										roles in this table.</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a> and/or <a
+											href="https://schema.org/Organization"
+												><code>Organization</code></a>.</td>
 									<td>
-										<a href="https://schema.org/contributor"><code>contributor</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+										<a href="https://schema.org/contributor"
+												><code>contributor</code></a> (<a
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>creator</code>
 									</td>
 									<td>The creator of the publication.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
-											<a href="https://schema.org/Organization"
-										><code>Organization</code></a>.</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a> and/or <a
+											href="https://schema.org/Organization"
+												><code>Organization</code></a>.</td>
 									<td>
-										<a href="https://schema.org/creator"><code>creator</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+										<a href="https://schema.org/creator"
+											><code>creator</code></a> (<a
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>editor</code>
 									</td>
 									<td>The editor of the publication.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a>.</td>
 									<td>
-										<a href="https://schema.org/editor"><code>editor</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+										<a href="https://schema.org/editor"><code>editor</code></a>
+											(<a href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>illustrator</code>
 									</td>
 									<td>The illustrator of the publication.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a>.</td>
 									<td>
-										<a href="https://schema.org/illustrator"><code>illustrator</code></a> (<a
+										<a href="https://schema.org/illustrator"
+												><code>illustrator</code></a> (<a
 											href="https://www.schema.org/Book">Book</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>inker</code>
 									</td>
-									<td>The individual who traces over the pencil drawings in ink.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>The individual who traces over the pencil drawings in
+										ink.</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a>.</td>
 									<td>
-										<a href="https://schema.org/inker"><code>inker</code></a> (<a
-											href="https://www.schema.org/VisualArtwork">VisualArtwork</a>) </td>
+										<a href="https://schema.org/inker"><code>inker</code></a>
+											(<a href="https://www.schema.org/VisualArtwork"
+											>VisualArtwork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>letterer</code>
 									</td>
-									<td>The individual who adds lettering, including speech balloons and sound effects,
-										to artwork.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>The individual who adds lettering, including speech balloons
+										and sound effects, to artwork.</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a>.</td>
 									<td>
-										<a href="https://bib.schema.org/letterer"><code>letterer</code></a> (<a
-											href="https://www.schema.org/VisualArtwork">VisualArtwork</a>) </td>
+										<a href="https://bib.schema.org/letterer"
+												><code>letterer</code></a> (<a
+											href="https://www.schema.org/VisualArtwork"
+											>VisualArtwork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>penciler</code>
 									</td>
 									<td>The individual who draws the primary narrative artwork.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a>.</td>
 									<td>
-										<a href="https://bib.schema.org/penciler"><code>penciler</code></a> (<a
-											href="https://www.schema.org/VisualArtwork">VisualArtwork</a>) </td>
+										<a href="https://bib.schema.org/penciler"
+												><code>penciler</code></a> (<a
+											href="https://www.schema.org/VisualArtwork"
+											>VisualArtwork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>publisher</code>
 									</td>
 									<td>The publisher of the publication.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
-											<a href="https://schema.org/Organization"
-										><code>Organization</code></a>.</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a> and/or <a
+											href="https://schema.org/Organization"
+												><code>Organization</code></a>.</td>
 									<td>
-										<a href="https://schema.org/publisher"><code>publisher</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+										<a href="https://schema.org/publisher"
+												><code>publisher</code></a> (<a
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 								<tr>
 									<td>
 										<code>readBy</code>
 									</td>
-									<td>A person who reads (performs) the publication (for audiobooks).</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>. </td>
+									<td>A person who reads (performs) the publication (for
+										audiobooks).</td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a>. </td>
 									<td>
-										<a href="https://bib.schema.org/readBy"><code>readBy</code></a> (<a
-											href="https://bib.schema.org/Audiobook">Audiobook</a>) </td>
+										<a href="https://bib.schema.org/readBy"
+											><code>readBy</code></a> (<a
+											href="https://bib.schema.org/Audiobook">Audiobook</a>)
+									</td>
 								</tr>
 								<tr>
 									<td>
 										<code>translator</code>
 									</td>
 									<td>The translator of the publication.</td>
-									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
-											<a href="https://schema.org/Organization"><code>Organization</code></a>. </td>
+									<td>One or more <a href="https://schema.org/Person"
+												><code>Person</code></a> and/or <a
+											href="https://schema.org/Organization"
+												><code>Organization</code></a>. </td>
 									<td>
-										<a href="https://bib.schema.org/translator"><code>translator</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+										<a href="https://bib.schema.org/translator"
+												><code>translator</code></a> (<a
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 							</tbody>
 						</table>
@@ -1353,97 +1503,110 @@
 				<section id="language-and-dir">
 					<h4>Language and Base Direction</h4>
 
-					<p>The <a>Web Publication</a> has a natural language value (e.g., English, French, Chinese), as well
-						as a natural base writing direction (left-to-right or right-to-left). The <abbr
-							title="information set"><a>infoset</a></abbr> has entries to set these values, which can
-						influence, for example, the behavior of a user agent (e.g., it might place a pop-up for a table
-						of contents on the right hand side for publications whose natural base direction is
-						right-to-left).</p>
+					<p>The <a>Web Publication</a> has a natural language value (e.g., English,
+						French, Chinese), as well as a natural base writing direction (left-to-right
+						or right-to-left). The <abbr title="information set"><a>infoset</a></abbr>
+						has entries to set these values, which can influence, for example, the
+						behavior of a user agent (e.g., it might place a pop-up for a table of
+						contents on the right hand side for publications whose natural base
+						direction is right-to-left).</p>
 
-					<p>Similarly, each natural language property value in the <a>Web Publication's</a>
-						<abbr title="information set"><a>infoset</a></abbr> (e.g., <a href="#wptitle">title</a>, <a
-							href="#creators">creators</a>) is <a
+					<p>Similarly, each natural language property value in the <a>Web
+							Publication's</a>
+						<abbr title="information set"><a>infoset</a></abbr> (e.g., <a
+							href="#wptitle">title</a>, <a href="#creators">creators</a>) is <a
 							href="https://w3c.github.io/string-meta/#dom-localizable"
-						>localizable</a>&#160;[[string-meta]], meaning that the same information is available for
-						each.</p>
+							>localizable</a>&#160;[[string-meta]], meaning that the same information
+						is available for each.</p>
 
-					<p>As a result, the <abbr title="information set"><a>infoset</a></abbr> has entries to set:</p>
+					<p>As a result, the <abbr title="information set"><a>infoset</a></abbr> has
+						entries to set:</p>
 
 					<ul>
 						<li>the natural <dfn>language</dfn>, and </li>
 						<li>the <dfn>base direction</dfn> (the display direction for the value)</li>
 					</ul>
 
-					<p>of both the <a>Web Publication</a> and the natural language properties values of the <abbr
-							title="information set"><a>infoset</a></abbr>.</p>
+					<p>of both the <a>Web Publication</a> and the natural language properties values
+						of the <abbr title="information set"><a>infoset</a></abbr>.</p>
 
 
 					<section id="language-and-dir-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The <abbr title="information set">infoset</abbr> MAY contain global language and base
-							direction declarations for the Web Publication. The natural language MUST be a tag that
-							conforms to&#160;[[!bcp47]], while the base language direction MUST have one of the
-							following values: </p>
+						<p>The <abbr title="information set">infoset</abbr> MAY contain global
+							language and base direction declarations for the Web Publication. The
+							natural language MUST be a tag that conforms to&#160;[[!bcp47]], while
+							the base language direction MUST have one of the following values: </p>
 
 						<ul>
-							<li><code>ltr</code>: indicates that the textual values are explicitly directionally set to
-								left-to-right text;</li>
-							<li><code>rtl</code>: indicates that the textual values are explicitly directionally set to
-								right-to-left text;</li>
-							<li><code>auto</code>: indicates that the textual values are explicitly directionally set to
-								the direction of the first character with a strong directionality.</li>
+							<li><code>ltr</code>: indicates that the textual values are explicitly
+								directionally set to left-to-right text;</li>
+							<li><code>rtl</code>: indicates that the textual values are explicitly
+								directionally set to right-to-left text;</li>
+							<li><code>auto</code>: indicates that the textual values are explicitly
+								directionally set to the direction of the first character with a
+								strong directionality.</li>
 						</ul>
 
-						<p>When specified, these properties are also used as defaults for textual values in the <abbr
-								title="information set">infoset</abbr>.</p>
+						<p>When specified, these properties are also used as defaults for textual
+							values in the <abbr title="information set">infoset</abbr>.</p>
 
-						<p class="note">It is important to differentiate the language <em>of the publication</em> from
-							the language and the base direction of the individual resources that compose it. If such
-							resources are, for example, in HTML, the language and direction need to be set in those
-							resources, too. The language and base direction of the publication are not inherited.</p>
+						<p class="note">It is important to differentiate the language <em>of the
+								publication</em> from the language and the base direction of the
+							individual resources that compose it. If such resources are, for
+							example, in HTML, the language and direction need to be set in those
+							resources, too. The language and base direction of the publication are
+							not inherited.</p>
 
-						<p>The global language information MAY be overridden by individual values.</p>
+						<p>The global language information MAY be overridden by individual
+							values.</p>
 
-						<p>When using Web Publication manifests with bidirectional text, user agents SHOULD identify the
-							base direction of any given natural language value by scanning the text for the first strong
-							directional character. Once the base direction has been identified, user agents MUST
-							determine the appropriate rendering and display of natural language values according to the
-							Unicode Bidirectional Algorithm&#160;[[!bidi]]. This could require wrapping additional
-							control characters or markup around the string prior to display, in order to apply the base
-							direction. (See <a href="#bidi-examples"></a>.) </p>
+						<p>When using Web Publication manifests with bidirectional text, user agents
+							SHOULD identify the base direction of any given natural language value
+							by scanning the text for the first strong directional character. Once
+							the base direction has been identified, user agents MUST determine the
+							appropriate rendering and display of natural language values according
+							to the Unicode Bidirectional Algorithm&#160;[[!bidi]]. This could
+							require wrapping additional control characters or markup around the
+							string prior to display, in order to apply the base direction. (See <a
+								href="#bidi-examples"></a>.) </p>
 
-						<p class="issue"> This section, in particular the features related to text directions, must be
-							reviewed by I18N experts. </p>
+						<p class="issue"> This section, in particular the features related to text
+							directions, must be reviewed by I18N experts. </p>
 
-						<p>If the manifest is <a href="#manifest-embedding">embedded</a> in the primary entry page via a
-								<code>script</code> element, and the manifest does not set the global language and/or
-							the base direction (see <a href="#manifest-default-language-and-dir"></a>), the
-								<code>lang</code> and the <code>dir</code> attributes of the <code>script</code> element
-							are used as the global <a>language</a> and <a>base direction</a>, respectively (see the
-							details on handling the <a
+						<p>If the manifest is <a href="#manifest-embedding">embedded</a> in the
+							primary entry page via a <code>script</code> element, and the manifest
+							does not set the global language and/or the base direction (see <a
+								href="#manifest-default-language-and-dir"></a>), the
+								<code>lang</code> and the <code>dir</code> attributes of the
+								<code>script</code> element are used as the global <a>language</a>
+							and <a>base direction</a>, respectively (see the details on handling the
+								<a
 								href="https://www.w3.org/TR/html/dom.html#the-lang-and-xmllang-attributes"
 									><code>lang</code></a> and <a
-								href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"><code>dir</code></a>
-							attributes in&#160;[[!html]]).</p>
+								href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
+									><code>dir</code></a> attributes in&#160;[[!html]]).</p>
 
-						<p class="issue">It is to be discussed whether this last paragraph, i.e., inheriting values from
-								<code>script</code>, should be kept.</p>
+						<p class="issue">It is to be discussed whether this last paragraph, i.e.,
+							inheriting values from <code>script</code>, should be kept.</p>
 
-						<p>If a user agent requires the language and one is not available in the <abbr
-								title="information set">infoset</abbr> (globally, or specifically for that property), or
-							the obtained value is invalid, the user agent MAY attempt to determine the language. This
-							specification does not mandate how such a language tag is created. The user agent might:</p>
+						<p>If a user agent requires the language and one is not available in the
+								<abbr title="information set">infoset</abbr> (globally, or
+							specifically for that property), or the obtained value is invalid, the
+							user agent MAY attempt to determine the language. This specification
+							does not mandate how such a language tag is created. The user agent
+							might:</p>
 
 						<ul>
 							<li>use the <a>non-empty</a> language declaration of the manifest;</li>
-							<li>use the first non-empty language declaration found in a resource in the <a>default
-									reading order</a>;</li>
+							<li>use the first non-empty language declaration found in a resource in
+								the <a>default reading order</a>;</li>
 							<li>calculate the language using its own algorithm.</li>
 						</ul>
 
-						<p> No default values are specified for the <a>language</a> or the default <a>base
-							direction</a>. </p>
+						<p> No default values are specified for the <a>language</a> or the default
+								<a>base direction</a>. </p>
 
 					</section>
 
@@ -1451,8 +1614,8 @@
 					<section id="language-and-dir-manifest">
 						<h5>Manifest Expression</h5>
 
-						<p>As this infoset item refers to several aspects of setting language and direction, these are
-							treated separately. </p>
+						<p>As this infoset item refers to several aspects of setting language and
+							direction, these are treated separately. </p>
 
 						<section id="manifest-default-language-and-dir">
 							<h6>Global Language and Direction</h6>
@@ -1471,12 +1634,14 @@
 										<td>
 											<code>inLanguage</code>
 										</td>
-										<td>Default <a>language</a> for the <a>Web Publication</a> as well as the
-											textual infoset values</td>
+										<td>Default <a>language</a> for the <a>Web Publication</a>
+											as well as the textual infoset values</td>
 										<td>language code as defined in&#160;[[!bcp47]]</td>
 										<td>
-											<a href="https://schema.org/inLanguage"><code>inLanguage</code></a> (<a
-												href="https://www.schema.org/Property">Property</a>) </td>
+											<a href="https://schema.org/inLanguage"
+												><code>inLanguage</code></a> (<a
+												href="https://www.schema.org/Property">Property</a>)
+										</td>
 									</tr>
 								</tbody>
 								<tbody>
@@ -1484,27 +1649,34 @@
 										<td>
 											<code>inDirection</code>
 										</td>
-										<td>Default <a>base direction</a> for the <a>Web Publication</a> as well as the
-											textual infoset values</td>
-										<td><code>ltr</code>, <code>rtl</code>, or <code>auto</code></td>
+										<td>Default <a>base direction</a> for the <a>Web
+												Publication</a> as well as the textual infoset
+											values</td>
+										<td><code>ltr</code>, <code>rtl</code>, or
+											<code>auto</code></td>
 										<td>(None)</td>
 									</tr>
 								</tbody>
 							</table>
 
-							<p class="note">If authors intend to use a manifest, or a manifest template, both as
-								embedded manifest and as a separate resource, they are strongly encouraged to set these
-								properties explicitly to avoid interference of the containing <code>script</code>
-								element in case of embedding.</p>
+							<p class="note">If authors intend to use a manifest, or a manifest
+								template, both as embedded manifest and as a separate resource, they
+								are strongly encouraged to set these properties explicitly to avoid
+								interference of the containing <code>script</code> element in case
+								of embedding.</p>
 
 						</section>
 
 						<section id="manifest-specific-language-and-dir">
 							<h6>Item-specific Language</h6>
 
-							<p> 
-								It is possible to set the language for any textual value in the manifest. This information MUST be set as a <dfn data-lt="localizable text">localizable string</dfn>, i.e., using the <a href="https://www.w3.org/TR/2014/REC-json-ld-20140116/#string-internationalization"><code>@value</code> and <code>@language</code> keywords</a> (instead of a simple string)&#160;[[!json-ld]]: 
-							</p>
+							<p> It is possible to set the language for any textual value in the
+								manifest. This information MUST be set as a <dfn
+									data-lt="localizable text">localizable string</dfn>, i.e., using
+								the <a
+									href="https://www.w3.org/TR/2014/REC-json-ld-20140116/#string-internationalization"
+										><code>@value</code> and <code>@language</code> keywords</a>
+								(instead of a simple string)&#160;[[!json-ld]]: </p>
 
 							<pre class="example" title="Setting the author name to French using a localizable string">
 {
@@ -1520,11 +1692,16 @@
     }
 }
 </pre>
-							<p> The value of the language tag MUST be set to a language code as defined in [[!bcp47]]. </p>
+							<p> The value of the language tag MUST be set to a language code as
+								defined in [[!bcp47]]. </p>
 
-							<p>
-								When used in a context of localizable texts, a simple string value is a shorthand for a <a>localizable string</a>, with the <code>@value</code> set to the string value, and the language set to the value of the <a href="#manifest-default-language-and-dir"><code>inLanguage</code></a> property, if applicable, and unset otherwise. In other words, the previous example is equivalent to:
-							</p>
+							<p> When used in a context of localizable texts, a simple string value
+								is a shorthand for a <a>localizable string</a>, with the
+									<code>@value</code> set to the string value, and the language
+								set to the value of the <a href="#manifest-default-language-and-dir"
+										><code>inLanguage</code></a> property, if applicable, and
+								unset otherwise. In other words, the previous example is equivalent
+								to: </p>
 
 							<pre class="example" title="Setting the default language of an author name to French">
 {
@@ -1537,12 +1714,14 @@
 </pre>
 							<p>(See also <a href="#strings-vs-objects"></a>.)</p>
 
-							<p>It is <em>not</em> possible to set the direction explicitly for a value.</p>
+							<p>It is <em>not</em> possible to set the direction explicitly for a
+								value.</p>
 
-							<p class="note"> Setting the direction for a natural text value is currently not possible in
-								JSON-LD&#160;[[!json-ld]]. In case the JSON-LD community, as well as the schema.org
-								community, introduces such a feature, future versions of this specification may extend
-								the ability of Web Publication Manifests to include this. </p>
+							<p class="note"> Setting the direction for a natural text value is
+								currently not possible in JSON-LD&#160;[[!json-ld]]. In case the
+								JSON-LD community, as well as the schema.org community, introduces
+								such a feature, future versions of this specification may extend the
+								ability of Web Publication Manifests to include this. </p>
 						</section>
 					</section>
 				</section>
@@ -1550,17 +1729,19 @@
 				<section id="last-modification-date">
 					<h4>Last Modification Date</h4>
 
-					<p>The <dfn>last modification date</dfn> is the date when the <a>Web Publication</a> was last
-						updated (i.e., whenever changes were last made to any of the resources of the Web Publication,
-						including the <a>manifest</a>).</p>
+					<p>The <dfn>last modification date</dfn> is the date when the <a>Web
+							Publication</a> was last updated (i.e., whenever changes were last made
+						to any of the resources of the Web Publication, including the
+							<a>manifest</a>).</p>
 
 					<section id="last-modification-date-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The last modification date does not necessarily reflect all changes to the Web Publication
-							(e.g., third-party content could change without the author being aware). User agents SHOULD
-							check the last modification date of individual resources to determine if they have changed
-							and need updating.</p>
+						<p>The last modification date does not necessarily reflect all changes to
+							the Web Publication (e.g., third-party content could change without the
+							author being aware). User agents SHOULD check the last modification date
+							of individual resources to determine if they have changed and need
+							updating.</p>
 					</section>
 
 					<section id="last-modification-date-manifest">
@@ -1581,13 +1762,16 @@
 										<code>dateModified</code>
 									</td>
 									<td>Last modification date of the publication.</td>
-									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
-											href="https://schema.org/DateTime"><code>DateTime</code></a>
-										value&#160;[[!schema.org]], both expressed in ISO 8601 Date, or Date Time
-										formats, respectively [[iso8601]].</td>
+									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or
+											<a href="https://schema.org/DateTime"
+												><code>DateTime</code></a>
+										value&#160;[[!schema.org]], both expressed in ISO 8601 Date,
+										or Date Time formats, respectively [[iso8601]].</td>
 									<td>
-										<a href="https://schema.org/dateModified"><code>dateModified</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+										<a href="https://schema.org/dateModified"
+												><code>dateModified</code></a> (<a
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 							</tbody>
 						</table>
@@ -1610,16 +1794,18 @@
 				<section id="publication-date">
 					<h4>Publication Date</h4>
 
-					<p>The <dfn>publication date</dfn> is the date on which the <a>Web Publication</a> was originally
-						published. It represents a static event in the lifecycle of a Web Publication and allows
-						subsequent revisions to be identified and compared.</p>
+					<p>The <dfn>publication date</dfn> is the date on which the <a>Web
+							Publication</a> was originally published. It represents a static event
+						in the lifecycle of a Web Publication and allows subsequent revisions to be
+						identified and compared.</p>
 
 					<section id="publication-date-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The exact moment of publication is intentionally left open to interpretation: it could be
-							when the Web Publication is first made available online or could be a point in time before
-							publication when the Web Publication is considered final.</p>
+						<p>The exact moment of publication is intentionally left open to
+							interpretation: it could be when the Web Publication is first made
+							available online or could be a point in time before publication when the
+							Web Publication is considered final.</p>
 					</section>
 
 					<section id="publication-date-manifest">
@@ -1640,12 +1826,16 @@
 										<code>datePublished</code>
 									</td>
 									<td>Creation date of the publication.</td>
-									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
-											href="https://schema.org/DateTime"><code>DateTime</code></a>, both expressed
-										in ISO 8601 Date, or Date Time formats, respectively [[!iso8601]].</td>
+									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or
+											<a href="https://schema.org/DateTime"
+												><code>DateTime</code></a>, both expressed in ISO
+										8601 Date, or Date Time formats, respectively
+										[[!iso8601]].</td>
 									<td>
-										<a href="https://schema.org/datePublished"><code>datePublished</code></a> (<a
-											href="https://www.schema.org/CreativeWork">CreativeWork</a>) </td>
+										<a href="https://schema.org/datePublished"
+												><code>datePublished</code></a> (<a
+											href="https://www.schema.org/CreativeWork"
+											>CreativeWork</a>) </td>
 								</tr>
 							</tbody>
 						</table>
@@ -1667,8 +1857,9 @@
 				<section id="reading-progression-direction">
 					<h4>Reading Progression Direction</h4>
 
-					<p>The <dfn data-lt="reading progression direction">reading progression</dfn> establishes the
-						reading direction from one resource to the next within a <a>Web Publication</a>.</p>
+					<p>The <dfn data-lt="reading progression direction">reading progression</dfn>
+						establishes the reading direction from one resource to the next within a
+							<a>Web Publication</a>.</p>
 
 					<section id="reading-progression-direction-infoset">
 						<h5>Infoset Requirements</h5>
@@ -1682,13 +1873,14 @@
 
 						<p>The default value is <code>ltr</code>.</p>
 
-						<p>This infoset item has <em>no effect</em> on the rendering of the individual primary
-							resources; it is only relevant for the progression direction from one resource to the
-							other.</p>
+						<p>This infoset item has <em>no effect</em> on the rendering of the
+							individual primary resources; it is only relevant for the progression
+							direction from one resource to the other.</p>
 
-						<p class="note">The reading progression of a <a>Web Publication</a> is used to adapt such
-							publication level interactions as menu position, swap direction, defining tap zones to lead
-							the user to the next and previous pages, touch gestures, etc.</p>
+						<p class="note">The reading progression of a <a>Web Publication</a> is used
+							to adapt such publication level interactions as menu position, swap
+							direction, defining tap zones to lead the user to the next and previous
+							pages, touch gestures, etc.</p>
 					</section>
 
 					<section id="reading-progression-direction-manifest">
@@ -1737,31 +1929,35 @@
 					<section id="title-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The title is specified by the <a href="#title-manifest">manifest expression</a>, when
-							present. If not included in the manifest, user agents MAY use the value of the <a
+						<p>The title is specified by the <a href="#title-manifest">manifest
+								expression</a>, when present. If not included in the manifest, user
+							agents MAY use the value of the <a
 								href="https://www.w3.org/TR/html/document-metadata.html#the-title-element"
-									><code>title</code> element</a>&#160;[[!html]] of the Web Publication’s <a>primary
-								entry page</a> (if present) .</p>
+									><code>title</code> element</a>&#160;[[!html]] of the Web
+							Publication’s <a>primary entry page</a> (if present) .</p>
 
-						<p class="note">Relying on the <code>title</code> element could be semantically problematic if
-							the Web Publication consists of several HTML resources (e.g., one per chapter of a book),
-							because the <a href="https://www.w3.org/TR/html/document-metadata.html#the-title-element"
-								>HTML definition</a> defines this element as "metadata" for the enclosing HTML document,
-							not for a collection of resources. Using this element is, on the other hand, preferred in
-							the case of a publication consisting of a single HTML document (e.g., a scholarly journal
+						<p class="note">Relying on the <code>title</code> element could be
+							semantically problematic if the Web Publication consists of several HTML
+							resources (e.g., one per chapter of a book), because the <a
+								href="https://www.w3.org/TR/html/document-metadata.html#the-title-element"
+								>HTML definition</a> defines this element as "metadata" for the
+							enclosing HTML document, not for a collection of resources. Using this
+							element is, on the other hand, preferred in the case of a publication
+							consisting of a single HTML document (e.g., a scholarly journal
 							article).</p>
 
-						<p>When specified in the <abbr title="information set"><a>infoset</a></abbr>, the title MUST be
-								<a>non-empty</a>.</p>
+						<p>When specified in the <abbr title="information set"
+							><a>infoset</a></abbr>, the title MUST be <a>non-empty</a>.</p>
 
 						<p>If a user agent requires a title and one is not available in the <abbr
-								title="information set">infoset</abbr>, it MAY create one (e.g., provide a
-							language-specific placeholder title or use the <abbr title="Uniform Resource Locator"
-								>URL</abbr> of the manifest).</p>
+								title="information set">infoset</abbr>, it MAY create one (e.g.,
+							provide a language-specific placeholder title or use the <abbr
+								title="Uniform Resource Locator">URL</abbr> of the manifest).</p>
 
 						<p class="note">A user agent is not expected to produce a <a
-								href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title">meaningful
-							title</a>&#160;[[wcag20]] for a Web Publication when one is not specified.</p>
+								href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title"
+								>meaningful title</a>&#160;[[wcag20]] for a Web Publication when one
+							is not specified.</p>
 					</section>
 
 					<section id="title-manifest">
@@ -1805,40 +2001,44 @@
 			<section id="resource-categorization-properties">
 				<h3>Resource Categorization Properties</h3>
 
-				<p><a>Web Publication</a> resources are specified via the <a>default reading order</a>, the <a>resource
-						list</a>, and the <a>links</a>, as defined in this section. These lists contain references to <a
-						href="#informative-properties">informative properties</a> like the <a href="#privacy-policy"
-						>privacy policy</a>, and <a href="#structural-properties">structural properties</a> like the
-						<a>table of contents</a>.</p>
+				<p><a>Web Publication</a> resources are specified via the <a>default reading
+						order</a>, the <a>resource list</a>, and the <a>links</a>, as defined in
+					this section. These lists contain references to <a
+						href="#informative-properties">informative properties</a> like the <a
+						href="#privacy-policy">privacy policy</a>, and <a
+						href="#structural-properties">structural properties</a> like the <a>table of
+						contents</a>.</p>
 
-				<p>Note that a particular resource's URL MUST NOT appear in more than one of these lists, and a URL MUST
-					NOT be repeated within a list.</p>
+				<p>Note that a particular resource's URL MUST NOT appear in more than one of these
+					lists, and a URL MUST NOT be repeated within a list.</p>
 
 				<section id="default-reading-order">
 					<h4>Default Reading Order</h4>
 
-					<p>The <dfn>default reading order</dfn> is a specific progression through a set of <a>Web
-							Publication</a> resources.</p>
+					<p>The <dfn>default reading order</dfn> is a specific progression through a set
+						of <a>Web Publication</a> resources.</p>
 
-					<p>A user might follow alternative pathways through the content, but in the absence of such
-						interaction the default reading order defines the expected progression from one resource to the
-						next.</p>
+					<p>A user might follow alternative pathways through the content, but in the
+						absence of such interaction the default reading order defines the expected
+						progression from one resource to the next.</p>
 
 					<section id="default-reading-order-infoset">
 						<h5>Infoset Requirements</h5>
 
 						<p>The default reading order MUST include at least one resource.</p>
 
-						<p>The default reading order is specified directly in the manifest. However, if the reading
-							order consists of only a single resource, namely the <a>primary entry page</a> of the Web
-							Publication, the default reading order need not be specified.</p>
+						<p>The default reading order is specified directly in the manifest. However,
+							if the reading order consists of only a single resource, namely the
+								<a>primary entry page</a> of the Web Publication, the default
+							reading order need not be specified.</p>
 					</section>
 
 					<section id="default-reading-order-manifest">
 						<h5>Manifest Expression</h5>
 
-						<p>If present in the Web Publication Manifest, this item MUST be mapped on the
-								<code>readingOrder</code> term, defined specifically for Web Publications.</p>
+						<p>If present in the Web Publication Manifest, this item MUST be mapped on
+							the <code>readingOrder</code> term, defined specifically for Web
+							Publications.</p>
 
 						<table class="zebra">
 							<thead>
@@ -1858,12 +2058,14 @@
 									<td>
 										<p>An array of:</p>
 										<ul>
-											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
+											<li>a string, representing the URL&#160;[[url]] of the
+												resource; or</li>
 											<li>an instance of a <a href="#publication-link-def"
-														><code>PublicationLink</code></a> object</li>
+												><code>PublicationLink</code></a> object</li>
 										</ul>
-										<p>The order in the array is <em>significant</em>. The URLs MUST NOT include
-											fragment identifiers. Non-HTML resources SHOULD be expressed as
+										<p>The order in the array is <em>significant</em>. The URLs
+											MUST NOT include fragment identifiers. Non-HTML
+											resources SHOULD be expressed as
 												<code>PublicationLink</code> objects with their
 												<code>encodingFormat</code> values set.</p>
 									</td>
@@ -1916,33 +2118,37 @@
 				<section id="resource-list">
 					<h4>Resource List</h4>
 
-					<p>The <dfn>resource list</dfn> enumerates all <a href="#wp-resources">resources</a> that are used
-						in the processing and rendering of a <a>Web Publication</a> (i.e., that are within its bounds)
-						and that are not listed in the <a>default reading order</a>.</p>
+					<p>The <dfn>resource list</dfn> enumerates all <a href="#wp-resources"
+							>resources</a> that are used in the processing and rendering of a <a>Web
+							Publication</a> (i.e., that are within its bounds) and that are not
+						listed in the <a>default reading order</a>.</p>
 
-					<p class="note">The union of the resource list and default reading order represents the definitive
-						list of resources that belong to the Web Publication. All other resources are external to the
-						Web Publication.</p>
+					<p class="note">The union of the resource list and default reading order
+						represents the definitive list of resources that belong to the Web
+						Publication. All other resources are external to the Web Publication.</p>
 
 					<section id="resource-list-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The completeness of the resource list will affect the usability of the Web Publication in
-							certain reading scenarios (e.g., the ability to read the Web Publication offline). For this
-							reason, it is strongly RECOMMENDED to provide a comprehensive list of all of the Web
-							Publication's constituent resources beyond those listed in the <a>default reading
-							order</a>.</p>
+						<p>The completeness of the resource list will affect the usability of the
+							Web Publication in certain reading scenarios (e.g., the ability to read
+							the Web Publication offline). For this reason, it is strongly
+							RECOMMENDED to provide a comprehensive list of all of the Web
+							Publication's constituent resources beyond those listed in the
+								<a>default reading order</a>.</p>
 
-						<p>In some cases, a comprehensive list of these resources might not be easily achieved (e.g.,
-							third-party scripts that reference resources from deep within their source), but a user
-							agent SHOULD still be able to render a Web Publication even if some of these resources are
-							not identified as belonging to the Web Publication (e.g., when it is taken offline without
-							them).</p>
+						<p>In some cases, a comprehensive list of these resources might not be
+							easily achieved (e.g., third-party scripts that reference resources from
+							deep within their source), but a user agent SHOULD still be able to
+							render a Web Publication even if some of these resources are not
+							identified as belonging to the Web Publication (e.g., when it is taken
+							offline without them).</p>
 
 						<div class="ednote"> The previous version of the draft included: <blockquote>
-								<p>If a user agent encounters a resource that it cannot locate in the resource list, it
-									MUST treat the resource as external to the Web Publication (e.g., it might alert the
-									user before loading, open the resource in a new window, or unload the current Web
+								<p>If a user agent encounters a resource that it cannot locate in
+									the resource list, it MUST treat the resource as external to the
+									Web Publication (e.g., it might alert the user before loading,
+									open the resource in a new window, or unload the current Web
 									Publication and resume normal Web browsing).</p>
 							</blockquote>
 							<p>This was not decided on the Toronto F2F, and is still open.</p>
@@ -1953,8 +2159,9 @@
 					<section id="resource-list-manifest">
 						<h5>Manifest Expression</h5>
 
-						<p>If present in the Web Publication Manifest, this item MUST be mapped on the
-								<code>resources</code> term, defined specifically for Web Publications. </p>
+						<p>If present in the Web Publication Manifest, this item MUST be mapped on
+							the <code>resources</code> term, defined specifically for Web
+							Publications. </p>
 
 						<table class="zebra">
 							<thead>
@@ -1974,13 +2181,15 @@
 									<td>
 										<p>An array of:</p>
 										<ul>
-											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
+											<li>a string, representing the URL&#160;[[url]] of the
+												resource; or</li>
 											<li>an instance of a <a href="#publication-link-def"
-														><code>PublicationLink</code></a> object</li>
+												><code>PublicationLink</code></a> object</li>
 										</ul>
-										<p>The order in the array is <em>not significant</em>. The URLs MUST NOT include
-											fragment identifiers. It is RECOMMENDED to use <code>PublicationLink</code>
-											objects with their <code>encodingFormat</code> values set.</p>
+										<p>The order in the array is <em>not significant</em>. The
+											URLs MUST NOT include fragment identifiers. It is
+											RECOMMENDED to use <code>PublicationLink</code> objects
+											with their <code>encodingFormat</code> values set.</p>
 									</td>
 									<td>(None)</td>
 								</tr>
@@ -2021,42 +2230,47 @@
 				<section id="links">
 					<h4>Links</h4>
 
-					<p>The <dfn>links</dfn> property provides a list of <a href="#wp-resources">resources</a> that are
-							<em>not</em> required for the processing and rendering of a Web Publication (i.e., the
-						content of the Web Publication remains unaffected even if these resources are not available).
-						Linked resources are typically made available to user agents to augment or enhance the
-						processing or rendering of it, such as:</p>
+					<p>The <dfn>links</dfn> property provides a list of <a href="#wp-resources"
+							>resources</a> that are <em>not</em> required for the processing and
+						rendering of a Web Publication (i.e., the content of the Web Publication
+						remains unaffected even if these resources are not available). Linked
+						resources are typically made available to user agents to augment or enhance
+						the processing or rendering of it, such as:</p>
 
 					<ul>
-						<li>a privacy policy or license that the user agent can offer a link to from a shelf;</li>
-						<li>a metadata record that the user agent can use to discover and display more information about
-							the Web Publication;</li>
-						<li>a dictionary of terms the user agent can process to provide enhanced language help;</li>
+						<li>a privacy policy or license that the user agent can offer a link to from
+							a shelf;</li>
+						<li>a metadata record that the user agent can use to discover and display
+							more information about the Web Publication;</li>
+						<li>a dictionary of terms the user agent can process to provide enhanced
+							language help;</li>
 					</ul>
 
-					<p>The <code>links</code> property can also be used to identify resources that are used in the
-						online rendering of a Web Publication, but that are not essential to include with it when it is
-						taken offline or packaged (e.g., to minimize the size). These include:</p>
+					<p>The <code>links</code> property can also be used to identify resources that
+						are used in the online rendering of a Web Publication, but that are not
+						essential to include with it when it is taken offline or packaged (e.g., to
+						minimize the size). These include:</p>
 
 					<ul>
-						<li>large font files that enhance the appearance of the Web Publication but are not vital to its
-							display (i.e., a fallback font will suffice);</li>
-						<li>third-party scripts that are not intended for use when a Web Publication is taken offline or
-							packaged (e.g., tracking scripts).</li>
+						<li>large font files that enhance the appearance of the Web Publication but
+							are not vital to its display (i.e., a fallback font will suffice);</li>
+						<li>third-party scripts that are not intended for use when a Web Publication
+							is taken offline or packaged (e.g., tracking scripts).</li>
 					</ul>
 
 					<section id="links-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The <code>links</code> list SHOULD include resources necessary to render a linked resource
-							(e.g., scripts, images, style sheets).</p>
+						<p>The <code>links</code> list SHOULD include resources necessary to render
+							a linked resource (e.g., scripts, images, style sheets).</p>
 
-						<p>Resources listed in the <code>links</code> list MUST NOT be listed in the <a
-								href="#default-reading-order">default reading order</a> or <a href="#resource-list"
-								>resource list</a>.</p>
+						<p>Resources listed in the <code>links</code> list MUST NOT be listed in the
+								<a href="#default-reading-order">default reading order</a> or <a
+								href="#resource-list">resource list</a>.</p>
 
-						<p>User agents MAY ignore linked resources, and are not required to take them offline with a Web
-							Publication. These resources SHOULD NOT be included when packaging a Web Publication.</p>
+						<p>User agents MAY ignore linked resources, and are not required to take
+							them offline with a Web Publication. These resources SHOULD NOT be
+							included when packaging a Web Publication.</p>
 					</section>
 
 					<section id="links-manifest">
@@ -2080,13 +2294,15 @@
 									<td>
 										<p>An array of:</p>
 										<ul>
-											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
+											<li>a string, representing the URL&#160;[[url]] of the
+												resource; or</li>
 											<li>an instance of a <a href="#publication-link-def"
-														><code>PublicationLink</code></a> object</li>
+												><code>PublicationLink</code></a> object</li>
 										</ul>
-										<p>The order in the array is <em>not significant</em>. It is RECOMMENDED to use
-												<code>PublicationLink</code> objects with their
-												<code>encodingFormat</code> and <code>rel</code> values set.</p>
+										<p>The order in the array is <em>not significant</em>. It is
+											RECOMMENDED to use <code>PublicationLink</code> objects
+											with their <code>encodingFormat</code> and
+												<code>rel</code> values set.</p>
 									</td>
 									<td>(None)</td>
 								</tr>
@@ -2102,35 +2318,41 @@
 				<section id="accessibility-report">
 					<h4>Accessibility Report</h4>
 
-					<p>An accessibility report provides information about the suitability of a <a>Web Publication</a>
-						for consumption by users with varying preferred reading modalities. These reports typically
-						identify the result of an evaluation against established accessibility criteria, such as those
-						provided in [[WCAG21]], and are an important source of information in determining the usability
-						of a Web Publication.</p>
+					<p>An accessibility report provides information about the suitability of a
+							<a>Web Publication</a> for consumption by users with varying preferred
+						reading modalities. These reports typically identify the result of an
+						evaluation against established accessibility criteria, such as those
+						provided in [[WCAG21]], and are an important source of information in
+						determining the usability of a Web Publication.</p>
 
 					<section id="accessibility-report-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a link to an
-							accessibility report when one is available for a Web Publication. It is RECOMMENDED that the
-							report be included as a resource of the Web Publication.</p>
+						<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a
+							link to an accessibility report when one is available for a Web
+							Publication. It is RECOMMENDED that the report be included as a resource
+							of the Web Publication.</p>
 
-						<p>It is also RECOMMENDED that the accessibility report be provided in a human-readable format,
-							such as <abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[html]]. Augmenting these
-							reports with machine-processable metadata, such as provided in Schema.org [[schema.org]], is
-							also RECOMMENDED.</p>
+						<p>It is also RECOMMENDED that the accessibility report be provided in a
+							human-readable format, such as <abbr title="Hypertext Markup Language"
+								>HTML</abbr>&#160;[[html]]. Augmenting these reports with
+							machine-processable metadata, such as provided in Schema.org
+							[[schema.org]], is also RECOMMENDED.</p>
 					</section>
 
 					<section id="accessibility-report-manifest">
 						<h5>Manifest Expression</h5>
 
-						<p>If present in the manifest, the accessibility report MUST be expressed as a <a
-								href="#publication-link-def"><code>PublicationLink</code></a>. The <code>rel</code>
-							value of the <a href="#publication-link-def"><code>PublicationLink</code></a> MUST include
-							the <code>https://www.w3.org/ns/wp#accessibility-report</code> identifier.</p>
+						<p>If present in the manifest, the accessibility report MUST be expressed as
+							a <a href="#publication-link-def"><code>PublicationLink</code></a>. The
+								<code>rel</code> value of the <a href="#publication-link-def"
+									><code>PublicationLink</code></a> MUST include the
+								<code>https://www.w3.org/ns/wp#accessibility-report</code>
+							identifier.</p>
 
-						<p class="ednote">The Working Group will attempt to define the <code>accessibility-report</code>
-							term by IANA, to avoid using a URL.</p>
+						<p class="ednote">The Working Group will attempt to define the
+								<code>accessibility-report</code> term by IANA, to avoid using a
+							URL.</p>
 
 						<pre class="example" title="Link to an accessibility report">
 {
@@ -2155,33 +2377,39 @@
 				<section id="privacy-policy">
 					<h4>Privacy Policy</h4>
 
-					<p>Users often have the legal right to know and control what information is collected about them,
-						how such information is stored and for how long, whether it is personally identifiable, and how
-						it can be expunged. Including a statement that addresses such privacy concerns is consequently
-						an important part of publishing <a>Web Publications</a>. Even if no information is collected,
-						such a declaration increases the trust users have in the content.</p>
+					<p>Users often have the legal right to know and control what information is
+						collected about them, how such information is stored and for how long,
+						whether it is personally identifiable, and how it can be expunged. Including
+						a statement that addresses such privacy concerns is consequently an
+						important part of publishing <a>Web Publications</a>. Even if no information
+						is collected, such a declaration increases the trust users have in the
+						content.</p>
 
 					<section id="privacy-policy-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>A link to a privacy policy can be included in the <abbr title="information set"
-									><a>infoset</a></abbr>. It is RECOMMENDED that the privacy policy be included as a
-							resource of the Web Publication.</p>
+						<p>A link to a privacy policy can be included in the <abbr
+								title="information set"><a>infoset</a></abbr>. It is RECOMMENDED
+							that the privacy policy be included as a resource of the Web
+							Publication.</p>
 
-						<p>It is RECOMMENDED that the privacy policy be provided in a human-readable format, such as
-								<abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[html]].</p>
+						<p>It is RECOMMENDED that the privacy policy be provided in a human-readable
+							format, such as <abbr title="Hypertext Markup Language"
+							>HTML</abbr>&#160;[[html]].</p>
 
-						<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
-							Publications.</p>
+						<p>Refer to <a href="#privacy"></a> for more information about privacy
+							considerations in Web Publications.</p>
 					</section>
 
 					<section id="privacy-policy-manifest">
 						<h4>Manifest Expression</h4>
 
 						<p>If present in the manifest, the privacy policy MUST be expressed as a <a
-								href="#publication-link-def"><code>PublicationLink</code></a>. The <code>rel</code>
-							value of the <a href="#publication-link-def"><code>PublicationLink</code></a> MUST include
-							the <code>privacy-policy</code> identifier&#160;[[!iana-link-relations]].</p>
+								href="#publication-link-def"><code>PublicationLink</code></a>. The
+								<code>rel</code> value of the <a href="#publication-link-def"
+									><code>PublicationLink</code></a> MUST include the
+								<code>privacy-policy</code>
+							identifier&#160;[[!iana-link-relations]].</p>
 
 						<pre class="example" title="Privacy policy expressed as an external link">
 {
@@ -2212,41 +2440,46 @@
 				<section id="cover">
 					<h4>Cover</h4>
 
-					<p>The <dfn>cover</dfn> is a resource that user agents can use to present the <a>Web Publication</a>
-						(e.g., in a library or bookshelf, or when initially loading the Web Publication).</p>
+					<p>The <dfn>cover</dfn> is a resource that user agents can use to present the
+							<a>Web Publication</a> (e.g., in a library or bookshelf, or when
+						initially loading the Web Publication).</p>
 
-					<p class="issue" data-number="261">The working group has not reached consensus on whether the cover
-						should be any resource or should be limited to images.</p>
+					<p class="issue" data-number="261">The working group has not reached consensus
+						on whether the cover should be any resource or should be limited to
+						images.</p>
 
 					<section id="cover-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a reference to a
-							cover.</p>
+						<p>The <abbr title="information set"><a>infoset</a></abbr> SHOULD include a
+							reference to a cover.</p>
 
-						<p>More than one cover MAY be referenced from the infoset (e.g., to provide alternative formats
-							and sizes for different device screens). If multiple covers are specified, each instance
-							MUST define at least one unique property to allow user agents to determine its usability
-							(e.g., a different format, height, width or relationship).</p>
+						<p>More than one cover MAY be referenced from the infoset (e.g., to provide
+							alternative formats and sizes for different device screens). If multiple
+							covers are specified, each instance MUST define at least one unique
+							property to allow user agents to determine its usability (e.g., a
+							different format, height, width or relationship).</p>
 					</section>
 
 					<section id="cover-manifest">
 						<h5>Manifest Expression</h5>
 
-						<p>If present in the manifest, the cover MUST be expressed as a <a href="#publication-link-def"
-									><code>PublicationLink</code></a>. The URL expressed in the <code>url</code> term
-							MUST NOT include a fragment identifier.</p>
+						<p>If present in the manifest, the cover MUST be expressed as a <a
+								href="#publication-link-def"><code>PublicationLink</code></a>. The
+							URL expressed in the <code>url</code> term MUST NOT include a fragment
+							identifier.</p>
 
 						<p>The <code>rel</code> value of the <a href="#publication-link-def"
 									><code>PublicationLink</code></a> MUST include the
 								<code>https://www.w3.org/ns/wp#cover</code> identifier.</p>
 
-						<p>If the cover is in an image format, a <code>title</code> and <code>description</code> SHOULD
-							be provided. User agents can use these properties to provide alternative text and
-							descriptions when necessary for accessibility.</p>
+						<p>If the cover is in an image format, a <code>title</code> and
+								<code>description</code> SHOULD be provided. User agents can use
+							these properties to provide alternative text and descriptions when
+							necessary for accessibility.</p>
 
-						<p class="ednote">The Working Group will attempt to define the <code>cover</code> term by IANA,
-							to avoid using a URL.</p>
+						<p class="ednote">The Working Group will attempt to define the
+								<code>cover</code> term by IANA, to avoid using a URL.</p>
 
 						<pre class="example" title="Cover HTML page">
 {
@@ -2317,65 +2550,76 @@
 				<section id="table-of-contents">
 					<h4>Table of Contents</h4>
 
-					<p>The <dfn>table of contents</dfn> property identifies the resource that contains the Web
-						Publication's <a href="#wp-table-of-contents">table of contents</a>.</p>
+					<p>The <dfn>table of contents</dfn> property identifies the resource that
+						contains the Web Publication's <a href="#wp-table-of-contents">table of
+							contents</a>.</p>
 
 					<section id="table-of-contents-infoset">
 						<h5>Infoset Requirements</h5>
 
-						<p>User agents MUST compute the <code>table-of-contents</code> as follows:</p>
+						<p>User agents MUST compute the <code>table-of-contents</code> as
+							follows:</p>
 
 						<ol>
 							<li>Identify the table of content resource: <ul>
-									<li> If a resource in either the <a href="#default-reading-order">default reading
-											order</a> or <a href="#resource-list">resource-list</a> is identified with a
-											<code>rel</code> value including
-										<code>contents</code>&#160;[[!iana-link-relations]], the corresponding
-											<code>url</code> value identifies the table of content resource. </li>
-									<li> Otherwise, the <a>primary entry page</a> is the table of content resource.
-									</li>
+									<li> If a resource in either the <a
+											href="#default-reading-order">default reading order</a>
+										or <a href="#resource-list">resource-list</a> is identified
+										with a <code>rel</code> value including
+											<code>contents</code>&#160;[[!iana-link-relations]], the
+										corresponding <code>url</code> value identifies the table of
+										content resource. </li>
+									<li> Otherwise, the <a>primary entry page</a> is the table of
+										content resource. </li>
 								</ul>
 							</li>
 							<li> If the table of content resource contains an HTML element with the
-								<code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria-1.0]], the
-								user agent MUST use that element as the table of contents. </li>
+									<code>role</code>&#160;[[!html]] value
+								<code>doc-toc</code>&#160;[[!dpub-aria-1.0]], the user agent MUST
+								use that element as the table of contents. </li>
 						</ol>
 
-						<p>If identifying the Table of Content is ambiguous (e.g., several table of content resources
-							are identified, or several elements with a <code>role</code> value <code>doc-toc</code> is
-							found within the table of content resource), the user agent MAY choose among them. This
-							specification does not mandate how this choice is made. The user agent might:</p>
+						<p>If identifying the Table of Content is ambiguous (e.g., several table of
+							content resources are identified, or several elements with a
+								<code>role</code> value <code>doc-toc</code> is found within the
+							table of content resource), the user agent MAY choose among them. This
+							specification does not mandate how this choice is made. The user agent
+							might:</p>
 
 						<ul>
 							<li>choose the first table of content resource by some heuristics</li>
-							<li>choose the first table of content element within the same resource in <a
-									href="https://dom.spec.whatwg.org/#concept-tree-order">document tree
-								order</a>&#160;[[!dom]]</li>
+							<li>choose the first table of content element within the same resource
+								in <a href="https://dom.spec.whatwg.org/#concept-tree-order"
+									>document tree order</a>&#160;[[!dom]]</li>
 						</ul>
 
-						<p>If this process does not result in a link to the table of contents, the Web Publication does
-							not have a table of contents and this property MUST NOT be included in the infoset.</p>
+						<p>If this process does not result in a link to the table of contents, the
+							Web Publication does not have a table of contents and this property MUST
+							NOT be included in the infoset.</p>
 
-						<p class="issue" data-number="291">Depending on the resolution to this issue, the infoset might
-							contain a separate entry for a machine-processable table of contents, restrictions could be
-							placed on the HTML structure of the referenced table of contents, or parsing rules for
-							extracting a table of contents could be added.</p>
+						<p class="issue" data-number="291">Depending on the resolution to this
+							issue, the infoset might contain a separate entry for a
+							machine-processable table of contents, restrictions could be placed on
+							the HTML structure of the referenced table of contents, or parsing rules
+							for extracting a table of contents could be added.</p>
 					</section>
 
 					<section id="table-of-contents-manifest">
 						<h5>Manifest Expression</h5>
 
-						<p>If present in the manifest, the table of content MUST be expressed as a <a
-								href="#publication-link-def"><code>PublicationLink</code></a>. The URL expressed in the
-								<code>url</code> term MUST NOT include a fragment identifier.</p>
+						<p>If present in the manifest, the table of content MUST be expressed as a
+								<a href="#publication-link-def"><code>PublicationLink</code></a>.
+							The URL expressed in the <code>url</code> term MUST NOT include a
+							fragment identifier.</p>
 
 						<p>The <code>rel</code> value of the <a href="#publication-link-def"
-									><code>PublicationLink</code></a> MUST include the <code>contents</code>
-							identifier&#160;[[!iana-link-relations]].</p>
+									><code>PublicationLink</code></a> MUST include the
+								<code>contents</code> identifier&#160;[[!iana-link-relations]].</p>
 
 						<p>The link to the table of contents MAY be specified in either the <a
-								href="#default-reading-order">default reading order</a> or <a href="#resource-list"
-								>resource-list</a>, but MUST NOT be specified in both.</p>
+								href="#default-reading-order">default reading order</a> or <a
+								href="#resource-list">resource-list</a>, but MUST NOT be specified
+							in both.</p>
 
 						<pre class="example" title="Table of content identified in another resource of the Web Publication">
 {
@@ -2425,40 +2669,46 @@
 			<section id="extensibility">
 				<h3>Extensibility</h3>
 
-				<p>The <abbr title="information set"><a>infoset</a></abbr> is designed to provide a basic set of
-					properties for use by user agents in presenting and rendering a <a>Web Publication</a>, but MAY be
-					extended in the following ways:</p>
+				<p>The <abbr title="information set"><a>infoset</a></abbr> is designed to provide a
+					basic set of properties for use by user agents in presenting and rendering a
+						<a>Web Publication</a>, but MAY be extended in the following ways:</p>
 
 				<ol>
-					<li>by the provision of <a href="#extensibility-linked-records">linked metadata records</a>.</li>
-					<li>through the inclusion of <a href="#extensibility-manifest-properties">additional properties in
-							the manifest</a>;</li>
+					<li>by the provision of <a href="#extensibility-linked-records">linked metadata
+							records</a>.</li>
+					<li>through the inclusion of <a href="#extensibility-manifest-properties"
+							>additional properties in the manifest</a>;</li>
 				</ol>
 
-				<p>Although both methods are valid, the use of linked records to extend the infoset is RECOMMENDED.</p>
+				<p>Although both methods are valid, the use of linked records to extend the infoset
+					is RECOMMENDED.</p>
 
-				<p>This specification does not define how such additional properties are compiled, stored or exposed by
-					user agents in their internal representation of the infoset. A user agent MAY ignore some or all
-					extended properties.</p>
+				<p>This specification does not define how such additional properties are compiled,
+					stored or exposed by user agents in their internal representation of the
+					infoset. A user agent MAY ignore some or all extended properties.</p>
 
 				<section id="extensibility-linked-records">
 					<h5>Linked records</h5>
 
-					<p>Extending the manifest through links to a record, such as an ONIX&#160;[[onix]] or
-						BibTeX&#160;[[bibtex]] file, MUST be expressed using a <a href="#publication-link-def"
-								><code>PublicationLink</code></a> object, where:</p>
+					<p>Extending the manifest through links to a record, such as an
+						ONIX&#160;[[onix]] or BibTeX&#160;[[bibtex]] file, MUST be expressed using a
+							<a href="#publication-link-def"><code>PublicationLink</code></a> object,
+						where:</p>
 					<ul>
 						<li> the <code>rel</code> value of the <a href="#publication-link-def"
-									><code>PublicationLink</code></a> SHOULD include a relevant identifier defined by
-							IANA or by other organizations; if the link record contains descriptive metadata it MUST
-							include the <code>describedby</code> (IANA) identifier; </li>
-						<li>the value of the <code>encodingFormat</code> in the link MUST use the MIME media
-							type&#160;[[!rfc2046]] defined for that particular type of record, if applicable.</li>
+									><code>PublicationLink</code></a> SHOULD include a relevant
+							identifier defined by IANA or by other organizations; if the link record
+							contains descriptive metadata it MUST include the
+								<code>describedby</code> (IANA) identifier; </li>
+						<li>the value of the <code>encodingFormat</code> in the link MUST use the
+							MIME media type&#160;[[!rfc2046]] defined for that particular type of
+							record, if applicable.</li>
 					</ul>
 
-					<p>Linked records MUST be included in the <a href="#resource-list">resource list</a> when they are
-						part of the Web Publication (i.e., are needed for more than just infoset extensibility).
-						Otherwise, they MUST be included in the <a href="#links">links list</a>.</p>
+					<p>Linked records MUST be included in the <a href="#resource-list">resource
+							list</a> when they are part of the Web Publication (i.e., are needed for
+						more than just infoset extensibility). Otherwise, they MUST be included in
+						the <a href="#links">links list</a>.</p>
 
 					<pre class="example" title="Link to external ONIX for Books Metadata file">
 {
@@ -2478,19 +2728,22 @@
     &#8230;
 }
 </pre>
-					<p class="ednote">The <code>application/onix+xml</code> MIME type has not yet been registered by
-						IANA at the time of writing this document, and is included in the example for illustrative
-						purposes only. </p>
+					<p class="ednote">The <code>application/onix+xml</code> MIME type has not yet
+						been registered by IANA at the time of writing this document, and is
+						included in the example for illustrative purposes only. </p>
 				</section>
 
 				<section id="extensibility-manifest-properties">
 					<h5>Additional Properties in the Manifest</h5>
 
-					<p>Additional properties can be included directly in the manifest. It is RECOMMENDED that these
-						properties be taken from public schemes like [[schema.org]] or [[dcterms]] and use values from
-						controlled vocabularies whenever possible. Proprietary terms MAY be used, but it is RECOMMENDED
-						that such terms be included using <a href="https://www.w3.org/TR/json-ld/#compact-iris">Compact
-							IRIs</a>&#160;[[!json-ld]], with prefixes defined as part of the context.</p>
+					<p>Additional properties can be included directly in the manifest. It is
+						RECOMMENDED that these properties be taken from public schemes like
+						[[schema.org]] or [[dcterms]] and use values from controlled vocabularies
+						whenever possible. Proprietary terms MAY be used, but it is RECOMMENDED that
+						such terms be included using <a
+							href="https://www.w3.org/TR/json-ld/#compact-iris">Compact
+						IRIs</a>&#160;[[!json-ld]], with prefixes defined as part of the
+						context.</p>
 
 					<pre class="example" title="Usage of the schema.org 'copyrightYear' and 'copyrightHolder' terms, as an extension to the basic data">
 {
@@ -2516,11 +2769,11 @@
     &#8230;
 }
 </pre>
-					<p class="note"> A prefix definition <code>dc</code> for [[dcterms]] is included in the context file
-						of [[schema.org]]. This means that it is not necessary to add the prefix explicitly. The same is
-						true for a number of other public vocabularies; see the <a
-							href="https://schema.org/docs/jsonldcontext.json">schema.org context file</a> for further
-						details. </p>
+					<p class="note"> A prefix definition <code>dc</code> for [[dcterms]] is included
+						in the context file of [[schema.org]]. This means that it is not necessary
+						to add the prefix explicitly. The same is true for a number of other public
+						vocabularies; see the <a href="https://schema.org/docs/jsonldcontext.json"
+							>schema.org context file</a> for further details. </p>
 
 				</section>
 			</section>
@@ -2528,93 +2781,141 @@
 		<section id="canonical-manifest">
 			<h4>Canonical Manifest</h4>
 
-			<p>A <dfn data-lt="canonical manifest|canonical web publication manifest">Canonical Web Publication Manifest</dfn> (or Canonical Manifest) is a version of the Web Publication <a>Manifest</a> where all possible ambiguities on property values (see, e.g., <a href="#arrays-and-single-values"></a> or <a href="#strings-vs-objects"></a>) have been removed, and all values that are possibly harnessed from the <a>primary entry page</a> are incorporated.</p>
+			<p>A <dfn data-lt="canonical manifest|canonical web publication manifest">Canonical Web
+					Publication Manifest</dfn> (or Canonical Manifest) is a version of the Web
+				Publication <a>Manifest</a> where all possible ambiguities on property values (see,
+				e.g., <a href="#arrays-and-single-values"></a> or <a href="#strings-vs-objects"
+				></a>) have been removed, and all values that are possibly harnessed from the
+					<a>primary entry page</a> are incorporated.</p>
 
-			<p class=note>For all the examples in <a href="#wp-manifest-examples"></a> there is a link to the corresponding canonical manifest.</p>
+			<p class="note">For all the examples in <a href="#wp-manifest-examples"></a> there is a
+				link to the corresponding canonical manifest.</p>
 
-			<p>The steps to convert a Web Publication Manifest into a Canonical Manifest are given by the following algorithm. The algorithm takes the following arguments:</p>
+			<p>The steps to convert a Web Publication Manifest into a Canonical Manifest are given
+				by the following algorithm. The algorithm takes the following arguments:</p>
 
 			<ul>
-				<li>the <code>manifest</code> string, that represent the <a>manifest</a> in JSON</li>
-				<li>the <code>document</code> <a href="https://www.w3.org/TR/html/dom.html#elementdef-document">HTML Document (DOM) Node</a>&nbsp;[[!html]], representing the <a>primary entry page</a></li>
-				<li>the <code>base</code> URL string, that represents the base URL for the manifest, and has the value of:
-					<ul>
-						<li>the <a href="https://www.w3.org/TR/dom/#dom-node-baseuri">baseURI</a>&nbsp;[[!dom]] value of the <code>script element</code> in the <a>primary entry page</a>, in case the manifest is <a href="#manifest-embedding">embedded</a>; or</li>
+				<li>the <code>manifest</code> string, that represent the <a>manifest</a> in
+					JSON</li>
+				<li>the <code>document</code>
+					<a href="https://www.w3.org/TR/html/dom.html#elementdef-document">HTML Document
+						(DOM) Node</a>&#160;;[[!html]], representing the <a>primary entry
+					page</a></li>
+				<li>the <code>base</code> URL string, that represents the base URL for the manifest,
+					and has the value of: <ul>
+						<li>the <a href="https://www.w3.org/TR/dom/#dom-node-baseuri"
+							>baseURI</a>&#160;[[!dom]] value of the <code>script element</code> in
+							the <a>primary entry page</a>, in case the manifest is <a
+								href="#manifest-embedding">embedded</a>; or</li>
 						<li>the URL of the manifest otherwise</li>
 					</ul>
 				</li>
-				<li>the <code>lang</code> string represents the default language, and has the value oft:
-					<ul>
-						<li>is the value of the <a href="https://www.w3.org/TR/html/dom.html#the-lang-and-xmllang-attributes"><code>lang</code> value</a>&nbsp;[[!html]] for the <code>script</code>  element in the <a>primary entry page</a>, in case the manifest is <a href="#manifest-embedding">embedded</a>; or </li>
+				<li>the <code>lang</code> string represents the default language, and has the value
+					oft: <ul>
+						<li>is the value of the <a
+								href="https://www.w3.org/TR/html/dom.html#the-lang-and-xmllang-attributes"
+									><code>lang</code> value</a>&#160;[[!html]] for the
+								<code>script</code> element in the <a>primary entry page</a>, in
+							case the manifest is <a href="#manifest-embedding">embedded</a>; or </li>
 						<li><code>undefined</code> otherwise</li>
 					</ul>
-					<li>the <code>dir</code> string represents the base direction, and has the value oft:
-						<ul>
-							<li>is the value of the <a href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"><code>dir</code> value</a>&nbsp;[[!html]] for the <code>script</code> element in the <a>primary entry page</a>, in case the manifest is <a href="#manifest-embedding">embedded</a>; or </li>
-							<li><code>undefined</code> otherwise</li>
-						</ul>
-					</li>
-					</li>
+				</li>
+				<li>the <code>dir</code> string represents the base direction, and has the value
+					oft: <ul>
+						<li>is the value of the <a
+								href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
+									><code>dir</code> value</a>&#160;[[!html]] for the
+								<code>script</code> element in the <a>primary entry page</a>, in
+							case the manifest is <a href="#manifest-embedding">embedded</a>; or </li>
+						<li><code>undefined</code> otherwise</li>
+					</ul>
+				</li>
 			</ul>
 
-			<p>
-				The steps of the algorithm are described below. As an abuse of notation, <code>P["term"]</code> refers to the value in the object <code>P</code> for the label <code>"term"</code>, where <code>P</code> is either <code>manifest</code>, or an object appearing within <code>manifest</code> (e.g., a <code>Person</code>).
-			</p>
+			<p> The steps of the algorithm are described below. As an abuse of notation,
+					<code>P["term"]</code> refers to the value in the object <code>P</code> for the
+				label <code>"term"</code>, where <code>P</code> is either <code>manifest</code>, or
+				an object appearing within <code>manifest</code> (e.g., a <code>Person</code>). </p>
 			<ol>
-				<li>
-					(<a href="#wptitle"></a>) if <code>manifest["name"]</code> is <code>undefined</code>, then locate the <a href="https://www.w3.org/TR/html/document-metadata.html#the-title-element"><code>title</code></a> HTML element&nbsp;[[!html]] using <code>document</code>. If that element exists, let <code>t</code> be its text content, and add to <code>manifest</code>:
-					<ul>
-						<li>if the language of <code>title</code> is explicitly <a href="https://www.w3.org/TR/html/dom.html#the-lang-and-xmllang-attributes">set</a> to the value of <code>l</code>, then add <br/><code>"name": {"@value": t, "@language": l}</code><br/></li>
-						<li>or <br/><code>"name": t</code><br> otherwise</li>
+				<li> (<a href="#wptitle"></a>) if <code>manifest["name"]</code> is
+						<code>undefined</code>, then locate the <a
+						href="https://www.w3.org/TR/html/document-metadata.html#the-title-element"
+							><code>title</code></a> HTML element&#160;[[!html]] using
+						<code>document</code>. If that element exists, let <code>t</code> be its
+					text content, and add to <code>manifest</code>: <ul>
+						<li>if the language of <code>title</code> is explicitly <a
+								href="https://www.w3.org/TR/html/dom.html#the-lang-and-xmllang-attributes"
+								>set</a> to the value of <code>l</code>, then add
+								<br /><code>"name": {"@value": t, "@language": l}</code><br /></li>
+						<li>or <br /><code>"name": t</code><br /> otherwise</li>
 					</ul>
 				</li>
-				<li>
-					(<a href="#language-and-dir"></a>) if <code>manifest["inLanguage"]</code> is <code>undefined</code> and the value of <code>lang</code> is <em>not</em> <code>undefined</code>, add<br><code>"inLanguage": lang</code><br> to <code>manifest</code>
+				<li> (<a href="#language-and-dir"></a>) if <code>manifest["inLanguage"]</code> is
+						<code>undefined</code> and the value of <code>lang</code> is <em>not</em>
+					<code>undefined</code>, add<br /><code>"inLanguage": lang</code><br /> to
+						<code>manifest</code>
 				</li>
-				<li>
-					(<a href="#language-and-dir"></a>) if <code>manifest["inDirection"]</code> is <code>undefined</code> and the value of <code>dir</code> is <em>not</em> <code>undefined</code>, add<br><code>"inDirection": dir</code><br> to <code>manifest</code>
+				<li> (<a href="#language-and-dir"></a>) if <code>manifest["inDirection"]</code> is
+						<code>undefined</code> and the value of <code>dir</code> is <em>not</em>
+					<code>undefined</code>, add<br /><code>"inDirection": dir</code><br /> to
+						<code>manifest</code>
 				</li>
-				<li>
-					(<a href='#default-reading-order'></a>) if <code>manifest["readingOrder"]</code> is <code>undefined</code>, add<br><code>"readingOrder": [{"@type": "PublicationLink", "url": <a href="https://www.w3.org/TR/dom41/#concept-document-url">document.URL</a>}]</code><br>to the <code>manifest</code>
+				<li> (<a href="#default-reading-order"></a>) if
+						<code>manifest["readingOrder"]</code> is <code>undefined</code>,
+						add<br /><code>"readingOrder": [{"@type": "PublicationLink", "url": <a
+							href="https://www.w3.org/TR/dom41/#concept-document-url"
+							>document.URL</a>}]</code><br />to the <code>manifest</code>
 				</li>
-				<li>
-					(<a href="#arrays-and-single-values"></a>) if the value of <code>P["term"]</code>, where <code>P</code> is any object in <code>manifest</code> (including itself) and <code>term</code> is:
-					<ul>
+				<li> (<a href="#arrays-and-single-values"></a>) if the value of
+						<code>P["term"]</code>, where <code>P</code> is any object in
+						<code>manifest</code> (including itself) and <code>term</code> is: <ul>
 						<li><code>@type</code>; or</li>
-						<li>one of the <a href="#accessibility">accessibility</a> terms except for <code>accessibilitySummary</code>; or</li>
+						<li>one of the <a href="#accessibility">accessibility</a> terms except for
+								<code>accessibilitySummary</code>; or</li>
 						<li>one of the <a href="#creators">creator</a> terms; or</li>
 						<li><code>name</code>; or</li>
-						<li>one of the <a href="#resource-categorization-properties">resource categorization properties</a>; or</li>
+						<li>one of the <a href="#resource-categorization-properties">resource
+								categorization properties</a>; or</li>
 						<li><code>rel</code></li>
-					</ul>
-					is a single string or object <code>v</code>, then change the relevant term/value to<br><code>"term" : [v]</code>
+					</ul> is a single string or object <code>v</code>, then change the relevant
+					term/value to<br /><code>"term" : [v]</code>
 				</li>
-				<li>
-					(<a href="#creators"></a>) if one of the values <code>v</code> in the <code>manifest["term"]</code> array, where <code>term</code> is one of the <a href="#creators">creator</a> terms, is a simple string or <a>localizable string</a>, exchange that element of the array to<br><code>{"@type": ["Person"], "name": [v]}</code>
+				<li> (<a href="#creators"></a>) if one of the values <code>v</code> in the
+						<code>manifest["term"]</code> array, where <code>term</code> is one of the
+						<a href="#creators">creator</a> terms, is a simple string or <a>localizable
+						string</a>, exchange that element of the array to<br /><code>{"@type":
+						["Person"], "name": [v]}</code>
 				</li>
-				<li>
-					(<a href="#link-values"></a>) if one of the values <code>v</code> in the <code>manifest["term"]</code> array, where <code>term</code> is one of the <a href="#resource-categorization-properties">resource categorization properties</a>, is a simple string, exchange that element of the array to<br><code>{"@type": ["PublicationLink"], "url": v}</code>
+				<li> (<a href="#link-values"></a>) if one of the values <code>v</code> in the
+						<code>manifest["term"]</code> array, where <code>term</code> is one of the
+						<a href="#resource-categorization-properties">resource categorization
+						properties</a>, is a simple string, exchange that element of the array
+						to<br /><code>{"@type": ["PublicationLink"], "url": v}</code>
 				</li>
-				<li>
-					(<a href="#strings-vs-objects"></a>) if the value, or one of the values in case of an array, of <code>P["term"]</code>, where <code>P</code> is any object in <code>manifest</code> (including itself) and <code>term</code> is:
-					<ul>
+				<li> (<a href="#strings-vs-objects"></a>) if the value, or one of the values in case
+					of an array, of <code>P["term"]</code>, where <code>P</code> is any object in
+						<code>manifest</code> (including itself) and <code>term</code> is: <ul>
 						<li><code>accessibilitySummary</code>; or</li>
 						<li><code>name</code>; or</li>
 						<li><code>description</code></li>
-					</ul>
-					is a single string <code>v</code>, then change the relevant term/value to:
-					<ul>
-						<li>if <code>manifest[inLanguage]</code> is set to the value of <code>l</code> then<br><code>"term": { "@value": v,"@language": l</code></li>
-						<li>otherwise<br><code>"term": {"@value": v}</code></li>
+					</ul> is a single string <code>v</code>, then change the relevant term/value to: <ul>
+						<li>if <code>manifest[inLanguage]</code> is set to the value of
+								<code>l</code> then<br /><code>"term": { "@value": v,"@language":
+								l</code></li>
+						<li>otherwise<br /><code>"term": {"@value": v}</code></li>
 					</ul>
 				</li>
-				<li>
-					(<a href="#manifest-relative-urls"></a>) if the value of <code>P["term"]</code>, where <code>P</code> is any object in <code>manifest</code> (including itself) and <code>term</code> is:
-					<ul>
+				<li> (<a href="#manifest-relative-urls"></a>) if the value of
+					<code>P["term"]</code>, where <code>P</code> is any object in
+						<code>manifest</code> (including itself) and <code>term</code> is: <ul>
 						<li><code>url</code>; or</li>
 						<li><code>@id</code></li>
-					</ul>
-					is a single string <code>u</code> which is <em>not</em> an <a href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL string</a>&nbsp;[[!url]], then resolve this value (considered to be a relative URL) using the value of <code>base</code>, yielding the value of <code>au</code>, and replace the term/value pair by<br><code>"term": au</code>
+					</ul> is a single string <code>u</code> which is <em>not</em> an <a
+						href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL
+						string</a>&#160;[[!url]], then resolve this value (considered to be a
+					relative URL) using the value of <code>base</code>, yielding the value of
+						<code>au</code>, and replace the term/value pair by<br /><code>"term":
+						au</code>
 				</li>
 			</ol>
 		</section>
@@ -2622,24 +2923,27 @@
 			<h2>Web Publication Lifecycle</h2>
 
 			<div class="ednote">
-				<p>The publishing working group is currently evaluating the best approach for implementing <a>Web
-						Publications</a> in user agents. This note is intended to provide an overview of where current
-					thinking is at and what issues are under consideration.</p>
+				<p>The publishing working group is currently evaluating the best approach for
+					implementing <a>Web Publications</a> in user agents. This note is intended to
+					provide an overview of where current thinking is at and what issues are under
+					consideration.</p>
 
-				<p>The development of Web Publications is not viewed as a separate forking of the Web, but an
-					enhancement layer that can be supported by user agents. To that end, the primary constraints on any
-					solution for Web Publications are that:</p>
+				<p>The development of Web Publications is not viewed as a separate forking of the
+					Web, but an enhancement layer that can be supported by user agents. To that end,
+					the primary constraints on any solution for Web Publications are that:</p>
 
 				<ul>
-					<li>the rendering of Web Publications must not interfere with the underlying Web model and <abbr
-							title="Application Programming Interfaces">APIs</abbr> &#8212; all functionality and
-						enhancements must be layered on top;</li>
-					<li>a Web Publication should not have to carry its own implementation code &#8212; functionality is
-						ideally provided by the user agent and/or polyfill.</li>
+					<li>the rendering of Web Publications must not interfere with the underlying Web
+						model and <abbr title="Application Programming Interfaces">APIs</abbr>
+						&#8212; all functionality and enhancements must be layered on top;</li>
+					<li>a Web Publication should not have to carry its own implementation code
+						&#8212; functionality is ideally provided by the user agent and/or
+						polyfill.</li>
 				</ul>
 
-				<p>While this specification will provide implementation flexibility for user agents, there are still a
-					number of areas that have been identified as potentially needing to be detailed. These include:</p>
+				<p>While this specification will provide implementation flexibility for user agents,
+					there are still a number of areas that have been identified as potentially
+					needing to be detailed. These include:</p>
 
 				<ul>
 					<li>
@@ -2677,121 +2981,136 @@
 					<li>updating of the <a>manifest</a>.</li>
 				</ul>
 
-				<p>The working group intends to flesh out the lifecycle in later revisions once it is clearer what
-					models are viable and what solutions can be standardized. Input on the feasibility and challenges of
-					these approaches is welcome at any time.</p>
+				<p>The working group intends to flesh out the lifecycle in later revisions once it
+					is clearer what models are viable and what solutions can be standardized. Input
+					on the feasibility and challenges of these approaches is welcome at any
+					time.</p>
 			</div>
 
 			<section id="obtaining-manifest">
 				<h3>Obtaining a manifest</h3>
 
-				<p class="ednote">This section requires additional work now that we also allow JSON-LD embedded in
-					HTML.</p>
+				<p class="ednote">This section requires additional work now that we also allow
+					JSON-LD embedded in HTML.</p>
 
-				<p>The <dfn data-lt="obtaining the manifest|obtaining a manifest|obtains a manifest">steps for obtaining
-						a manifest</dfn> are given by the following algorithm. The algorithm, if successful, returns a
-						<a>processed manifest</a> and the <var>manifest URL</var>; otherwise, it terminates prematurely
-					and returns nothing. In the case of nothing being returned, the user agent MUST ignore the manifest
-					declaration.</p>
+				<p>The <dfn data-lt="obtaining the manifest|obtaining a manifest|obtains a manifest"
+						>steps for obtaining a manifest</dfn> are given by the following algorithm.
+					The algorithm, if successful, returns a <a>processed manifest</a> and the
+						<var>manifest URL</var>; otherwise, it terminates prematurely and returns
+					nothing. In the case of nothing being returned, the user agent MUST ignore the
+					manifest declaration.</p>
 
 				<ol>
-					<li>From the <code>Document</code> of the top-level browsing context, let <var>origin</var> be the
-							<code>Document</code>'s origin, and <var>manifest link</var> be the first <code>link</code>
-						element in tree order whose <code>rel</code> attribute contains the token
+					<li>From the <code>Document</code> of the top-level browsing context, let
+							<var>origin</var> be the <code>Document</code>'s origin, and
+							<var>manifest link</var> be the first <code>link</code> element in tree
+						order whose <code>rel</code> attribute contains the token
 							<code>publication</code>. </li>
-					<li>If <var>origin</var> is an [[!html]] opaque origin, terminate this algorithm. </li>
+					<li>If <var>origin</var> is an [[!html]] opaque origin, terminate this
+						algorithm. </li>
 					<li>If <var>manifest link</var> is <code>null</code>, terminate this algorithm. </li>
-					<li>If <var>manifest link</var>'s <code>href</code> attribute's value is the empty string, then
-						abort these steps. </li>
-					<li>Let <var>manifest URL</var> be the result of parsing the value of the <code>href</code>
-						attribute, relative to the element's base URL. If parsing fails, then abort these steps. </li>
-					<li>Let <var>request</var> be a new [[!fetch]] request, whose URL is <var>manifest URL</var>, and
-						whose context is the same as the browsing context of the <code>Document</code>. </li>
-					<li>If the <var>manifest link</var>'s <code>crossOrigin</code> attribute's value is
-							'<code>use-credentials</code>', then set <var>request</var>'s credentials to
-							'<code>include</code>'. </li>
-					<li>Await the result of performing a fetch with <var>request</var>, letting <var>response</var> be
-						the result. </li>
+					<li>If <var>manifest link</var>'s <code>href</code> attribute's value is the
+						empty string, then abort these steps. </li>
+					<li>Let <var>manifest URL</var> be the result of parsing the value of the
+							<code>href</code> attribute, relative to the element's base URL. If
+						parsing fails, then abort these steps. </li>
+					<li>Let <var>request</var> be a new [[!fetch]] request, whose URL is
+							<var>manifest URL</var>, and whose context is the same as the browsing
+						context of the <code>Document</code>. </li>
+					<li>If the <var>manifest link</var>'s <code>crossOrigin</code> attribute's value
+						is '<code>use-credentials</code>', then set <var>request</var>'s credentials
+						to '<code>include</code>'. </li>
+					<li>Await the result of performing a fetch with <var>request</var>, letting
+							<var>response</var> be the result. </li>
 					<li>If <var>response</var> is a network error, terminate this algorithm. </li>
 					<li>Let <var>text</var> be the result of UTF-8 decoding <var>response</var>'s <a
 							data-cite="!fetch#concept-request-body">body</a>. </li>
-					<li>Let <var>manifest</var> be the result of running <a>processing a manifest</a> given
-							<var>text</var>, <var>manifest URL</var>, and the URL that represents the address of the
-						top-level browsing context. </li>
+					<li>Let <var>manifest</var> be the result of running <a>processing a
+							manifest</a> given <var>text</var>, <var>manifest URL</var>, and the URL
+						that represents the address of the top-level browsing context. </li>
 					<li>Return <var>manifest</var> and <var>manifest URL</var>. </li>
 				</ol>
 
-				<p class="note">See the <a href="#obtaining-manifest-diagram">diagram in the appendix</a> for a visual
-					representation of the algorithm.</p>
+				<p class="note">See the <a href="#obtaining-manifest-diagram">diagram in the
+						appendix</a> for a visual representation of the algorithm.</p>
 			</section>
 
 			<section id="processing-manifest">
 				<h3>Processing the manifest</h3>
 
-				<p class="ednote">The new JSON-LD based approach will require additional processing from the client. Due
-					to the flexible nature of JSON-LD and schema.org, a simple conversion from JSON to WebIDL will not
-					be enough.</p>
+				<p class="ednote">The new JSON-LD based approach will require additional processing
+					from the client. Due to the flexible nature of JSON-LD and schema.org, a simple
+					conversion from JSON to WebIDL will not be enough.</p>
 
-				<p>The <dfn data-lt="processing the manifest|processing a manifest">steps for processing a
-						manifest</dfn> are given by the following algorithm. The algorithm takes a <var>text</var>
-					string as an argument, which represents a <a>manifest</a>, and a <var>manifest
-					URL</var>&#160;[[!url]], which represents the location of the manifest, and a <var>document
-						URL</var>&#160;[[!url]]. The output from inputting a JSON document into this algorithm is a
-						<dfn>processed manifest</dfn>. </p>
+				<p>The <dfn data-lt="processing the manifest|processing a manifest">steps for
+						processing a manifest</dfn> are given by the following algorithm. The
+					algorithm takes a <var>text</var> string as an argument, which represents a
+						<a>manifest</a>, and a <var>manifest URL</var>&#160;[[!url]], which
+					represents the location of the manifest, and a <var>document
+					URL</var>&#160;[[!url]]. The output from inputting a JSON document into this
+					algorithm is a <dfn>processed manifest</dfn>. </p>
 
 				<ol>
-					<li>Let <var>json</var> be the result of <a data-cite="!ecmascript#sec-json.parse">parsing</a>
-						<var>text</var>. If <a data-cite="!ecmascript#sec-json.parse">parsing</a> throws an error: <ol>
-							<li>Issue a developer warning with any details pertaining to the JSON parsing error. </li>
-							<li>Set <var>json</var> to be the result of <a data-cite="!ecmascript#sec-24.5.1"
-									>parsing</a> the string <code>"{}"</code>. </li>
+					<li>Let <var>json</var> be the result of <a
+							data-cite="!ecmascript#sec-json.parse">parsing</a>
+						<var>text</var>. If <a data-cite="!ecmascript#sec-json.parse">parsing</a>
+						throws an error: <ol>
+							<li>Issue a developer warning with any details pertaining to the JSON
+								parsing error. </li>
+							<li>Set <var>json</var> to be the result of <a
+									data-cite="!ecmascript#sec-24.5.1">parsing</a> the string
+									<code>"{}"</code>. </li>
 						</ol>
 					</li>
 					<li>If Type(<var>json</var>) is not <code>Object</code>: <ol>
 							<li>Issue a developer warning that the manifest needs to be an object. </li>
-							<li>Set <var>json</var> to be the result of <a data-cite="!ecmascript#sec-24.5.1"
-									>parsing</a> the string <code>"{}"</code>. </li>
+							<li>Set <var>json</var> to be the result of <a
+									data-cite="!ecmascript#sec-24.5.1">parsing</a> the string
+									<code>"{}"</code>. </li>
 						</ol>
 					</li>
-					<li>Extension point: process any proprietary and/or other supported members at this point in the
-						algorithm. </li>
-					<li>Let <var>manifest</var> be the result of <a href="https://www.w3.org/TR/WebIDL-1/#es-dictionary"
-							>converting</a> [[!webidl-1]] <var>json</var> to a <a>WebPublicationManifest</a> dictionary.
+					<li>Extension point: process any proprietary and/or other supported members at
+						this point in the algorithm. </li>
+					<li>Let <var>manifest</var> be the result of <a
+							href="https://www.w3.org/TR/WebIDL-1/#es-dictionary">converting</a>
+						[[!webidl-1]] <var>json</var> to a <a>WebPublicationManifest</a> dictionary.
 					</li>
 				</ol>
 
-				<p class="note">See the <a href="#processing-manifest-diagram">diagram in the appendix</a> for a visual
-					representation of the algorithm.</p>
+				<p class="note">See the <a href="#processing-manifest-diagram">diagram in the
+						appendix</a> for a visual representation of the algorithm.</p>
 			</section>
 
 		</section>
 		<section id="wp-features">
 			<h2>User Agent Features</h2>
 
-			<p class="ednote">This section contains placeholders for possible reading enhancements/features the user
-				agent may/should/must provide. The list is subject to addition, modification and removal as the
-				enhancements get discussed in more detail.</p>
+			<p class="ednote">This section contains placeholders for possible reading
+				enhancements/features the user agent may/should/must provide. The list is subject to
+				addition, modification and removal as the enhancements get discussed in more
+				detail.</p>
 
 			<p class="issue" data-number="143"></p>
 
 			<section id="feature-publication-mode">
 				<h3>Switch to publication mode</h3>
 
-				<p>When a user agent <a>obtains a manifest</a> it SHOULD provide the option to switch the display to
-						<a>publication mode</a>.</p>
+				<p>When a user agent <a>obtains a manifest</a> it SHOULD provide the option to
+					switch the display to <a>publication mode</a>.</p>
 
 				<p>This feature has the following requirements:</p>
 
 				<ol>
-					<li>it MUST inform the user that the current resource is part of a <a>Web Publication</a></li>
+					<li>it MUST inform the user that the current resource is part of a <a>Web
+							Publication</a></li>
 					<li>it SHOULD display the title of the Web Publication</li>
 					<li>it MAY display additional metadata from the <abbr title="information set"
-						><a>infoset</a></abbr></li>
+								><a>infoset</a></abbr></li>
 				</ol>
 
-				<p><dfn>Publication mode</dfn> is a display mode implemented by the user agent that follows the
-					conventions listed in <a href="#feature-presentation">presentation</a> and <a
-						href="#feature-navigation">navigation</a>.</p>
+				<p><dfn>Publication mode</dfn> is a display mode implemented by the user agent that
+					follows the conventions listed in <a href="#feature-presentation"
+						>presentation</a> and <a href="#feature-navigation">navigation</a>.</p>
 			</section>
 
 			<section id="feature-presentation">
@@ -2800,48 +3119,56 @@
 				<section id="layout">
 					<h4>Layout</h4>
 
-					<p>The layout and rendering of <a>Web Publications</a> is governed by the same rules that apply to
-						all Web content: <abbr title="Hypertext Markup Language">HTML</abbr> documents are styled and
-						laid out according to the rules of <abbr title="Cascading Style Sheets">CSS</abbr>, SVG
-						documents are rendered as defined by that format, etc. This specification requires no particular
-						profile or subset of <abbr title="Cascading Style Sheets">CSS</abbr>, <abbr
-							title="Hypertext Markup Language">HTML</abbr>, or <abbr title="Scalable Vector Graphics"
-							>SVG</abbr> to be supported, other than the expectations set for these technologies by their
-						respective specifications.</p>
+					<p>The layout and rendering of <a>Web Publications</a> is governed by the same
+						rules that apply to all Web content: <abbr title="Hypertext Markup Language"
+							>HTML</abbr> documents are styled and laid out according to the rules of
+							<abbr title="Cascading Style Sheets">CSS</abbr>, SVG documents are
+						rendered as defined by that format, etc. This specification requires no
+						particular profile or subset of <abbr title="Cascading Style Sheets"
+							>CSS</abbr>, <abbr title="Hypertext Markup Language">HTML</abbr>, or
+							<abbr title="Scalable Vector Graphics">SVG</abbr> to be supported, other
+						than the expectations set for these technologies by their respective
+						specifications.</p>
 
 					<div class="ednote">
-						<p>This specification intentionally avoids introducing any new layout features. Any shortcoming
-							of the Web platform in terms of layout needs to be addressed for the whole Web platform,
-							which means via <abbr title="Cascading Style Sheets">CSS</abbr>.</p>
+						<p>This specification intentionally avoids introducing any new layout
+							features. Any shortcoming of the Web platform in terms of layout needs
+							to be addressed for the whole Web platform, which means via <abbr
+								title="Cascading Style Sheets">CSS</abbr>.</p>
 
 						<p>This working group will work with other relevant groups of the <abbr
-								title="World Wide Web Consortium">W3C</abbr> to address platform-wide limitations that
-							negatively impact <a>Web Publications</a>.</p>
+								title="World Wide Web Consortium">W3C</abbr> to address
+							platform-wide limitations that negatively impact <a>Web
+							Publications</a>.</p>
 					</div>
 
-					<p>For the purposes of layout, each resource of a Web Publication is treated as a separate document.
-						User agents MUST NOT mix content from multiple resources in the same rendering (e.g., <a
-							href="https://www.w3.org/TR/CSS21/visuren.html#floats">CSS floats</a> or <a
-							href="https://www.w3.org/TR/CSS21/visuren.html#absolutely-positioned">absolutely positioned
-							elements</a> from one resource cannot intrude or overlap with content from an other
-						resource).</p>
+					<p>For the purposes of layout, each resource of a Web Publication is treated as
+						a separate document. User agents MUST NOT mix content from multiple
+						resources in the same rendering (e.g., <a
+							href="https://www.w3.org/TR/CSS21/visuren.html#floats">CSS floats</a> or
+							<a href="https://www.w3.org/TR/CSS21/visuren.html#absolutely-positioned"
+							>absolutely positioned elements</a> from one resource cannot intrude or
+						overlap with content from an other resource).</p>
 
 					<div class="note">
-						<p>Despite this general requirement that each resource should be treated as a separate document
-							for the purpose of layout, there are some places where <abbr title="Cascading Style Sheets"
-								>CSS</abbr> specifications should be amended to be able to deal more intelligently with
-							collections of resources like <a>Web Publications</a>.</p>
+						<p>Despite this general requirement that each resource should be treated as
+							a separate document for the purpose of layout, there are some places
+							where <abbr title="Cascading Style Sheets">CSS</abbr> specifications
+							should be amended to be able to deal more intelligently with collections
+							of resources like <a>Web Publications</a>.</p>
 
 						<p>One instance is the definition of <a
-								href="https://drafts.csswg.org/css-content/#cross-references">cross-references</a>,
-							which are currently restricted to work only within a single document. This restriction
-							should be relaxed to allow for cross-references between separate resources of a single Web
+								href="https://drafts.csswg.org/css-content/#cross-references"
+								>cross-references</a>, which are currently restricted to work only
+							within a single document. This restriction should be relaxed to allow
+							for cross-references between separate resources of a single Web
 							Publication.</p>
 
 						<p>Another related would be to allow <a
-								href="https://drafts.csswg.org/css-lists-3/#counter-properties">counters</a> to
-							accumulate across multiple resources of a single Web Publication (e.g., so that figures in
-							multiple sections may be numbered in a single sequence).</p>
+								href="https://drafts.csswg.org/css-lists-3/#counter-properties"
+								>counters</a> to accumulate across multiple resources of a single
+							Web Publication (e.g., so that figures in multiple sections may be
+							numbered in a single sequence).</p>
 					</div>
 
 				</section>
@@ -2849,8 +3176,8 @@
 				<section id="feature-user-settings">
 					<h4>User Settings</h4>
 
-					<p>When a user agent renders a <a>Web Publication</a>, it SHOULD provide user settings to customize
-						the experience.</p>
+					<p>When a user agent renders a <a>Web Publication</a>, it SHOULD provide user
+						settings to customize the experience.</p>
 
 					<p>User settings MAY include:</p>
 
@@ -2861,13 +3188,14 @@
 						<li>playback speed (for audio and video resources).</li>
 					</ul>
 
-					<p>This specification does not cover how user agents override author styles to offer user
-						settings.</p>
+					<p>This specification does not cover how user agents override author styles to
+						offer user settings.</p>
 
 					<div class="ednote">
-						<p>To provide user settings in their reader mode, browsers usually get rid of most of the author
-							styles. There is always a tension in reading environments between author styles and the
-							user's preference, which is very hard to balance.</p>
+						<p>To provide user settings in their reader mode, browsers usually get rid
+							of most of the author styles. There is always a tension in reading
+							environments between author styles and the user's preference, which is
+							very hard to balance.</p>
 					</div>
 
 					<p class="issue" data-number="138"></p>
@@ -2876,21 +3204,24 @@
 				<section id="scrolling-or-paginating" class="informative">
 					<h4>Scrolling or Paginating</h4>
 
-					<p>Publications have historically been presented via paged media, whereas Web pages almost always
-						scroll. As the preferences of individual readers vary, and as different types of publications
-						are better suited for one or the other, this specification encourages user agents to support
-						both, and to offer a choice to their users.</p>
+					<p>Publications have historically been presented via paged media, whereas Web
+						pages almost always scroll. As the preferences of individual readers vary,
+						and as different types of publications are better suited for one or the
+						other, this specification encourages user agents to support both, and to
+						offer a choice to their users.</p>
 
 					<div class="ednote">
-						<p>It might be useful for authors to be able to specify a preference between scrolling and
-							pagination, even if a strict requirement is not possible. This should most likely be
-							addressed through an extension of <a
+						<p>It might be useful for authors to be able to specify a preference between
+							scrolling and pagination, even if a strict requirement is not possible.
+							This should most likely be addressed through an extension of <a
 								href="https://www.w3.org/TR/css-device-adapt-1/#atviewport-rule"
-								><code>@viewport</code></a> or of <a
-								href="https://drafts.csswg.org/css-device-adapt/#viewport-meta">the viewport meta
-								tag</a>(see&#160;[[css-device-adapt]]), or possibly through an extension of <a
-								href="https://drafts.csswg.org/css-page-3/#at-page-rule"><code>@page</code></a>
-							(see&#160;[[css-page-3]]). This should be discussed with the relevant working groups (<a
+									><code>@viewport</code></a> or of <a
+								href="https://drafts.csswg.org/css-device-adapt/#viewport-meta">the
+								viewport meta tag</a>(see&#160;[[css-device-adapt]]), or possibly
+							through an extension of <a
+								href="https://drafts.csswg.org/css-page-3/#at-page-rule"
+									><code>@page</code></a> (see&#160;[[css-page-3]]). This should
+							be discussed with the relevant working groups (<a
 								href="https://www.w3.org/Style/CSS/">CSSWG</a>, <a
 								href="https://www.w3.org/WebPlatform/WG/">WebPlatformWG</a>, <a
 								href="https://whatwg.org/">WHATWG</a>).</p>
@@ -2901,40 +3232,45 @@
 				<section id="feature-pagination">
 					<h4>Paginated Layout</h4>
 
-					<p>When a user agent renders a <a>Web Publication</a> in a paginated layout, it MUST lay out each
-						document in the <a>default reading order</a> sequentially, with the last page of a resource
-						being followed by the first page of the subsequent one.</p>
+					<p>When a user agent renders a <a>Web Publication</a> in a paginated layout, it
+						MUST lay out each document in the <a>default reading order</a> sequentially,
+						with the last page of a resource being followed by the first page of the
+						subsequent one.</p>
 
 					<div class="ednote">
-						<p>To avoid blank pages, if a resource ends on a left page (resp. right page), the subsequent
-							one should start on a right page (resp. left page) even if the <a
-								href="https://drafts.csswg.org/css-page-3/#progression">page progression</a>
-							(see&#160;[[css-page-3]]) would otherwise lead to it starting on the opposite page. It
-							should also be possible to use the <a
-								href="https://www.w3.org/TR/css-break-3/#propdef-break-before">break-before</a> property
-							(see&#160;[[!css-break-3]]) to force the content to resume on the opposite side if that was
-							desired by the author.</p>
+						<p>To avoid blank pages, if a resource ends on a left page (resp. right
+							page), the subsequent one should start on a right page (resp. left page)
+							even if the <a href="https://drafts.csswg.org/css-page-3/#progression"
+								>page progression</a> (see&#160;[[css-page-3]]) would otherwise lead
+							to it starting on the opposite page. It should also be possible to use
+							the <a href="https://www.w3.org/TR/css-break-3/#propdef-break-before"
+								>break-before</a> property (see&#160;[[!css-break-3]]) to force the
+							content to resume on the opposite side if that was desired by the
+							author.</p>
 
-						<p>[[css-page-3]] needs to be amended to describe this exception to the general behavior when
-							dealing with collections of documents instead of individual documents.</p>
+						<p>[[css-page-3]] needs to be amended to describe this exception to the
+							general behavior when dealing with collections of documents instead of
+							individual documents.</p>
 					</div>
 
 
 					<div class="ednote">
-						<p>How is pagination supposed to work when subsequent resources have opposite <a
-								href="https://drafts.csswg.org/css-page-3/#progression">page progression</a> directions
-							(see&#160;[[css-page-3]]). For example, due to different a different writing mode? This is
-							not necessarily a problem from a layout point of view, as each page is independent, but from
-							an UI point of view. If swiping left means next page until the end of one chapter, and
-							starts meaning previous page in the next chapter because the language is switched from
-							English to Hebrew, this is going to be confusing.</p>
+						<p>How is pagination supposed to work when subsequent resources have
+							opposite <a href="https://drafts.csswg.org/css-page-3/#progression">page
+								progression</a> directions (see&#160;[[css-page-3]]). For example,
+							due to different a different writing mode? This is not necessarily a
+							problem from a layout point of view, as each page is independent, but
+							from an UI point of view. If swiping left means next page until the end
+							of one chapter, and starts meaning previous page in the next chapter
+							because the language is switched from English to Hebrew, this is going
+							to be confusing.</p>
 					</div>
 
 					<div class="ednote">
 						<p>[[css-page-3]] needs to be amended so that <a
-								href="https://drafts.csswg.org/css-page-3/#page-based-counters">page counters</a> are
-							not automatically reset to at the beginning of each new resource belonging to the same Web
-							Publication.</p>
+								href="https://drafts.csswg.org/css-page-3/#page-based-counters">page
+								counters</a> are not automatically reset to at the beginning of each
+							new resource belonging to the same Web Publication.</p>
 					</div>
 
 					<p class="issue" data-number="137"></p>
@@ -2950,20 +3286,24 @@
 				<section id="feature-reading-order">
 					<h4>Reading Order</h4>
 
-					<p>Hyperlinks are the means by which multiple resources are linked together on the Web. When users
-						reach the end of one resource, they have to activate a hyperlink to move to the next resource in
-						the sequence. While this model of navigation is effective, it is also disruptive for immersive
-						reading &#8212; it forces users to disengage from the content and perform the actions necessary
-						to activate the links. It is also limited to media types that support hyperlinks.</p>
+					<p>Hyperlinks are the means by which multiple resources are linked together on
+						the Web. When users reach the end of one resource, they have to activate a
+						hyperlink to move to the next resource in the sequence. While this model of
+						navigation is effective, it is also disruptive for immersive reading &#8212;
+						it forces users to disengage from the content and perform the actions
+						necessary to activate the links. It is also limited to media types that
+						support hyperlinks.</p>
 
-					<p>The <a>default reading order</a> provides an enhancement to the hyperlink model, allowing the
-						user agent to automatically move the user to the next resource when a more natural action
-						occurs, like a swipe across the screen. It is similar conceptually and functionally to the
-							<code>link</code> element's <a href="https://www.w3.org/TR/html5/links.html#sec-link-types"
-								><code>next</code> and <code>prev</code> relationships</a>&#160;[[!html]].</p>
+					<p>The <a>default reading order</a> provides an enhancement to the hyperlink
+						model, allowing the user agent to automatically move the user to the next
+						resource when a more natural action occurs, like a swipe across the screen.
+						It is similar conceptually and functionally to the <code>link</code>
+						element's <a href="https://www.w3.org/TR/html5/links.html#sec-link-types"
+								><code>next</code> and <code>prev</code>
+						relationships</a>&#160;[[!html]].</p>
 
-					<p>User agents MUST provide the ability to move forward and backward in the <a>default reading
-							order</a> of a <a>Web Publication</a>.</p>
+					<p>User agents MUST provide the ability to move forward and backward in the
+							<a>default reading order</a> of a <a>Web Publication</a>.</p>
 
 					<p class="issue" data-number="144"></p>
 					<p class="issue" data-number="38"></p>
@@ -2972,19 +3312,21 @@
 				<section id="feature-progression">
 					<h4>Progression</h4>
 
-					<p>While reading a <a>Web Publication</a>, the user follows a natural progression within a resource
-						as well as between resources (following the <a>default reading order</a>).</p>
+					<p>While reading a <a>Web Publication</a>, the user follows a natural
+						progression within a resource as well as between resources (following the
+							<a>default reading order</a>).</p>
 
-					<p>User agents SHOULD provide the option to save this progression in the publication and returns the
-						user to their last location the next time they open the publication.</p>
+					<p>User agents SHOULD provide the option to save this progression in the
+						publication and returns the user to their last location the next time they
+						open the publication.</p>
 
-					<p>When the user agent <a>obtains a manifest</a> for the first time, it MAY also prompt the user
-						whether they would like to:</p>
+					<p>When the user agent <a>obtains a manifest</a> for the first time, it MAY also
+						prompt the user whether they would like to:</p>
 
 					<ul>
 						<li>continue reading the publication from their current location; or</li>
-						<li>start reading the publication from the first resource in the <a>default reading
-							order</a>.</li>
+						<li>start reading the publication from the first resource in the <a>default
+								reading order</a>.</li>
 					</ul>
 					<p class="issue" data-number="145"></p>
 				</section>
@@ -2995,34 +3337,41 @@
 
 					<section>
 						<h5>Short description</h5>
-						<p> The user agent should provide access to the table of contents without leaving current
-							resource from anywhere in the publication. </p>
-						<p> For accessibility reasons, it is RECOMMENDED for User Agents to use a table of contents to
-							allow multiple ways for users to access content. </p>
+						<p> The user agent should provide access to the table of contents without
+							leaving current resource from anywhere in the publication. </p>
+						<p> For accessibility reasons, it is RECOMMENDED for User Agents to use a
+							table of contents to allow multiple ways for users to access content.
+						</p>
 					</section>
 					<section>
 						<h5>Affordances</h5>
-						<p> The table of contents is a listed as a structural property in the infoset, see <a
-								href="#table-of-contents"></a>
+						<p> The table of contents is a listed as a structural property in the
+							infoset, see <a href="#table-of-contents"></a>
 						</p>
-						<p> The table of content is referred to in the Web Publication Manifest (see <a
-								href="#table-of-contents-manifest"></a>) and is expressed using an HTML element; see <a
-								href="#table-of-contents"></a> for further details. </p>
-						<p> User agents MAY use the <a>default reading order</a> in the case a Table of Contents is not
-							explicitly specified to create a table of contents. </p>
+						<p> The table of content is referred to in the Web Publication Manifest (see
+								<a href="#table-of-contents-manifest"></a>) and is expressed using
+							an HTML element; see <a href="#table-of-contents"></a> for further
+							details. </p>
+						<p> User agents MAY use the <a>default reading order</a> in the case a Table
+							of Contents is not explicitly specified to create a table of contents.
+						</p>
 					</section>
 					<section>
 						<h5>Use Case References</h5>
 
 						<dl>
-							<dt><a href="https://www.w3.org/TR/pwp-ucr/#r_reading-order">Req. 12</a></dt>
-							<dd> “There should be a means to indicate the author’s preferred navigation structure among
-								the resources of a Web Publication. A user agent needs to know the sequence in which to
-								present components of a Web Publication to the user, including the starting point.” (See
-								[[pwp-ucr]]) </dd>
-							<dt><a href="https://www.w3.org/TR/pwp-ucr/#r_random-access">Req. 13</a></dt>
-							<dd> “Authors of a Web Publication should be able to provide the user agent with information
-								to access random parts of the publication” (See [[pwp-ucr]]) </dd>
+							<dt><a href="https://www.w3.org/TR/pwp-ucr/#r_reading-order">Req.
+								12</a></dt>
+							<dd> “There should be a means to indicate the author’s preferred
+								navigation structure among the resources of a Web Publication. A
+								user agent needs to know the sequence in which to present components
+								of a Web Publication to the user, including the starting point.”
+								(See [[pwp-ucr]]) </dd>
+							<dt><a href="https://www.w3.org/TR/pwp-ucr/#r_random-access">Req.
+								13</a></dt>
+							<dd> “Authors of a Web Publication should be able to provide the user
+								agent with information to access random parts of the publication”
+								(See [[pwp-ucr]]) </dd>
 						</dl>
 					</section>
 				</section>
@@ -3037,8 +3386,8 @@
 			<section id="feature-search">
 				<h3>Search</h3>
 
-				<p class="ednote">Detail on inter-publication search across multiple resources will be included in a
-					future draft.</p>
+				<p class="ednote">Detail on inter-publication search across multiple resources will
+					be included in a future draft.</p>
 			</section>
 
 			<section id="feature-reading-state">
@@ -3048,94 +3397,109 @@
 
 				<section>
 					<h5>Short description</h5>
-					<p> The user must be able to leave the Web Publication and return to it at the last position they
-						left from. The User Agent must retain the reading position, based on the last known position of
-						the reader in the web publication. The position should be based on the reader's position in the
+					<p> The user must be able to leave the Web Publication and return to it at the
+						last position they left from. The User Agent must retain the reading
+						position, based on the last known position of the reader in the web
+						publication. The position should be based on the reader's position in the
 						file, within the reading order. </p>
-					<p> The user agent may retain reading state if the web publication is revised. </p>
+					<p> The user agent may retain reading state if the web publication is revised.
+					</p>
 				</section>
 				<section>
 					<h5>Affordances</h5>
-					<p> The navigation of the web publication should be defined in the <a>Default Reading Order</a>
-						required by the Information Set. </p>
-					<p> User Agents should not have to set the reading state in the following type of resources: </p>
+					<p> The navigation of the web publication should be defined in the <a>Default
+							Reading Order</a> required by the Information Set. </p>
+					<p> User Agents should not have to set the reading state in the following type
+						of resources: </p>
 					<ul>
 						<li>External Links (i.e. a link to google.com)</li>
 						<li>Data references (i.e. a linked CSV file)</li>
 						<li>Multimedia content (i.e. a video)</li>
 					</ul>
 
-					<p> Reading state should only apply to content documents listed as being within the bounds of the
-						Web Publication. </p>
+					<p> Reading state should only apply to content documents listed as being within
+						the bounds of the Web Publication. </p>
 				</section>
 				<section>
 					<h5>Examples</h5>
-					<p> Example 1:<br /> Sarah is reading a long article on her way to work. She arrives before she has
-						finished, but wants to continue from the place she left off. The user agent should remember her
-						reading state for the next time she opens the publication. </p>
+					<p> Example 1:<br /> Sarah is reading a long article on her way to work. She
+						arrives before she has finished, but wants to continue from the place she
+						left off. The user agent should remember her reading state for the next time
+						she opens the publication. </p>
 
 					<h5>Testing</h5>
-					<p> If a tester opens a web publication in a WP-aware UA, moves ahead in the publication, closes the
-						reader, then reopens it, they should be returned to the last known reading state. </p>
+					<p> If a tester opens a web publication in a WP-aware UA, moves ahead in the
+						publication, closes the reader, then reopens it, they should be returned to
+						the last known reading state. </p>
 				</section>
 			</section>
 		</section>
 		<section id="locators" class="informative">
 			<h3>Web Publication Locators</h3>
 
-			<p class="ednote"> The document referred from this section, i.e., Web Annotation Extensions for Web
-				Publications&#160;[[!wpub-ann]], has been recently renamed. Its previous was "Locators for Web
-				Publication". The terminology used in this section has to be realigned with the name change. </p>
+			<p class="ednote"> The document referred from this section, i.e., Web Annotation
+				Extensions for Web Publications&#160;[[!wpub-ann]], has been recently renamed. Its
+				previous was "Locators for Web Publication". The terminology used in this section
+				has to be realigned with the name change. </p>
 
-			<p>Locators are used to identify, locate, retrieve, and/or reference locations and content fragments within
-					<a>Web Publications</a> (e.g., for address(es), bookmarks, and annotations). Locators traditionally
-				take the form of fragment identifiers&#160;[[rfc3986]], where the portion of a <abbr
-					title="Uniform Resource Locator">URL</abbr> preceded by a number sign character (<code>#</code>)
-				identifies a specific position within the referenced resource.</p>
+			<p>Locators are used to identify, locate, retrieve, and/or reference locations and
+				content fragments within <a>Web Publications</a> (e.g., for address(es), bookmarks,
+				and annotations). Locators traditionally take the form of fragment
+				identifiers&#160;[[rfc3986]], where the portion of a <abbr
+					title="Uniform Resource Locator">URL</abbr> preceded by a number sign character
+					(<code>#</code>) identifies a specific position within the referenced
+				resource.</p>
 
-			<p>For some use cases, it is essential to identify and reference a <a>Web Publication</a> resource—or a
-				location in or a segment of a resource—in the scope or context of the Web Publication to which it
-				belongs. A traditional fragment identifier cannot satisfy this requirement, since only the <abbr
-					title="Uniform Resource Locator">URL</abbr> of the constituent resource containing the location or
-				content fragment of interest is expressed. The Web Annotation Extensions for Web
-				Publications&#160;[[!wpub-ann]] document, based on the Web Annotation Model&#160;[[!annotation-model]],
-				addresses this issue by providing the means to express both the <abbr title="Uniform Resource Locator"
-					>URL</abbr> of the resource and the <abbr title="Uniform Resource Locator">URL</abbr> of the Web
+			<p>For some use cases, it is essential to identify and reference a <a>Web
+					Publication</a> resource—or a location in or a segment of a resource—in the
+				scope or context of the Web Publication to which it belongs. A traditional fragment
+				identifier cannot satisfy this requirement, since only the <abbr
+					title="Uniform Resource Locator">URL</abbr> of the constituent resource
+				containing the location or content fragment of interest is expressed. The Web
+				Annotation Extensions for Web Publications&#160;[[!wpub-ann]] document, based on the
+				Web Annotation Model&#160;[[!annotation-model]], addresses this issue by providing
+				the means to express both the <abbr title="Uniform Resource Locator">URL</abbr> of
+				the resource and the <abbr title="Uniform Resource Locator">URL</abbr> of the Web
 				Publication.</p>
 
-			<p>Web Publication Locators also address the problem of referencing into a resource that was not authored
-				with such a need in mind. A fragment identifier can only reference elements with explicit identifiers
-				and locations with explicit anchor points. Web Publication Locators include a variety of selectors that
-				work with the general structures and content of a resource (e.g., text selectors, <abbr
+			<p>Web Publication Locators also address the problem of referencing into a resource that
+				was not authored with such a need in mind. A fragment identifier can only reference
+				elements with explicit identifiers and locations with explicit anchor points. Web
+				Publication Locators include a variety of selectors that work with the general
+				structures and content of a resource (e.g., text selectors, <abbr
 					title="Cascading Style Sheets">CSS</abbr> selectors).</p>
 
-			<p class="ednote">As Web Publication Locators currently rely on a <abbr title="JavaScript Object Notation"
-					>JSON</abbr>-based expression syntax, it is not yet clear how much of this syntax can be translated
-				to a fragment identifier. This may limit the usefulness beyond expressions that are also <abbr
-					title="JavaScript Object Notation">JSON</abbr>-based (e.g., outside of annotations or
-				bookmarks).</p>
+			<p class="ednote">As Web Publication Locators currently rely on a <abbr
+					title="JavaScript Object Notation">JSON</abbr>-based expression syntax, it is
+				not yet clear how much of this syntax can be translated to a fragment identifier.
+				This may limit the usefulness beyond expressions that are also <abbr
+					title="JavaScript Object Notation">JSON</abbr>-based (e.g., outside of
+				annotations or bookmarks).</p>
 
 			<div class="ednote">
-				<p>Illustrate with example of an easy to understand Web Publication Locator, such as might be used in
-					annotating a simple Web Publication.</p>
+				<p>Illustrate with example of an easy to understand Web Publication Locator, such as
+					might be used in annotating a simple Web Publication.</p>
 			</div>
 
-			<p>The semantics of Web Publication Locators are a mapping and extension of the Web Annotation Data
-				Model&#160;[[annotation-model]] and Vocabulary&#160;[[annotation-vocab]] for describing and referencing
-				a segment of a Web resource. As a result, Web Publication Locators provide the expressiveness needed for
-				a broad range of annotation and bookmarking use cases. Additionally, Web Publication Locators provide a
-				way to identify and reference a location within a Web Publication (i.e., as distinct from identifying
-				and referencing a content fragment consisting of a span of characters or bytes). A Web Publication
-				Locator can be used to identify, retrieve and/or reference a fragment of a Web Publication that spans
+			<p>The semantics of Web Publication Locators are a mapping and extension of the Web
+				Annotation Data Model&#160;[[annotation-model]] and
+				Vocabulary&#160;[[annotation-vocab]] for describing and referencing a segment of a
+				Web resource. As a result, Web Publication Locators provide the expressiveness
+				needed for a broad range of annotation and bookmarking use cases. Additionally, Web
+				Publication Locators provide a way to identify and reference a location within a Web
+				Publication (i.e., as distinct from identifying and referencing a content fragment
+				consisting of a span of characters or bytes). A Web Publication Locator can be used
+				to identify, retrieve and/or reference a fragment of a Web Publication that spans
 				multiple resources. </p>
 
 			<div class="note">
-				<p>In composing a Web Publication Locator, use the <a>canonical identifier</a> of the Web Publication in
-					preference to any alternative addresses. Such use facilitates the collation of Web Publication
-					Locators associated with a particular Web Publication. <abbr title="Uniform Resource Locators"
-						>URLs</abbr> of Web Publication resources appearing in a Web Publication Locator should match
-					the <abbr title="Uniform Resource Locators">URL</abbr> of the resource provided in the <abbr
-						title="information set"><a>infoset</a></abbr>.</p>
+				<p>In composing a Web Publication Locator, use the <a>canonical identifier</a> of
+					the Web Publication in preference to any alternative addresses. Such use
+					facilitates the collation of Web Publication Locators associated with a
+					particular Web Publication. <abbr title="Uniform Resource Locators">URLs</abbr>
+					of Web Publication resources appearing in a Web Publication Locator should match
+					the <abbr title="Uniform Resource Locators">URL</abbr> of the resource provided
+					in the <abbr title="information set"><a>infoset</a></abbr>.</p>
 			</div>
 		</section>
 		<section id="security">
@@ -3154,13 +3518,15 @@
 			<section id="webidl-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>Although a Web Publication manifest is authored as [[json-ld]], user agents process this information
-					into an internal data structure representing the infoset in order to utilize the properties. The
-					exact manner in which this processing occurs, and how the data is used internally, is user
-					agent-dependent. To ensure interoperability when exposing the infoset items, however, this appendix
-					defines a common, abstract representation of the data structures using the standard formalism of the
-					Web Interface Definition Language [[webidl-1]] which can express the expected names, datatypes, and
-					possible restrictions for each member of the infoset. (A WebIDL representation can be mapped onto
+				<p>Although a Web Publication manifest is authored as [[json-ld]], user agents
+					process this information into an internal data structure representing the
+					infoset in order to utilize the properties. The exact manner in which this
+					processing occurs, and how the data is used internally, is user agent-dependent.
+					To ensure interoperability when exposing the infoset items, however, this
+					appendix defines a common, abstract representation of the data structures using
+					the standard formalism of the Web Interface Definition Language [[webidl-1]]
+					which can express the expected names, datatypes, and possible restrictions for
+					each member of the infoset. (A WebIDL representation can be mapped onto
 					ECMAScript, C, or other programming languages.)</p>
 			</section>
 
@@ -3179,43 +3545,50 @@
 					<dt>
 						<dfn>type</dfn>
 					</dt>
-					<dd>Contains the <a href="#manifest-pub-types">publication type</a>; the value is the name of the
-						relevant schema.org type. Required.</dd>
+					<dd>Contains the <a href="#manifest-pub-types">publication type</a>; the value
+						is the name of the relevant schema.org type. Required.</dd>
 
 					<dt>
 						<dfn>accessMode</dfn>
 					</dt>
-					<dd>Contains the value of the <a href="#accessibility">accessMode</a> property.</dd>
+					<dd>Contains the value of the <a href="#accessibility">accessMode</a>
+						property.</dd>
 
 					<dt>
 						<dfn>accessModeSufficient</dfn>
 					</dt>
-					<dd>Contains the value of the <a href="#accessibility">accessModeSufficient</a> property.</dd>
+					<dd>Contains the value of the <a href="#accessibility">accessModeSufficient</a>
+						property.</dd>
 
 					<dt>
 						<dfn>accessibilityAPI</dfn>
 					</dt>
-					<dd>Contains the value of the <a href="#accessibility">accessibilityAPI</a> property.</dd>
+					<dd>Contains the value of the <a href="#accessibility">accessibilityAPI</a>
+						property.</dd>
 
 					<dt>
 						<dfn>accessibilityControl</dfn>
 					</dt>
-					<dd>Contains the value of the <a href="#accessibility">accessibilityControl</a> property.</dd>
+					<dd>Contains the value of the <a href="#accessibility">accessibilityControl</a>
+						property.</dd>
 
 					<dt>
 						<dfn>accessibilityFeature</dfn>
 					</dt>
-					<dd>Contains the value of the <a href="#accessibility">accessibilityFeature</a> property.</dd>
+					<dd>Contains the value of the <a href="#accessibility">accessibilityFeature</a>
+						property.</dd>
 
 					<dt>
 						<dfn>accessibilityHazard</dfn>
 					</dt>
-					<dd>Contains the value of the <a href="#accessibility">accessibilityHazard</a> property.</dd>
+					<dd>Contains the value of the <a href="#accessibility">accessibilityHazard</a>
+						property.</dd>
 
 					<dt>
 						<dfn>accessibilitySummary</dfn>
 					</dt>
-					<dd>Contains the value of the <a href="#accessibility">accessibilitySummary</a> property.</dd>
+					<dd>Contains the value of the <a href="#accessibility">accessibilitySummary</a>
+						property.</dd>
 
 					<dt>
 						<dfn>id</dfn>
@@ -3304,7 +3677,8 @@
 					<dt>
 						<dfn>name</dfn>
 					</dt>
-					<dd>Contains one or more <a href="#wptitle">title(s)</a> for the publication.</dd>
+					<dd>Contains one or more <a href="#wptitle">title(s)</a> for the
+						publication.</dd>
 
 					<dt>
 						<dfn>readingOrder</dfn>
@@ -3325,21 +3699,22 @@
 						<dfn>accessibilityReport</dfn>
 					</dt>
 
-					<dd>Contains the URL reference to the <a href="#accessibility-report">accessibility
-						report</a>.&#160;[[!url]]</dd>
+					<dd>Contains the URL reference to the <a href="#accessibility-report"
+							>accessibility report</a>.&#160;[[!url]]</dd>
 
 					<dt>
 						<dfn>privacyPolicy</dfn>
 					</dt>
 
 					<dd>Contains the URL reference to the <a href="#privacy-policy">privacy
-						policy</a>.&#160;[[!url]]</dd>
+							policy</a>.&#160;[[!url]]</dd>
 
 					<dt>
 						<dfn>cover</dfn>
 					</dt>
 
-					<dd>Contains the URL reference(s) to one or more <a href="#cover">cover(s)</a>.&#160;[[!url]]</dd>
+					<dd>Contains the URL reference(s) to one or more <a href="#cover"
+						>cover(s)</a>.&#160;[[!url]]</dd>
 
 					<dt>
 						<dfn>toc</dfn>
@@ -3352,16 +3727,17 @@
 				<h3><dfn>Person</dfn> and <dfn>Organization</dfn> members</h3>
 
 				<p>These definitions reflect the basic information derived from the schema.org <a
-						href="https://schema.org/Person">Person</a> and <a href="https://schema.org/Organization"
-						>Organization</a> classes, respectively. The WebIDL definitions only contain the minimal
-					information for the <a>infoset</a>; user agents MAY interpret a wider range of properties, as
+						href="https://schema.org/Person">Person</a> and <a
+						href="https://schema.org/Organization">Organization</a> classes,
+					respectively. The WebIDL definitions only contain the minimal information for
+					the <a>infoset</a>; user agents MAY interpret a wider range of properties, as
 					defined by schema.org.</p>
 
 
 				<p>The <a href="#dom-webpublicationmanifest-artist">artist</a>, <a
-						href="#dom-webpublicationmanifest-author">author</a>, etc., members are each a sequence of
-							<a><code>Person</code></a> or <a><code>Organization</code></a> dictionaries with the
-					following members:</p>
+						href="#dom-webpublicationmanifest-author">author</a>, etc., members are each
+					a sequence of <a><code>Person</code></a> or <a><code>Organization</code></a>
+					dictionaries with the following members:</p>
 
 				<pre class="idl" data-include="webidl/person.webidl" data-include-format="text">
                 </pre>
@@ -3392,12 +3768,14 @@
 					<dt>
 						<dfn>id</dfn>
 					</dt>
-					<dd>Contains a canonical identifier of the organization as a URL.&#160;[[url]]</dd>
+					<dd>Contains a canonical identifier of the organization as a
+						URL.&#160;[[url]]</dd>
 
 					<dt>
 						<dfn>url</dfn>
 					</dt>
-					<dd>Contains an address for the organization in the form of a URL.&#160;[[url]]</dd>
+					<dd>Contains an address for the organization in the form of a
+						URL.&#160;[[url]]</dd>
 				</dl>
 
 
@@ -3408,8 +3786,9 @@
 
 				<pre class="idl" data-include="webidl/localizable_string.webidl" data-include-format="text"></pre>
 
-				<p>When the <code>lang</code> is specified in <a><code>LocalizableString</code></a>, this value
-					overrides the default language specified in <a><code>WebPublicationManifest</code></a>.</p>
+				<p>When the <code>lang</code> is specified in <a><code>LocalizableString</code></a>,
+					this value overrides the default language specified in
+							<a><code>WebPublicationManifest</code></a>.</p>
 
 				<p><a><code>LocalizableString</code></a> has the following members:</p>
 
@@ -3421,7 +3800,8 @@
 					<dt>
 						<dfn>lang</dfn>
 					</dt>
-					<dd>Contains the <a href="#language-and-dir">language</a> value.&#160;[[bcp47]]</dd>
+					<dd>Contains the <a href="#language-and-dir">language</a>
+						value.&#160;[[bcp47]]</dd>
 				</dl>
 			</section>
 
@@ -3430,7 +3810,8 @@
 
 				<pre class="idl" data-include="webidl/publication_link.webidl" data-include-format="text"></pre>
 
-				<p>The <a><code>PublicationLink</code></a> dictionary contains the following members:</p>
+				<p>The <a><code>PublicationLink</code></a> dictionary contains the following
+					members:</p>
 
 				<dl data-dfn-for="PublicationLink">
 					<dt>
@@ -3485,7 +3866,8 @@
 
 				<pre class="idl" data-include="webidl/progression_direction.webidl" data-include-format="text"></pre>
 
-				<p>The <a><code>ProgressionDirection</code></a> enum can contain the following values:</p>
+				<p>The <a><code>ProgressionDirection</code></a> enum can contain the following
+					values:</p>
 				<dl data-dfn-for="ProgressionDirection">
 					<dt>
 						<dfn>ltr</dfn>
@@ -3504,20 +3886,28 @@
 
 			<section>
 				<h3>Simple Book</h3>
-				<p>A manifest for a simple book. The <a href="https://w3c.github.io/wpub/experiments/separate_manifest/mobydick.jsonld">canonical version</a> of this manifest is also available.</p>
+				<p>A manifest for a simple book. The <a
+						href="https://w3c.github.io/wpub/experiments/separate_manifest/mobydick.jsonld"
+						>canonical version</a> of this manifest is also available.</p>
 				<pre class="example" data-include="experiments/separate_manifest/mobydick-simple.jsonld" data-include-format="text"></pre>
 			</section>
 
 			<section>
 				<h3>Single-Document Publication</h3>
-				<p>Example for an embedded manifest example. The <a href="https://w3c.github.io/wpub/experiments/w3c_rec/simple-canonical.jsonld">canonical version</a> of the manifest is, as well as a <a href="https://github.com/w3c/wpub/blob/master/experiments/w3c_rec/full_version.html">more elaborate version</a> for the same document are also available.</p>
+				<p>Example for an embedded manifest example. The <a
+						href="https://w3c.github.io/wpub/experiments/w3c_rec/simple-canonical.jsonld"
+						>canonical version</a> of the manifest is, as well as a <a
+						href="https://github.com/w3c/wpub/blob/master/experiments/w3c_rec/full_version.html"
+						>more elaborate version</a> for the same document are also available.</p>
 				<pre class="example" data-include="experiments/w3c_rec/simple_version.html" data-include-format="text"></pre>
 			</section>
 
 			<section>
 				<h3>Audiobook</h3>
-				<p>A manifest for an audiobook. The <a href="https://w3c.github.io/wpub/experiments/audiobook/flatland-canonical.json">canonical version</a> of this manifest is also available.</p>
-			<pre class="example" data-include="experiments/audiobook/flatland.json" data-include-format="text"></pre>
+				<p>A manifest for an audiobook. The <a
+						href="https://w3c.github.io/wpub/experiments/audiobook/flatland-canonical.json"
+						>canonical version</a> of this manifest is also available.</p>
+				<pre class="example" data-include="experiments/audiobook/flatland.json" data-include-format="text"></pre>
 			</section>
 		</section>
 		<section id="bidi-examples" class="appendix informative">
@@ -3537,11 +3927,13 @@
 
 					<tr>
 						<td><code><bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA;
-									&#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo></code></td>
+									&#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;,
+									W3C</bdo></code></td>
 						<td>rtl</td>
 						<td>First strong directional character</td>
 						<td style="width: 50%"><bdi>&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA;
-								&#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdi></td>
+								&#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;,
+							W3C</bdi></td>
 					</tr>
 
 					<tr>
@@ -3549,17 +3941,20 @@
 							<code><bdo dir="ltr">The document is titled,
 									"&amp;#x2067;&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA;
 									&#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;,
-								W3C&amp;#x2069;"</bdo></code>
+									W3C&amp;#x2069;"</bdo></code>
 						</td>
 						<td>ltr</td>
 						<td>First strong directional character</td>
-						<td>The document is titled, "<bdi>&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA;
-								&#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdi>"</td>
+						<td>The document is titled,
+								"<bdi>&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA;
+								&#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;,
+							W3C</bdi>"</td>
 					</tr>
 
 
 					<tr>
-						<td><code><bdo dir="ltr">&amp;#x200F;HTML &#x05D4;&#x05D9;&#x05D0; &#x05E9;&#x05E4;&#x05EA;
+						<td><code><bdo dir="ltr">&amp;#x200F;HTML &#x05D4;&#x05D9;&#x05D0;
+									&#x05E9;&#x05E4;&#x05EA;
 									&#x05E1;&#x05D9;&#x05DE;&#x05D5;&#x05DF;</bdo></code></td>
 						<td>rtl</td>
 						<td>Bidi Control Character</td>
@@ -3568,11 +3963,12 @@
 					</tr>
 
 					<tr>
-						<td><code><bdo dir="ltr">&amp;#x200E;'&#x0633;&#x0644;&#x0627;&#x0645;' is hello in
-									Persian</bdo></code></td>
+						<td><code><bdo dir="ltr">&amp;#x200E;'&#x0633;&#x0644;&#x0627;&#x0645;' is
+									hello in Persian</bdo></code></td>
 						<td>ltr</td>
 						<td>Bidi Control Character</td>
-						<td><code>'<bdi>&#x0633;&#x0644;&#x0627;&#x0645;</bdi>' is hello in Persian</code></td>
+						<td><code>'<bdi>&#x0633;&#x0644;&#x0627;&#x0645;</bdi>' is hello in
+								Persian</code></td>
 					</tr>
 				</tbody>
 			</table>
@@ -3580,16 +3976,17 @@
 		<section id="app-lifecycle-diagrams" class="appendix informative">
 			<h2>Lifecycle diagrams</h2>
 
-			<p>These diagrams provide a visual view of the lifecycle steps, as specified in <a href="#wp-lifecycle"
-				></a>.</p>
+			<p>These diagrams provide a visual view of the lifecycle steps, as specified in <a
+					href="#wp-lifecycle"></a>.</p>
 
 			<figure id="obtaining-manifest-diagram">
 				<object data="images/lifecycle_obtain_manifest.svg" type="image/svg+xml"
 					aria-describedby="obtaining-manifest-diagram-alt">
-					<p id="obtaining-manifest-diagram-alt">Flowchart depicts how to obtain a manifest.</p>
+					<p id="obtaining-manifest-diagram-alt">Flowchart depicts how to obtain a
+						manifest.</p>
 				</object>
-				<figcaption>Obtain a manifest.<br />See the normative description of the algorithm in <a
-						href="#obtaining-manifest"></a>. Image available in <a
+				<figcaption>Obtain a manifest.<br />See the normative description of the algorithm
+					in <a href="#obtaining-manifest"></a>. Image available in <a
 						href="images/lifecycle_obtain_manifest.svg"
 						title="SVG image of the algorithm for obtaining a manifest">SVG</a> and <a
 						title="PNG image of the algorithm for obtaining a manifest"
@@ -3599,14 +3996,16 @@
 			<figure id="processing-manifest-diagram">
 				<object data="images/lifecycle_process_a_manifest.svg" type="image/svg+xml"
 					aria-describedby="processing-manifest-diagram-alt">
-					<p id="processing-manifest-diagram-alt">Flowchart depicts how to obtain a manifest.</p>
+					<p id="processing-manifest-diagram-alt">Flowchart depicts how to obtain a
+						manifest.</p>
 				</object>
-				<figcaption> Process a manifest. <br />See the normative description of the algorithm in <a
-						href="#processing-manifest"></a>. Image available in <a
+				<figcaption> Process a manifest. <br />See the normative description of the
+					algorithm in <a href="#processing-manifest"></a>. Image available in <a
 						href="images/lifecycle_process_a_manifest.svg"
 						title="SVG image of the algorithm for processing a manifest">SVG</a> and <a
 						title="PNG image of the algorithm for processing a manifest"
-						href="images/lifecycle_process_a_manifest.png">PNG</a> formats. </figcaption>
+						href="images/lifecycle_process_a_manifest.png">PNG</a> formats.
+				</figcaption>
 			</figure>
 
 		</section>
@@ -3614,22 +4013,25 @@
 			<h2>Image Descriptions</h2>
 
 			<dl>
-				<dt id="WP-diagram-descr">Description for the <a href="#WP-diagram">“Structure of Web Publications”
-						diagram</a>:</dt>
-				<dd>A simplified diagram of the structure of a <a>Web Publication</a>. The Web Publication is broken
-					down into two elements. The first element is the actual contents (all the real things listed in the
-					manifest). This element is broken down into the CSS, the actual “things” such as the <abbr
-						title="Hypertext Markup Language">HTML</abbr> documents, audio, etc, and the images, fonts etc.
-					The actual “things” have an additional subset of items that includes the entry page to the
-					publication and all of the other documents. The second element is the Manifest (JSON). The manifest
-					is used to generate the <a href="#wp-infoset-manifest">Information Set (“Infoset”)</a>, which
-					consists of a list of all the “things” in the publication, the publication metadata, and the default
-					reading order of content. It is noted in the diagram that the entry page has to link to the
-					manifest. (<a role="doc-backlink" href="#WP-diagram">Return to the diagram</a> of Web
-					Publication.)</dd>
+				<dt id="WP-diagram-descr">Description for the <a href="#WP-diagram">“Structure of
+						Web Publications” diagram</a>:</dt>
+				<dd>A simplified diagram of the structure of a <a>Web Publication</a>. The Web
+					Publication is broken down into two elements. The first element is the actual
+					contents (all the real things listed in the manifest). This element is broken
+					down into the CSS, the actual “things” such as the <abbr
+						title="Hypertext Markup Language">HTML</abbr> documents, audio, etc, and the
+					images, fonts etc. The actual “things” have an additional subset of items that
+					includes the entry page to the publication and all of the other documents. The
+					second element is the Manifest (JSON). The manifest is used to generate the <a
+						href="#wp-infoset-manifest">Information Set (“Infoset”)</a>, which consists
+					of a list of all the “things” in the publication, the publication metadata, and
+					the default reading order of content. It is noted in the diagram that the entry
+					page has to link to the manifest. (<a role="doc-backlink" href="#WP-diagram"
+						>Return to the diagram</a> of Web Publication.)</dd>
 			</dl>
 
 		</section>
-		<section id="ack" data-include="common/html/acknowledgements.html" data-include-replace="true"></section>
+		<section id="ack" data-include="common/html/acknowledgements.html"
+			data-include-replace="true"></section>
 	</body>
 </html>


### PR DESCRIPTION
This PR removes the resource list from the required properties.

I also found the intro paragraph about the list confusing, as it seems to still have a mix of old ideas in it (mentioning "all resources" and then excluding resources, remnants of primary v secondary resources in mentioning the bounds). I've tried to simplify it, as well.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/313.html" title="Last updated on Aug 22, 2018, 3:18 PM GMT (8f79ea2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/313/004e444...8f79ea2.html" title="Last updated on Aug 22, 2018, 3:18 PM GMT (8f79ea2)">Diff</a>