### PR TITLE
Reference to opaque origin in the manifest lifecycle

### DIFF
--- a/index.html
+++ b/index.html
@@ -2983,7 +2983,7 @@
 						obtaining a manifest</dfn>, starting from the <a>primary entry page</a>, are given by the
 					following algorithm. The algorithm, if successful, returns a <a>processed manifest</a>; otherwise,
 					it terminates prematurely and returns nothing. In the case of nothing being returned, the user agent
-					MUST ignore the manifest declaration. </p>
+					MUST ignore the manifest declaration.</p>
 
 				<ol>
 					<li> From the <code>Document</code> of the top-level browsing context of the <a>primary entry
@@ -2991,7 +2991,7 @@
 							link</var> be the first <code>link</code> element in tree order in <code>Document</code>
 						whose <code>rel</code> attribute contains the <code>publication</code> token. </li>
 
-					<li> If <var>origin</var> is an [[!html]] opaque origin, terminate this algorithm. </li>
+					<li> If the <code>Document</code> is sandboxed (e.g. a cross-origin document in an iframe&nbsp;[[!html]], terminate the algorithm.</li>
 
 					<li> If <var>manifest link</var> is <code>null</code>, terminate this algorithm. </li>
 


### PR DESCRIPTION
Adopted the [change proposal](https://github.com/w3c/wpub/issues/321#issuecomment-429741645) of @JayPanoz. This replaces the (opaque:-) reference to an opaque origin...

Some issues on security must be addressed in the security section, too, which may, eventually, add some more text to the lifecycle section. But this PR seems to provide a proper intermediate stage.

Fix #321 

Cc: @JayPanoz, @rdeltour @llemeurfr @dauwhe


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/343.html" title="Last updated on Oct 15, 2018, 9:19 AM GMT (1349ceb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/343/1481110...1349ceb.html" title="Last updated on Oct 15, 2018, 9:19 AM GMT (1349ceb)">Diff</a>