### PR TITLE
WebIDL Alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -3545,8 +3545,7 @@
 					<dt>
 						<dfn>type</dfn>
 					</dt>
-					<dd>Contains the <a href="#manifest-pub-types">publication type</a>; the value
-						is the name of the relevant schema.org type. Required.</dd>
+					<dd>Contains on or more <a href="#manifest-pub-types">publication type</a> strings; the value is the name of the relevant schema.org type. Required.</dd>
 
 					<dt>
 						<dfn>accessMode</dfn>
@@ -3724,25 +3723,26 @@
 			</section>
 
 			<section id="contributor-idl">
-				<h3><dfn>Person</dfn> and <dfn>Organization</dfn> members</h3>
+				<h3><dfn>Contributor</dfn>  members</h3>
 
-				<p>These definitions reflect the basic information derived from the schema.org <a
-						href="https://schema.org/Person">Person</a> and <a
-						href="https://schema.org/Organization">Organization</a> classes,
-					respectively. The WebIDL definitions only contain the minimal information for
-					the <a>infoset</a>; user agents MAY interpret a wider range of properties, as
-					defined by schema.org.</p>
+				<p>
+					These definitions reflect the basic information derived from the schema.org <a href="https://schema.org/Person">Person</a> and <a href="https://schema.org/Organization">Organization</a> classes. The WebIDL definitions only contain the minimal information for the <a>infoset</a>; user agents MAY interpret a wider range of properties, as defined by schema.org.
+				</p>
 
 
 				<p>The <a href="#dom-webpublicationmanifest-artist">artist</a>, <a
 						href="#dom-webpublicationmanifest-author">author</a>, etc., members are each
-					a sequence of <a><code>Person</code></a> or <a><code>Organization</code></a>
-					dictionaries with the following members:</p>
+					a sequence of <a><code>Contributor</code></a> dictionaries, whose <code>type</code> member
+					indicate whether the contributor is a <a href="https://schema.org/Person">Person</a> or an <a href="https://schema.org/Organization">Organization</a>. The members of this dictionary are:</p>
 
-				<pre class="idl" data-include="webidl/person.webidl" data-include-format="text">
+				<pre class="idl" data-include="webidl/contributor.webidl" data-include-format="text">
                 </pre>
 
-				<dl data-dfn-for="Person">
+				<dl data-dfn-for="Contributor">
+					<dt>
+						<dfn>type</dfn>
+					</dt>
+					<dd>Contains one or more strings for the contributor's type. This sequence SHOULD include "Person" or "Contributor".</dd>
 					<dt>
 						<dfn>name</dfn>
 					</dt>
@@ -3757,28 +3757,6 @@
 					</dt>
 					<dd>Contains an address for the person in the form of a URL.&#160;[[!url]]</dd>
 				</dl>
-
-				<pre class="idl" data-include="webidl/organization.webidl" data-include-format="text">
-                </pre>
-				<dl data-dfn-for="Organization">
-					<dt>
-						<dfn>name</dfn>
-					</dt>
-					<dd>Contains one or more localizable strings for the organization's name.</dd>
-					<dt>
-						<dfn>id</dfn>
-					</dt>
-					<dd>Contains a canonical identifier of the organization as a
-						URL.&#160;[[url]]</dd>
-
-					<dt>
-						<dfn>url</dfn>
-					</dt>
-					<dd>Contains an address for the organization in the form of a
-						URL.&#160;[[url]]</dd>
-				</dl>
-
-
 			</section>
 
 			<section id="localizable-idl">
@@ -3798,7 +3776,7 @@
 					</dt>
 					<dd>Contains the localized string.</dd>
 					<dt>
-						<dfn>lang</dfn>
+						<dfn>language</dfn>
 					</dt>
 					<dd>Contains the <a href="#language-and-dir">language</a>
 						value.&#160;[[bcp47]]</dd>

--- a/index.html
+++ b/index.html
@@ -3545,7 +3545,7 @@
 					<dt>
 						<dfn>type</dfn>
 					</dt>
-					<dd>Contains on or more <a href="#manifest-pub-types">publication type</a> strings; the value is the name of the relevant schema.org type. Required.</dd>
+					<dd>Contains one or more <a href="#manifest-pub-types">publication type</a> strings; the value is the name of the relevant schema.org type. Required.</dd>
 
 					<dt>
 						<dfn>accessMode</dfn>
@@ -3729,11 +3729,9 @@
 					These definitions reflect the basic information derived from the schema.org <a href="https://schema.org/Person">Person</a> and <a href="https://schema.org/Organization">Organization</a> classes. The WebIDL definitions only contain the minimal information for the <a>infoset</a>; user agents MAY interpret a wider range of properties, as defined by schema.org.
 				</p>
 
-
 				<p>The <a href="#dom-webpublicationmanifest-artist">artist</a>, <a
 						href="#dom-webpublicationmanifest-author">author</a>, etc., members are each
