### PR TITLE
Reading order and resources together set the bounds of a publication

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,9 +255,9 @@
 
 					<p>To ensure interoperability when exposing the infoset items, this specification defines an
 						abstract representation of the data structures using the Web Interface Definition Language
-						(WebIDL) [[webidl-1]] which expresses the expected name, datatype, and possible restrictions
-						for each member of the manifest expressed in the infoset. (A WebIDL representation
-						can be mapped onto ECMAScript, C, or other programming languages.)</p>
+						(WebIDL) [[webidl-1]] which expresses the expected name, datatype, and possible restrictions for
+						each member of the manifest expressed in the infoset. (A WebIDL representation can be mapped
+						onto ECMAScript, C, or other programming languages.)</p>
 				</section>
 
 				<section id="webidl-wpm">
@@ -674,6 +674,22 @@ partial dictionary WebPublicationManifest {
 					absence of a preference by user agent implementers, selection of the first manifest listed is
 					suggested as a default.</p>
 
+			</section>
+
+			<section id="wp-bounds">
+				<h2>Web Publication Bounds</h2>
+
+				<p>A Web Publication consists of a finite set of <a href="#wp-resources">resources</a> that represent
+					its content. This extent is known as its bounds and is defined within its manifest &#8212; it is
+					obtained from the union of resources listed in the <a href="#default-reading-order">default reading
+						order</a> and <a href="#resource-list">resource list</a>.</p>
+
+				<p>To determine whether a resource is within the bounds of a Web Publication, user agents MUST compare
+					the absolute URL of a resource to the absolute URLs of the resources obtained from the union. If the
+					resource is identified in the enumeration, it is within the bounds of the Web Publication. All other
+					resources are external to the Web Publication.</p>
+
+				<p>Resources within the bounds of a Web Publication do not have to share the same domain.</p>
 			</section>
 
 			<section id="wp-resources">
@@ -2342,12 +2358,6 @@ partial dictionary WebPublicationManifest {
 					<p>The <dfn>resource list</dfn> enumerates any additional <a href="#wp-resources">resources</a> used
 						in the processing and rendering of a <a>Web Publication</a> that are not already listed in the
 							<a>default reading order</a>. It is expressed using the <code>resources</code> property.</p>
-
-					<p>
-						The union of the resource list and default reading order represents the definitive
-						list of resources that belong to the Web Publication and defines the bounds of the publication. All other resources are external to the
-						Web Publication.
-					</p>
 
 					<section id="resource-list-infoset">
 						<h5>Infoset Requirements</h5>

--- a/index.html
+++ b/index.html
@@ -2343,9 +2343,11 @@ partial dictionary WebPublicationManifest {
 						in the processing and rendering of a <a>Web Publication</a> that are not already listed in the
 							<a>default reading order</a>. It is expressed using the <code>resources</code> property.</p>
 
-					<p class="note">The union of the resource list and default reading order represents the definitive
-						list of resources that belong to the Web Publication. All other resources are external to the
-						Web Publication.</p>
+					<p>
+						The union of the resource list and default reading order represents the definitive
+						list of resources that belong to the Web Publication and defines the bounds of the publication. All other resources are external to the
+						Web Publication.
+					</p>
 
 					<section id="resource-list-infoset">
 						<h5>Infoset Requirements</h5>
@@ -2361,16 +2363,6 @@ partial dictionary WebPublicationManifest {
 							agent SHOULD still be able to render a Web Publication even if some of these resources are
 							not identified as belonging to the Web Publication (e.g., when it is taken offline without
 							them).</p>
-
-						<div class="ednote"> The previous version of the draft included: <blockquote>
-								<p>If a user agent encounters a resource that it cannot locate in the resource list, it
-									MUST treat the resource as external to the Web Publication (e.g., it might alert the
-									user before loading, open the resource in a new window, or unload the current Web
-									Publication and resume normal Web browsing).</p>
-							</blockquote>
-							<p>This was not decided on the Toronto F2F, and is still open.</p>
-						</div>
-						<p class="issue" data-number="205"></p>
 					</section>
 
 					<section id="resource-list-manifest">


### PR DESCRIPTION
Made changes as [decided upon at the F2F](https://www.w3.org/publishing/groups/publ-wg/Meetings/Minutes/2018/2018-10-22-pwg.html#section4) with the discussion also recorded in #205.

Fix #205.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/353.html" title="Last updated on Oct 24, 2018, 5:14 PM GMT (8d5c9b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/353/611cd98...8d5c9b7.html" title="Last updated on Oct 24, 2018, 5:14 PM GMT (8d5c9b7)">Diff</a>