-					a sequence of <a><code>Contributor</code></a> dictionaries, whose <code>type</code> member
-					indicate whether the contributor is a <a href="https://schema.org/Person">Person</a> or an <a href="https://schema.org/Organization">Organization</a>. The members of this dictionary are:</p>
+					a sequence of <a><code>Contributor</code></a> dictionaries, each of whose <code>type</code> member indicates whether the contributor is a <a href="https://schema.org/Person">Person</a> or an <a href="https://schema.org/Organization">Organization</a>. The members of this dictionary are:</p>
 
 				<pre class="idl" data-include="webidl/contributor.webidl" data-include-format="text">
                 </pre>

--- a/webidl/contributor.webidl
+++ b/webidl/contributor.webidl
@@ -1,7 +1,7 @@
 
-dictionary Organization {
+dictionary Contributor {
+             sequence<DOMString>         type;                     
     required sequence<LocalizableString> name;
              DOMString                   id;
              DOMString                   url;
 };
-

--- a/webidl/localizable_string.webidl
+++ b/webidl/localizable_string.webidl
@@ -1,4 +1,4 @@
 dictionary LocalizableString {
-    required DOMString       value;
-             DOMString       lang;
+    required DOMString value;
+             DOMString language;
 };

--- a/webidl/manifest.webidl
+++ b/webidl/manifest.webidl
@@ -1,47 +1,47 @@
 dictionary WebPublicationManifest {
-    required DOMString                          url;
-    required DOMString                          type;
+    required DOMString                    url;
+    required sequence<DOMString>          type;
 
-             sequence<DOMString>                accessMode;
-             sequence<DOMString>                accessModeSufficient;
-             sequence<DOMString>                accessibilityAPI;
-             sequence<DOMString>                accessibilityControl;
-             sequence<DOMString>                accessibilityFeature;
-             sequence<DOMString>                accessibilityHazard;
-             LocalizableString                  accessibilitySummary;
+             sequence<DOMString>          accessMode;
+             sequence<DOMString>          accessModeSufficient;
+             sequence<DOMString>          accessibilityAPI;
+             sequence<DOMString>          accessibilityControl;
+             sequence<DOMString>          accessibilityFeature;
+             sequence<DOMString>          accessibilityHazard;
+             LocalizableString            accessibilitySummary;
 
-             DOMString                          id;
+             DOMString                    id;
 
-             sequence<Person>                   artist;
-             sequence<(Person or Organization)> author;
-             sequence<Person>                   colorist;
-             sequence<(Person or Organization)> contributor;
-             sequence<(Person or Organization)> creator;
-             sequence<Person>                   editor;
-             sequence<Person>                   illustrator;
-             sequence<Person>                   inker;
-             sequence<Person>                   letterer;
-             sequence<Person>                   penciler;
-             sequence<(Person or Organization)> publisher;
-             sequence<Person>                   readby;
-             sequence<(Person or Organization)> translator;
+             sequence<Contributor>        artist;
+             sequence<Contributor>        author;
+             sequence<Contributor>        colorist;
+             sequence<Contributor>        contributor;
+             sequence<Contributor>        creator;
+             sequence<Contributor>        editor;
+             sequence<Contributor>        illustrator;
+             sequence<Contributor>        inker;
+             sequence<Contributor>        letterer;
+             sequence<Contributor>        penciler;
+             sequence<Contributor>        publisher;
+             sequence<Contributor>        readby;
+             sequence<Contributor>        translator;
 
-             DOMString                          inLanguage;
-             TextDirection                      inDirection;
+             DOMString                    inLanguage;
+             TextDirection                inDirection;
 
-             DOMString                          dateModified;
-             DOMString                          datePublished;
+             DOMString                    dateModified;
+             DOMString                    datePublished;
 
-             ProgressionDirection               readingProgression = "ltr";
+             ProgressionDirection         readingProgression = "ltr";
 
-             sequence<LocalizableString>        name;
+             sequence<LocalizableString>  name;
 
-   required  sequence<PublicationLink>          readingOrder;
-             sequence<PublicationLink>          resources = [];
-             sequence<PublicationLink>          links = [];
+   required  sequence<PublicationLink>    readingOrder;
+             sequence<PublicationLink>    resources = [];
+             sequence<PublicationLink>    links = [];
 
-             PublicationLink                    accessibilityReport;
-             PublicationLink                    privacyPolicy;
-             sequence<PublicationLink>          cover;
-             HTMLElement                        toc;
+             PublicationLink              accessibilityReport;
+             PublicationLink              privacyPolicy;
+             sequence<PublicationLink>    cover;
+             HTMLElement                  toc;
 };

--- a/webidl/person.webidl
+++ b/webidl/person.webidl
@@ -1,6 +1,0 @@
-
-dictionary Person {
-    required sequence<LocalizableString> name;
-             DOMString                   id;
-             DOMString                   url;
-};


### PR DESCRIPTION
Alignment with the canonical manifest (to make conversion easier)

- Using 'Contributor' (with an explicit 'type' field) instead of separate Person and Contributor
- Using 'language' instead of 'lang' in Localizable texts
- 'type' is a sequence of strings, not a single string


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/315.html" title="Last updated on Aug 23, 2018, 1:43 PM GMT (b40343e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/315/e21b29b...b40343e.html" title="Last updated on Aug 23, 2018, 1:43 PM GMT (b40343e)">Diff</a>