### PR TITLE
Add content and processing requirements for machine-readable toc

### DIFF
--- a/common/css/common.css
+++ b/common/css/common.css
@@ -66,3 +66,9 @@ table.zebra tr:nth-child(even) {
 
 table.zebra th{border-bottom:1px solid #bbb;padding:.2em 1em;}
 table.zebra td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+
+details {
+	background-color: rgb(245,245,245);
+	border-left: 0.3em solid rgb(200,200,200);
+	padding: 0.3em;
+}

--- a/experiments/toc_generator/index.html
+++ b/experiments/toc_generator/index.html
@@ -159,6 +159,8 @@
 							var new_branch = new Object();
 								new_branch.name = '';
 								new_branch.url = '';
+								new_branch.type = '';
+								new_branch.rel = '';
 								new_branch.entries = new Array();
 							
 							current_toc_branch = new_branch;
@@ -168,9 +170,17 @@
 						else if (lc_element == 'a') {
 							if (current_toc_branch !== null) {
 								if (current_toc_branch.name === '') {
+									
 									var label = node.textContent.trim();
 									current_toc_branch.name = (label !== '') ? label : null;
-									current_toc_branch.url = node.href ? node.getAttribute('href') : null;
+									
+									current_toc_branch.url = node.hasAttribute('href') ? node.getAttribute('href') : null;
+									
+									var type = node.hasAttribute('type') ? node.getAttribute('type').trim() : null;
+									current_toc_branch.type = type ? type : null;
+									
+									var rel = node.hasAttribute('rel') ? node.getAttribute('rel').trim() : null;
+									current_toc_branch.rel = rel ? rel : null;
 								}
 							}
 							return false;

--- a/experiments/toc_generator/index.html
+++ b/experiments/toc_generator/index.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>TOC Generator</title>
+		<style>
+			body {
+				font-family: Helvetica, Verdana, sans-serif;
+				font-size: 62.5%;
+				width: 55rem;
+				padding: 0 1rem;
+			}
+			h1 {
+				font-size: 1.6rem;
+				color: rgb(0, 140, 120);
+			}
+			p,
+			legend,
+			pre {
+				font-size: 1.1rem;
+			}
+			textarea {
+				width: 52rem;
+			}
+			pre {
+				min-height: 14rem;
+				background-color: rgb(245, 247, 250);
+				max-height: 20rem;
+				overflow: scroll;
+				width: 55rem;
+			}</style>
+		<script>
+    		//<![CDATA[
+    		'use strict';
+    		
+    		function generateTOC() {
+    			
+    			document.getElementById('toc-out').textContent = '';
+    			
+    			var toc_str = document.getElementById('toc-in').value;
+    			
+    			var parser = new DOMParser();
+				var htmldoc = parser.parseFromString(toc_str, "text/html");
+				
+				var toc = htmldoc.querySelector('nav[role~="doc-toc"]');
+				
+				if (toc) {
+					parseTOC(toc,null,null);
+				}
+				else {
+					alert('No table of contents found.');
+				}
+    		}
+			
+			function parseTOC(root, enter, exit) {
+				
+				var node = root;
+				
+				var toc = new Object();
+				var stack = new Array();
+				var current_toc_branch = null;
+				
+				start: while (node) {
+					
+					if (node == root) {
+						toc.name = '';
+						toc.entries = new Array();
+					}
+					else {
+						// only interested in processing start element nodes
+						if (node.nodeType == 1) {
+							// if process_start returns false, skip descending into the element
+							if (!process_start(node)) {
+								if (node.nextSibling) {
+									node = node.nextSibling;
+									continue start;
+								}
+							}
+						}
+					}
+					
+					if (node.firstChild) {
+						node = node.firstChild;
+						continue start;
+					}
+					
+					while (node) {
+					
+						// only interested in processing end element nodes
+						if (node.nodeType == 1) {
+							if (node == root) {
+								if (toc.entries.length == 0) {
+									toc.entries = null;
+								}
+								var output = document.getElementById('toc-out');
+								output.textContent = (toc.entries !== null && toc.entries.length > 0) ? JSON.stringify(toc,null,3) : 'null';
+							}
+							else {
+								process_end(node, root);
+							}
+						}
+						
+						if (node == root) {
+							node = null;
+						}
+						
+						else if (node.nextSibling) {
+							node = node.nextSibling;
+							continue start;
+						}
+						
+						else {
+							node = node.parentNode;
+						}
+					}
+					
+					
+					function process_start(node) {
+					
+						var lc_element = node.localName.toLowerCase();
+						
+						// set toc name to the heading if undefined and no branches have been created yet
+						if (lc_element.match(/^h[1-6]$/)) {
+							if (toc.name === '' && stack.length == 0) {
+								var label = node.textContent.trim();
+								toc.name = label ? label : null;
+							}
+							return false;
+						}
+						
+						else if (lc_element.match(/^[ou]l$/)) {
+							// the toc does not have a heading if one is not discovered before the first list
+							if (toc.name === '') {
+								toc.name = null;
+							}
+							
+							if (current_toc_branch !== null) {
+								// skip processing if this is an additional list within a branch
+								if (current_toc_branch.entries !== null && current_toc_branch.entries.length > 0) {
+									return false;
+								}
+								else {
+									stack.push(Object.assign({},current_toc_branch));
+								}
+							}
+							
+							else {
+								if (stack.length == 0) {
+									// skip processing if this is an additional list at the root of the nav element
+									if (toc.entries !== null && toc.entries.length > 0) {
+										return false;
+									}
+								}
+							}
+						}
+						
+						// create a new object when encountering a list item and push on current_toc_branch
+						else if (lc_element == 'li') {
+							
+							var new_branch = new Object();
+								new_branch.name = '';
+								new_branch.url = '';
+								new_branch.entries = new Array();
+							
+							current_toc_branch = new_branch;
+						}
+						
+						// set the current current_toc_branch name and url properties when encountering an a tag
+						else if (lc_element == 'a') {
+							if (current_toc_branch !== null) {
+								if (current_toc_branch.name === '') {
+									var label = node.textContent.trim();
+									current_toc_branch.name = (label !== '') ? label : null;
+									current_toc_branch.url = node.href ? node.getAttribute('href') : null;
+								}
+							}
+							return false;
+						}
+						
+						// don't descend into sectioning and sectioning root elements
+						else if (lc_element == 'aside' ||
+							lc_element == 'article' ||
+							lc_element == 'section' ||
+							lc_element == 'nav' ||
+							lc_element == 'blockquote' ||
+							lc_element == 'details' ||
+							lc_element == 'dialog' ||
+							lc_element == 'fieldset' ||
+							lc_element == 'figure' ||
+							lc_element == 'td' ||
+							node.hidden) {
+							return false;
+						}
+						
+						return true;
+					}
+					
+					function process_end(node,root) {
+						
+						var lc_element = node.localName.toLowerCase();
+						
+						if (lc_element.match(/^[ou]l$/)) {
+							if (stack.length > 0) {
+								current_toc_branch = stack.pop();
+							}
+						}
+						
+						else if (lc_element == 'li') {
+							
+							// if the entries array is empty after processing the branch, set it to null
+							if (current_toc_branch.entries.length == 0) {
+								current_toc_branch.entries = null;
+							}
+							
+							// if there are active branches being created, the finished branch gets added into current_toc_branch
+							// otherwise, if there are no active branches it gets added to the root toc object's entries array
+							if (stack.length > 0) {
+								
+								if (current_toc_branch.name === '') {
+									
+									// if the branch has no name but subentries, set the name to null,
+									// otherwise, discard the branch if it doesn't have a name or any subentries
+									if (current_toc_branch.length > 0) {
+										current_toc_branch.name = null;
+									}
+									
+									else {
+										current_toc_branch = null;
+										return;
+									}
+								}
+								
+								// add the active branch to the entries array of its parent
+								stack[stack.length-1].entries.push(Object.assign({},current_toc_branch));
+							}
+							else {
+								toc.entries.push(Object.assign({},current_toc_branch));
+							}
+							
+							// discard the active branch now that processing is complete
+							current_toc_branch = null;
+						}
+					}
+				}
+			}
+			//]]>
+    	</script>
+	</head>
+	<body>
+		<header>
+			<h1>Web Publication Table of Contents Generator</h1>
+		</header>
+		<main>
+			<p>This application parses out the machine-readable table of contents for a Web Publication using the
+				algorithm defined in the specification. It is provided for illustrative purposes only. The table of
+				contents to parse must be contained in a <code>nav</code> element with the <code>role</code> attribute
+				value <code>doc-toc</code>.</p>
+			<p>Current limitations of this tool are that it does not calculate the accessible names for headings and
+				anchors and cannot verify that the URLs in <code>href</code> attributes resolve to Web Publication
+				resources.</p>
+			<fieldset>
+				<legend>Add markup:</legend>
+				<textarea aria-label="source markup" rows="20" cols="65" id="toc-in"></textarea>
+				<div><input type="button" onclick="generateTOC()" value="Generate TOC" /></div>
+			</fieldset>
+			<p><strong>Result:</strong></p>
+			<pre id="toc-out" aria-live="polite"></pre>
+		</main>
+	</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3952,8 +3952,9 @@ partial dictionary WebPublicationManifest {
 								<ol>
 									<li>Set <em>current toc branch</em> to a new object.</li>
 
-									<li>Create <code>name</code> and <code>url</code> properties for the object and set
-										them to empty strings.</li>
+									<li>Create <code>name</code>, <code>url</code>, <code>type</code>, and
+											<code>rel</code> properties for the object and set them to empty
+										strings.</li>
 
 									<li>Create an <code>entries</code> property for the object and set it to an empty
 										array.</li>
@@ -3968,6 +3969,8 @@ partial dictionary WebPublicationManifest {
 {
    "name": '',
    "url": '',
+   "type": '',
+   "rel": '',
    "entries": []
 }</pre>
 									</aside>
@@ -4029,21 +4032,29 @@ partial dictionary WebPublicationManifest {
 										<pre>{
    "name": "Section 1",
    "url": "http://example.com/contents.html#s1",
+   "type": "text/html",
+   "rel": null,
    "entries": []
 },
 {
    "name": "Section 1.1",
    "url": "http://example.com/contents.html#s1.1",
+   "type": "text/html",
+   "rel": null,
    "entries": null
 }</pre>
 										<p>Then only the following single object remains after merging:</p>
 										<pre>{
    "name": "Section 1",
    "url": "http://example.com/contents.html#s1",
+   "type": "text/html",
+   "rel": null,
    "entries": [
       {
          "name": "Section 1.1",
          "url": "http://example.com/contents.html#s1.1",
+         "type": "text/html",
+         "rel": null,
          "entries": null
       }
    ]
@@ -4078,6 +4089,16 @@ partial dictionary WebPublicationManifest {
 													<a>resource list</a>, set the <code>url</code> property of
 													<em>current toc branch</em> to the value. Otherwise, set the
 												property to <code>null</code>.</li>
+											<li>If the element has a <code>type</code> attribute, and the value of the
+												attribute is not an empty string after trimming leading and trailing
+												white space, set the <code>type</code> property of <em>current toc
+													branch</em> to its value. Otherwise, set the property to
+													<code>null</code>.</li>
+											<li>If the element has a <code>rel</code> attribute, and the value of the
+												attribute is not an empty string after trimming leading and trailing
+												white space, set the <code>rel</code> property of <em>current toc
+													branch</em> to its value. Otherwise, set the property to
+													<code>null</code>.</li>
 										</ol>
 										<p>Exit the element and continue processing with the next element.</p>
 									</li>
@@ -4093,6 +4114,17 @@ partial dictionary WebPublicationManifest {
 										that it resolve to a resource that belongs to the publication to meet the
 										requirements of this specification. If not, the branch is retained but the entry
 										will not be linkable.</p>
+									<p>Additional information about the target of the link &#8212; the type of resource
+										and its relationship &#8212; is also retained.</p>
+									<aside class="example" title="Visualization of a link to an SVG image">
+										<pre>{
+   "name": "In the Beginning",
+   "url": "http://example.com/page1.svg",
+   "type": "image/svg",
+   "rel": null,
+   "entries": []
+},</pre>
+									</aside>
 								</details>
 							</li>
 

--- a/index.html
+++ b/index.html
@@ -3899,7 +3899,7 @@ partial dictionary WebPublicationManifest {
 												<code>name</code> to <code>null</code>.</p>
 									</li>
 									<li>
-										<p>if <em>current toc branch</em> is not <code>null</code>:</p>
+										<p>If <em>current toc branch</em> is not <code>null</code>:</p>
 										<ol>
 											<li>If the <code>entries</code> property of <em>current toc branch</em> is
 													<code>null</code> or a non-empty array, exit the element and
@@ -3935,11 +3935,8 @@ partial dictionary WebPublicationManifest {
 
 							<li>
 								<p><strong>When exiting a <a>list element</a>:</strong></p>
-								<p>Run these steps:</p>
-								<ol>
-									<li>If the stack is not empty, pop the top object off the stack and set <em>current
-											toc branch</em> to it.</li>
-								</ol>
+								<p>If the stack is not empty, pop the top object off the stack and set <em>current toc
+										branch</em> to it.</p>
 								<details>
 									<summary>Explanation</summary>
 									<p>This resets <em>current toc branch</em> back to the parent object after all of

--- a/index.html
+++ b/index.html
@@ -3777,60 +3777,371 @@ partial dictionary WebPublicationManifest {
 			<section id="app-toc-ua">
 				<h3>User Agent Processing</h3>
 
-				<p>The expected structure of the machine-readable table of contents is defined such that a hierarchical
-					tree of links can be extracted from it. The root list within the <code>nav</code> element represents
-					the root of the tree, and each list item is either a branch (if it contains a sub-list) or a leaf
-					(if it contains only a link). The following algorithm describes how to construct this tree. (It does
-					not define how the extracted table of contents is presented to users.)</p>
+				<p>This section defines an algorithm for extracting a table of contents from a <code>nav</code> element.
+					It is defined in terms of a walk over the nodes of a DOM tree, in <a
+						href="https://www.w3.org/TR/html/infrastructure.html#tree-order">tree order</a>, with each node
+					being visited when it is <em>entered</em> and when it is <em>exited</em> during the walk. Each time
+					a node is visited, it can be seen as triggering an <em>enter</em> or <em>exit</em> event.</p>
 
-				<p>Note that due to the flexibility that HTML markup provides authors, the HTML table of contents might
-					contain additional elements not described in this section (e.g., <code>div</code> elements used for
-					styling, or supplementary content). These elements MUST be ignored. In addition, the flexibility of
-					HTML markup also means that some inspection might be required to find the referenced elements.</p>
+				<p class="note">For illustrative purposes, the examples in this section show the structure of the table
+					of contents as JavaScript objects. User agents can process and internalize the resulting structure
+					in whatever language and form is appropriate.</p>
+
+				<p>For the purposes of this algorithm, a <dfn>list element</dfn> is defined as either an [[!html]] <a
+						href="https://www.w3.org/TR/html/grouping-content.html#the-ol-element"><code>ol</code></a> or <a
+						href="https://www.w3.org/TR/html/grouping-content.html#the-ul-element"><code>ul</code></a>
+					element.</p>
+
+				<p>The following algorithm MUST be applied to a walk of a DOM subtree rooted at the first
+						<code>nav</code> element in document order with the <code>role</code> attribute value
+						<code>doc-toc</code>. All explanations are <em>informative</em>.</p>
 
 				<ol>
-					<li>Locate the first instance of a <code>nav</code> element with the <code>role</code> attribute
-						value <code>doc-toc</code>. Any subsequent instances MUST be ignored, even if the first does not
-						produce a usable table of contents.</li>
-					<li>If needed, a title for the table of contents MAY be obtained from the first descendant instance
-						of <a href="https://www.w3.org/TR/html/dom.html#heading-content">heading content</a>.</li>
-					<li>Locate the first descendant list element (<code>ol</code> or <code>ul</code>) of the
-							<code>nav</code> element. This list is used to produce the hierarchical tree of links. Any
-						subsequent lists MUST be ignored.</li>
 					<li>
-						<p>Process each list item (<code>li</code>) into a branch or leaf node as follows:</p>
-						<ul>
-							<li>If the list item contains a descendant list (<code>ol</code> or <code>ul</code>), create
-								a branch node; otherwise, create a leaf node.</li>
-							<li>Locate the first descendant <code>a</code> element that is not the descendant of a
-								nested list. If no element is found, discard the node and continue processing with the
-								next list item.</li>
+						<p>Let <em>toc</em> be a object that represents the table of contents and initialize it as
+							follows:</p>
+						<ol>
+							<li>Create a <code>name</code> property for <em>toc</em> that represents the title of the
+								table of contents and set to an empty string.</li>
+
+							<li>Create an <code>entries</code> property for <em>toc</em> that represents all the
+								branches of the table of contents and set to an empty array.</li>
+						</ol>
+						<details>
+							<summary>Explanation</summary>
+							<p>This step initializes the <em>toc</em> object that will store the title and the branches
+								of the table of contents.</p>
+							<aside class="example" title="Visualization of the default toc object">
+								<pre>
+{
+   "name": '',
+   "entries": []
+}</pre>
+							</aside>
+						</details>
+					</li>
+
+					<li>
+						<p>Initialize a stack.</p>
+						<details>
+							<summary>Explanation</summary>
+							<p>The stack is used to hold branches that are not yet complete. As a new sub-branch is
+								encountered, the parent gets pushed onto the stack so it can be retrieved later.</p>
+						</details>
+					</li>
+
+					<li>
+						<p>Let <em>current toc branch</em> be a variable set to <code>null</code>.</p>
+						<details>
+							<summary>Explanation</summary>
+							<p><em>current toc branch</em> is used to hold the object that represents the branch of the
+								table of contents that is currently being processed.</p>
+						</details>
+					</li>
+
+					<li>
+						<p>Walk over the DOM in <a href="https://www.w3.org/TR/html/infrastructure.html#tree-order">tree
+								order</a>, starting with the <code>nav</code> element the table of contents is being
+							built from, and trigger the first relevant step below for each element as the walk enters
+							and exits it.</p>
+						<ol>
 							<li>
-								<p>Create the text label for the node as follows:</p>
-								<ul>
-									<li>If the <code>a</code> element has an <code>aria-label</code> attribute, use the
-										value of the attribute as the label.</li>
-									<li>Otherwise, use the <a href="https://www.w3.org/TR/domcore/#dom-node-textcontent"
-											>text content</a> [[!DOM4]] of the element as the label.</li>
-								</ul>
+								<p><strong>When entering a <a
+											href="https://www.w3.org/TR/html/dom.html#heading-content-2">heading
+											content</a> element:</strong></p>
+								<p>Run these steps:</p>
+								<ol>
+									<li>If the stack is empty, and the <code>name</code> property of <em>toc</em> is an
+										empty string, calculate the <a
+											href="https://www.w3.org/TR/accname-1.1/#mapping_additional_nd_te"
+											>accessible name</a> [[!accname-1.1]] of the element. If the resulting value
+										is not an empty string after trimming all leading and trailing whitespace, set
+										the <code>name</code> property of <em>toc</em> to the value. Otherwise, set the
+											<code>name</code> property to <code>null</code>.</li>
+									<li>Exit the element and continue processing with the next element.</li>
+								</ol>
+								<details>
+									<summary>Explanation</summary>
+									<p>This step identifies the heading for the table of contents. A heading is only
+										processed if the value of the <em>toc</em>
+										<code>name</code> property is an empty string (i.e., no headings have yet been
+										encountered).</p>
+									<aside class="example" title="Visualization of the toc object with a heading">
+										<pre>
+{
+   "name": "Contents",
+   "entries": []
+}</pre>
+									</aside>
+									<p>If the <code>name</code> is not an empty string, or is <code>null</code>, then a
+										previous heading has already been encountered or content has been encountered
+										that indicates the <code>nav</code> element does not have a heading (e.g., a
+										list has already been processed, since the heading would not follow the list of
+										links).</p>
+									<aside class="example" title="Visualization of the toc object without a heading">
+										<pre>
+{
+   "name": null,
+   "entries": []
+}</pre>
+										<p>If a heading is not provided, the user agent will have to provide one, if
+											necessary, when making use of the table of contents.</p>
+									</aside>
+								</details>
 							</li>
-							<li>If the <code>a</code> item has an <code>href</code> attribute, and the destination of
-								IRI contained in the attribute is a resource in the <a>default reading order</a> or
-									<code>resource list</code>, store the IRI. Otherwise, the node is not linkable and
-								no IRI is associated with it.</li>
-							<li>If the list item is a branch, its child nodes are created by processing the first
-								descendant list in the same manner. This process continues until there are no more
-								branch nodes.</li>
-						</ul>
+
+							<li>
+								<p><strong>When entering a <a>list element</a>:</strong></p>
+								<p>Run these steps:</p>
+								<ol>
+									<li>
+										<p>If the <code>name</code> property of <em>toc</em> is an empty string, set
+												<code>name</code> to <code>null</code>.</p>
+									</li>
+									<li>
+										<p>if <em>current toc branch</em> is not <code>null</code>:</p>
+										<ol>
+											<li>If the <code>entries</code> property of <em>current toc branch</em> is
+													<code>null</code> or a non-empty array, exit the element and
+												continue processing with the next element.</li>
+											<li>Otherwise, push the object in <em>current toc branch</em> onto the stack
+												and set <em>current toc branch</em> to <code>null</code>.</li>
+										</ol>
+									</li>
+									<li>
+										<p>Otherwise, if the stack is empty:</p>
+										<ol>
+											<li>If the <code>entries</code> property of <em>toc</em> is
+													<code>null</code> or a non-empty array, exit the element and
+												continue processing with the next element.</li>
+											<li>Otherwise, do nothing.</li>
+										</ol>
+									</li>
+								</ol>
+								<details>
+									<summary>Explanation</summary>
+									<p>This algorithm does not process multiple lists in a single branch or at the root
+										of the <code>nav</code> element, so if a list has already been encountered (the
+											<code>entries</code> property contains one or more branches or is set to
+											<code>null</code>), this list is skipped.</p>
+									<p>If a list is encountered and the table of contents (<code>toc</code>) still does
+										not have a name (i.e., no heading element has been encountered), the table of
+										contents is assumed to not have a heading (i.e., the heading for the table of
+										contents cannot appear after the first list of entries). The value of the
+											<code>name</code> property is changed from an empty string to
+											<code>null</code> as no further headings encountered apply, either.</p>
+								</details>
+							</li>
+
+							<li>
+								<p><strong>When exiting a <a>list element</a>:</strong></p>
+								<p>Run these steps:</p>
+								<ol>
+									<li>If the stack is not empty, pop the top object off the stack and set <em>current
+											toc branch</em> to it.</li>
+								</ol>
+								<details>
+									<summary>Explanation</summary>
+									<p>This resets <em>current toc branch</em> back to the parent object after all of
+										its child branches have been processed.</p>
+								</details>
+							</li>
+
+							<li>
+								<p><strong>When entering a <a
+											href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">list
+											item</a> element:</strong></p>
+								<p>Run these steps:</p>
+								<ol>
+									<li>Set <em>current toc branch</em> to a new object.</li>
+
+									<li>Create <code>name</code> and <code>url</code> properties for the object and set
+										them to empty strings.</li>
+
+									<li>Create an <code>entries</code> property for the object and set it to an empty
+										array.</li>
+								</ol>
+								<details>
+									<summary>Explanation</summary>
+									<p>Each list item represents a possible new branch in the table of contents, so
+										whenever one is encountered a new blank object is created in <em>current toc
+											branch</em>.</p>
+									<aside class="example" title="Visualization of a new branch object">
+										<pre>
+{
+   "name": '',
+   "url": '',
+   "entries": []
+}</pre>
+									</aside>
+									<p>This object gets populated with information as a descendant <code>a</code>
+										element and list are encountered.</p>
+								</details>
+							</li>
+
+							<li>
+								<p><strong>When exiting a <a
+											href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">list
+											item</a> element:</strong></p>
+								<p>Run these steps:</p>
+								<ol>
+									<li>
+										<p>If <code>entries</code> property of <em>current toc branch</em> contains an
+											empty array, set its value to <code>null</code>.</p>
+									</li>
+									<li>
+										<p>If the stack contains one or more entries:</p>
+										<ol>
+											<li>If the <code>entries</code> property of <em>current toc branch</em>
+												contains a non-empty array, and its <code>name</code> property is an
+												empty string, set its <code>name</code> to null;</li>
+											<li>If the <code>entries</code> property of <em>current toc branch</em>
+												contains an empty array, and its <code>name</code> property is an empty
+												string, set <em>current toc branch</em> to null and exit this processing
+												step.</li>
+										</ol>
+										<p>Add <em>current toc branch</em> to the array in the <code>entries</code>
+											property of the object at the top of the stack.</p>
+									</li>
+									<li>
+										<p>Otherwise, add the object in <em>current toc branch</em> to the
+												<code>entries</code> array of <em>toc</em>.</p>
+									</li>
+
+									<li>
+										<p>Set <em>current toc branch</em> to <code>null</code>.</p>
+									</li>
+								</ol>
+								<details>
+									<summary>Explanation</summary>
+									<p>Exiting a list item indicates that processing of the current branch is complete.
+										Before adding this branch to its parent's <code>entries</code> array, the branch
+										needs to be tested to see if it has a name and/or any sub-branches. If it does
+										not have a name but has sub-branches, the branch is kept (the user agent will
+										have to supply a name later, if needed). If it does not have a name or any
+										branches, it is invalid and is discarded.</p>
+									<p>To determine where to merge the branch, the stack is checked. If there are no
+										objects in the stack, it is added into the <code>entries</code> property of the
+										root <em>toc</em> object (i.e., it is a top-level branch). Otherwise, it gets
+										added into the <code>entries</code> property of the object immediately preceding
+										it in the stack.</p>
+									<p>As a final step, <em>current toc branch</em> is reset back to
+										<code>null</code>.</p>
+									<aside class="example" title="Visualization of a branch merge">
+										<p>If the following two objects are in <em>current toc branch</em></p>
+										<pre>{
+   "name": "Section 1",
+   "url": "http://example.com/contents.html#s1",
+   "entries": []
+},
+{
+   "name": "Section 1.1",
+   "url": "http://example.com/contents.html#s1.1",
+   "entries": null
+}</pre>
+										<p>Then only the following single object remains after merging:</p>
+										<pre>{
+   "name": "Section 1",
+   "url": "http://example.com/contents.html#s1",
+   "entries": [
+      {
+         "name": "Section 1.1",
+         "url": "http://example.com/contents.html#s1.1",
+         "entries": null
+      }
+   ]
+}</pre>
+									</aside>
+								</details>
+							</li>
+
+							<li>
+								<p><strong>When entering an <a
+											href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element"
+											>anchor</a> element and <em>current toc branch</em> is not
+										<code>null</code>:</strong></p>
+								<p>Run these steps:</p>
+								<ol>
+									<li>
+										<p>If the <code>name</code> property of <em>current toc branch</em> is not an
+											empty string, do nothing.</p>
+									</li>
+									<li>
+										<p>Otherwise:</p>
+										<ol>
+											<li>Calculate the <a
+													href="https://www.w3.org/TR/accname-1.1/#mapping_additional_nd_te"
+													>accessible name</a> [[!accname-1.1]] for the element. If the
+												resulting value is a non-empty string after trimming leading and
+												trailing white space, set the <code>name</code> property of <em>current
+													toc branch</em> to the resulting value. Otherwise, set the property
+												to <code>null</code>.</li>
+											<li>If the element has an <code>href</code> attribute and the IRI in the
+												attribute resolves to a resource in the <a>default reading order</a> or
+													<a>resource list</a>, set the <code>url</code> property of
+													<em>current toc branch</em> to the value. Otherwise, set the
+												property to <code>null</code>.</li>
+										</ol>
+										<p>Exit the element and continue processing with the next element.</p>
+									</li>
+								</ol>
+								<details>
+									<summary>Explanation</summary>
+									<p>This step processes anchor tags to obtain values for the <code>name</code> and
+											<code>url</code> properties of a branch.</p>
+									<p>If the name of the current branch is already defined, then processing of this
+										element is terminated (i.e., to avoid processing multiple links for a single
+										branch).</p>
+									<p>In addition to having an <code>href</code> attribute specified, it is necessary
+										that it resolve to a resource that belongs to the publication to meet the
+										requirements of this specification. If not, the branch is retained but the entry
+										will not be linkable.</p>
+								</details>
+							</li>
+
+							<li>
+								<p><strong>When entering a <a
+											href="https://www.w3.org/TR/html/dom.html#sectioning-content-2">sectioning
+											content</a> element, a <a
+											href="https://www.w3.org/TR/html/sections.html#sectioning-roots">sectioning
+											root</a> element, or an element with a <a
+											href="https://www.w3.org/TR/html/editing.html#element-attrdef-global-hidden"
+											>hidden</a> attribute:</strong></p>
+								<p>Exit the element and continue processing with the next element.</p>
+								<details>
+									<summary>Explanation</summary>
+									<p>As sectioning and sectioning root elements can define their own outlines,
+										descending into them poses problems for generating the table of contents (i.e.,
+										they may contain content that is not directly related). As a result, they are
+										skipped over when encountered to prevent their child content from being
+										processed.</p>
+								</details>
+							</li>
+
+							<li>
+								<p><strong>Otherwise: do nothing.</strong></p>
+								<details>
+									<summary>Explanation</summary>
+									<p>For all other elements, this steps allows their descendant elements to continue
+										to be processed.</p>
+								</details>
+							</li>
+						</ol>
+					</li>
+					<li>
+						<p>After completing the DOM walk, if the <em>entries</em> property of <em>toc</em> contains a
+							non-empty array, <em>toc</em> represents the machine-processed table of contents.</p>
+						<p>Otherwise, the Web Publication does not have a table of contents that can be used for machine
+							rendering purposes.</p>
+						<details>
+							<summary>Explanation</summary>
+							<p>If the <code>entries</code> array in the root <em>toc</em> object does not contain any
+								branches (either because no list was found in the <code>nav</code> element or the list
+								did not contain any conforming list items), then the algorithm did not produce a usable
+								table of contents.</p>
+						</details>
 					</li>
 				</ol>
-
-				<p>If the table of contents <code>nav</code> uses a different content model, processing of it to obtain
-					a hierarchy of links is OPTIONAL. In such cases, the user agent MAY simply extract all
-						<code>a</code> elements and process them into a tree with only a single level of leaf nodes.</p>
-
-				<p>If a user agent is unable to obtain a set of one or more links from the table of contents
-						<code>nav</code>, the Web Publication does not have a table of contents.</p>
 			</section>
 		</section>
 		<section id="app-manifest-examples" class="appendix informative">

--- a/index.html
+++ b/index.html
@@ -3605,7 +3605,6 @@ partial dictionary WebPublicationManifest {
 									href="https://www.w3.org/TR/html/grouping-content.html#the-ul-element"
 										><code>ul</code></a></dt>
 							<dd>
-								<p>In this order:</p>
 								<ul class="nomark">
 									<li>
 										<p>

--- a/index.html
+++ b/index.html
@@ -416,8 +416,8 @@ dictionary WebPublicationManifest {
 								characteristics of the target resource.</li>
 						</ol>
 
-						<p>In other words, a single string value is a shorthand for a <code>LinkedResource</code>
-							object whose <code>url</code> property is set to that string value. (See also <a
+						<p>In other words, a single string value is a shorthand for a <code>LinkedResource</code> object
+							whose <code>url</code> property is set to that string value. (See also <a
 								href="#strings-vs-objects"></a>.)</p>
 
 						<pre class="example" title="Resource list that includes one link using a relative URL as a string ('datatypes.svg') and two that display the various properties of the a LinkedResource object">
@@ -790,15 +790,13 @@ partial dictionary WebPublicationManifest {
 						page</a>, the manifest SHOULD <a href="#table-of-contents">identify the resource</a> that
 					contains the structure.</p>
 
-				<p>
-					When specified, the table of content MUST include a link to at least one <a href="#wp-resources">resource</a>,
-					and all links SHOULD refer to <a href="#wp-resources">resources</a> within <a href="#wp-bounds">publication bounds</a>. 
-				</p>
+				<p> When specified, the table of content MUST include a link to at least one <a href="#wp-resources"
+						>resource</a>, and all links SHOULD refer to <a href="#wp-resources">resources</a> within <a
+						href="#wp-bounds">publication bounds</a>. </p>
 
 				<p>Refer to the <a href="#table-of-contents">table of contents property definition</a> for more
 					information on how to identify which resource contains the table of contents.</p>
 
-				<p class="issue" data-number="291">Do we need a more detailed definition for the HTML TOC format?</p>
 			</section>
 
 			<section id="wp-pagelist">
@@ -2077,7 +2075,8 @@ enum ProgressionDirection {
 				<section id="wp-title">
 					<h4>Title</h4>
 
-					<p>The title provides the human-readable name of the <a>Web Publication</a>. It is expressed using the <code>name</code> property.</p>
+					<p>The title provides the human-readable name of the <a>Web Publication</a>. It is expressed using
+						the <code>name</code> property.</p>
 
 					<table class="zebra">
 						<thead>
@@ -2102,22 +2101,30 @@ enum ProgressionDirection {
 						</tbody>
 					</table>
 
-					<p>
-						The title is specified by the <a href="#wp-title">manifest expression</a>, when present. If not included in the <a>authored manifest</a>, the user agent MUST use the value of the <a data-cite="!html#the-title-element"><code>title</code> element</a>&#160;[[!html]] of the Web Publication’s <a>primary entry page</a>, if present, when generating the <a>canonical manifest</a>.
-					</p>
+					<p> The title is specified by the <a href="#wp-title">manifest expression</a>, when present. If not
+						included in the <a>authored manifest</a>, the user agent MUST use the value of the <a
+							data-cite="!html#the-title-element"><code>title</code> element</a>&#160;[[!html]] of the Web
+						Publication’s <a>primary entry page</a>, if present, when generating the <a>canonical
+							manifest</a>. </p>
 
-					<p id="generate_title">
-						If the title is not available either in the <a>authored manifest</a> or as a non empty <a data-cite="!html#the-title-element"><code>title</code> element</a> in the <a>primary entry page</a>, the user agent MUST create one. This specification does not specify what heuristics the user agent should use; it can, for example, use a language-specific placeholder title, use the <abbr title="Uniform Resource Locator">URL</abbr> of the manifest or the primary entry page, or use the value of the <a href="#address">address</a> in the <a>authored manifest</a>. 
-					</p>
-	
-					<p class="note">
-						Relying on the <code>title</code> element could be semantically problematic if the Web Publication consists of several HTML resources (e.g., one per chapter of a book), because the <a data-cite="!html#the-title-element">HTML definition</a> defines this element as "metadata" for the enclosing HTML document, not for a collection of resources. Using this element is, on the other hand, preferred in the case of a publication consisting of a single HTML document (e.g., a scholarly journal article).
-					</p>
+					<p id="generate_title"> If the title is not available either in the <a>authored manifest</a> or as a
+						non empty <a data-cite="!html#the-title-element"><code>title</code> element</a> in the
+							<a>primary entry page</a>, the user agent MUST create one. This specification does not
+						specify what heuristics the user agent should use; it can, for example, use a language-specific
+						placeholder title, use the <abbr title="Uniform Resource Locator">URL</abbr> of the manifest or
+						the primary entry page, or use the value of the <a href="#address">address</a> in the
+							<a>authored manifest</a>. </p>
+
+					<p class="note"> Relying on the <code>title</code> element could be semantically problematic if the
+						Web Publication consists of several HTML resources (e.g., one per chapter of a book), because
+						the <a data-cite="!html#the-title-element">HTML definition</a> defines this element as
+						"metadata" for the enclosing HTML document, not for a collection of resources. Using this
+						element is, on the other hand, preferred in the case of a publication consisting of a single
+						HTML document (e.g., a scholarly journal article). </p>
 
 					<p class="note">A user agent is not expected to produce a <a
-						data-cite="WCAG20#navigation-mechanisms-title">meaningful
-						title</a>&#160;[[wcag20]] for a Web Publication when one is not specified.
-					</p>
+							data-cite="WCAG20#navigation-mechanisms-title">meaningful title</a>&#160;[[wcag20]] for a
+						Web Publication when one is not specified. </p>
 
 					<pre class="idl">
 partial dictionary WebPublicationManifest {
@@ -2181,7 +2188,7 @@ partial dictionary WebPublicationManifest {
 									<ul>
 										<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
 										<li>an instance of a <a href="#publication-link-def"
-													><code>LinkedResource</code></a> object</li>
+												><code>LinkedResource</code></a> object</li>
 									</ul>
 									<p>The order in the array is <em>significant</em>. The URLs MUST NOT include
 										fragment identifiers. Non-HTML resources SHOULD be expressed as
@@ -2275,7 +2282,7 @@ partial dictionary WebPublicationManifest {
 									<ul>
 										<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
 										<li>an instance of a <a href="#publication-link-def"
-													><code>LinkedResource</code></a> object</li>
+												><code>LinkedResource</code></a> object</li>
 									</ul>
 									<p>The order in the array is <em>not significant</em>. The URLs MUST NOT include
 										fragment identifiers. It is RECOMMENDED to use <code>LinkedResource</code>
@@ -2361,7 +2368,7 @@ partial dictionary WebPublicationManifest {
 									<ul>
 										<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
 										<li>an instance of a <a href="#publication-link-def"
-													><code>LinkedResource</code></a> object</li>
+												><code>LinkedResource</code></a> object</li>
 									</ul>
 									<p>The order in the array is <em>not significant</em>. It is RECOMMENDED to use
 											<code>LinkedResource</code> objects with their <code>encodingFormat</code>
@@ -2434,19 +2441,13 @@ partial dictionary WebPublicationManifest {
 						as [[!html]]. Augmenting these reports with machine-processable metadata, such as provided in
 						Schema.org [[!schema.org]], is also RECOMMENDED.</p>
 
-					<p>If present in the manifest, the <span data-dfn-for="WebPublicationManifest"><dfn
-								data-lt="accessibilityReport">accessibility report</dfn></span> MUST be expressed as a
-							<a href="#publication-link-def"><code>LinkedResource</code></a>. The <code>rel</code> value
-						of the <a href="#publication-link-def"><code>LinkedResource</code></a> MUST include the
+					<p>If present in the manifest, the accessibility report MUST be expressed as a <a
+							href="#publication-link-def"><code>LinkedResource</code></a>. The <code>rel</code> value of
+						the <a href="#publication-link-def"><code>LinkedResource</code></a> MUST include the
 							<code>https://www.w3.org/ns/wp#accessibility-report</code> identifier.</p>
 
 					<p class="ednote">The Working Group will attempt to define the <code>accessibility-report</code>
 						term with IANA, to avoid using a URL.</p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
-    LinkedResource accessibilityReport;
-};</pre>
 
 					<pre class="example" title="Link to an accessibility report">
 {
@@ -2493,11 +2494,6 @@ partial dictionary WebPublicationManifest {
 						the <a href="#publication-link-def"><code>LinkedResource</code></a> MUST include the
 							<code>privacy-policy</code> identifier&#160;[[!iana-link-relations]].</p>
 
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
-    LinkedResource privacyPolicy;
-};</pre>
-
 					<pre class="example" title="Privacy policy expressed as an external link">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
@@ -2541,14 +2537,12 @@ partial dictionary WebPublicationManifest {
 						at least one unique property to allow user agents to determine its usability (e.g., a different
 						format, height, width or relationship).</p>
 
-					<p>If present in the manifest, the <span data-dfn-for="WebPublicationManifest"><dfn data-lt="cover"
-								>cover</dfn></span> MUST be expressed as a <a href="#publication-link-def"
+					<p>If present in the manifest, the cover MUST be expressed as a <a href="#publication-link-def"
 								><code>LinkedResource</code></a>. The URL expressed in the <code>url</code> term MUST
 						NOT include a fragment identifier.</p>
 
-					<p>The <code>rel</code> value of the <a href="#publication-link-def"
-							><code>LinkedResource</code></a> MUST include the
-							<code>https://www.w3.org/ns/wp#cover</code> identifier.</p>
+					<p>The <code>rel</code> value of the <a href="#publication-link-def"><code>LinkedResource</code></a>
+						MUST include the <code>https://www.w3.org/ns/wp#cover</code> identifier.</p>
 
 					<p>If the cover is in an image format, a <code>title</code> and <code>description</code> SHOULD be
 						provided. User agents can use these properties to provide alternative text and descriptions when
@@ -2556,11 +2550,6 @@ partial dictionary WebPublicationManifest {
 
 					<p class="ednote">The Working Group will attempt to define the <code>cover</code> term by IANA, to
 						avoid using a URL.</p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
-    sequence&lt;LinkedResource> cover;
-};</pre>
 
 					<pre class="example" title="Cover HTML page">
 {
@@ -2664,23 +2653,16 @@ partial dictionary WebPublicationManifest {
 					<p class="ednote">The Working Group will attempt to define the <code>pagelist</code> term by IANA,
 						to avoid using a URL.</p>
 
-					<p>If present in the manifest, the <span data-dfn-for="WebPublicationManifest"><dfn
-								data-lt="pagelist">page list</dfn></span> MUST be expressed as a <a
-							href="#publication-link-def"><code>LinkedResource</code></a>. The URL expressed in the
-							<code>url</code> term MUST NOT include a fragment identifier.</p>
+					<p>If present in the manifest, the page list MUST be expressed as a <a href="#publication-link-def"
+								><code>LinkedResource</code></a>. The URL expressed in the <code>url</code> term MUST
+						NOT include a fragment identifier.</p>
 
-					<p>The <code>rel</code> value of the <a href="#publication-link-def"
-							><code>LinkedResource</code></a> MUST include the
-							<code>https://www.w3.org/ns/wp#pagelist</code> identifier.</p>
+					<p>The <code>rel</code> value of the <a href="#publication-link-def"><code>LinkedResource</code></a>
+						MUST include the <code>https://www.w3.org/ns/wp#pagelist</code> identifier.</p>
 
 					<p>The link to the page list MAY be specified in either the <a href="#default-reading-order">default
 							reading order</a> or <a href="#resource-list">resource-list</a>, but MUST NOT be specified
 						in both.</p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
-    HTMLElement pagelist;
-};</pre>
 
 					<pre class="example" title="Pagelist identified in another resource of the Web Publication">
 {
@@ -2735,28 +2717,20 @@ partial dictionary WebPublicationManifest {
 					<p>If this process does not result in a link to the table of contents, the Web Publication does not
 						have a table of contents and this property MUST NOT be included in the canonical manifest.</p>
 
-					<p class="issue" data-number="291">Depending on the resolution to this issue, the manifest might
-						contain a separate entry for a machine-processable table of contents, restrictions could be
-						placed on the HTML structure of the referenced table of contents, or parsing rules for
-						extracting a table of contents could be added.</p>
+					<p>See the separate section <a href="#app-toc-structure"></a> for the HTML structure that the table
+						of content SHOULD adhere to.</p>
 
 					<p>If present in the manifest, the <span data-dfn-for="WebPublicationManifest"><dfn data-lt="toc"
 								>table of contents</dfn></span> MUST be expressed as a <a href="#publication-link-def"
 								><code>LinkedResource</code></a>. The URL expressed in the <code>url</code> term MUST
 						NOT include a fragment identifier.</p>
 
-					<p>The <code>rel</code> value of the <a href="#publication-link-def"
-							><code>LinkedResource</code></a> MUST include the <code>contents</code>
-						identifier&#160;[[!iana-link-relations]].</p>
+					<p>The <code>rel</code> value of the <a href="#publication-link-def"><code>LinkedResource</code></a>
+						MUST include the <code>contents</code> identifier&#160;[[!iana-link-relations]].</p>
 
 					<p>The link to the table of contents MAY be specified in either the <a href="#default-reading-order"
 							>default reading order</a> or <a href="#resource-list">resource-list</a>, but MUST NOT be
 						specified in both.</p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
-    HTMLElement toc;
-};</pre>
 
 					<pre class="example" title="Table of content identified in another resource of the Web Publication">
 {
@@ -3036,16 +3010,16 @@ partial dictionary WebPublicationManifest {
 					</li>
 					<li> (<a href="#wp-title"></a>) if <var>manifest["name"]</var> is <code>undefined</code>, then
 						locate the <a data-cite="!html#the-title-element"><code>title</code></a> HTML element using
-							<var>document</var>. If that element exists and is non-empty, let <var>t</var> be its text content, and add to <var>manifest</var>: 
-							<ul>
-								<li> if the language of <code>title</code> is explicitly <a
-										data-cite="!html#the-lang-and-xml:lang-attributes">set</a> to the value of
-										<var>l</var>, then add <br />
-									<code class="json">"name": [{"value": t, "language": l}]</code>
-								</li>
-								<li>or <br />
-									<code class="json">"name": [t]</code><br /> otherwise </li>
-							</ul>
+							<var>document</var>. If that element exists and is non-empty, let <var>t</var> be its text
+						content, and add to <var>manifest</var>: <ul>
+							<li> if the language of <code>title</code> is explicitly <a
+									data-cite="!html#the-lang-and-xml:lang-attributes">set</a> to the value of
+									<var>l</var>, then add <br />
+								<code class="json">"name": [{"value": t, "language": l}]</code>
+							</li>
+							<li>or <br />
+								<code class="json">"name": [t]</code><br /> otherwise </li>
+						</ul>
 					</li>
 					<li> (<a href="#language-and-dir"></a>) if <var>manifest["inLanguage"]</var> is
 							<code>undefined</code> and the value of <var>lang</var> is <em>not</em>
@@ -3124,7 +3098,8 @@ partial dictionary WebPublicationManifest {
 							usage of the embedded values of <code>lang</code> and <code>dir</code> (steps (1) and (2) in
 							this section) depend on <a href="https://github.com/w3c/json-ld-syntax/issues/22">JSON-LD
 								#22</a>, <a href="https://github.com/w3c/json-ld-syntax/issues/57">JSON-LD #57</a>, and,
-							ultimately, <a href="https://github.com/w3ctag/design-reviews/issues/312">TAG #312</a>. </li>
+							ultimately, <a href="https://github.com/w3ctag/design-reviews/issues/312">TAG #312</a>.
+						</li>
 					</ul>
 				</div>
 			</section>
@@ -3164,10 +3139,10 @@ partial dictionary WebPublicationManifest {
 									<var>Obj</var> in <var>manifest object[term]</var> has <var>Obj["name"]</var> set.
 								If not, remove <var>Obj</var> from <var>manifest object[term]</var> array and issue a
 								warning. </li>
-								<li>
-									Check whether the value of <var>manifest object["name"]</var> is not empty. If it is, generate a value (see the <a href="#generate_title">separate note for details</a>) and issue a warning.
-								</li>
-								<li> For all the terms defined in <a href="#resource-categorization-properties"></a>, check
+							<li> Check whether the value of <var>manifest object["name"]</var> is not empty. If it is,
+								generate a value (see the <a href="#generate_title">separate note for details</a>) and
+								issue a warning. </li>
+							<li> For all the terms defined in <a href="#resource-categorization-properties"></a>, check
 								whether every object <var>Obj</var> in <var>manifest object[term]</var> has
 									<var>Obj["url"]</var> set. If not, remove <var>Obj</var> from <var>manifest
 									object[term]</var> array and issue a warning. If yes, check whether
@@ -3562,6 +3537,302 @@ partial dictionary WebPublicationManifest {
 			<h2>Privacy</h2>
 
 			<div class="ednote">Placeholder for privacy issues.</div>
+		</section>
+		<section id="app-toc-structure" class="appendix">
+			<h2>Machine-Processable Table of Contents</h2>
+
+			<section id="app-toc-html-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>To facilitate navigation within pages and across sites, HTML uses the <a
+						href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code> element</a>
+					[[html]] to express lists of links. Although generic in nature by default, the purpose of a
+						<code>nav</code> element can be more specifically identified by use of the <a
+						href="https://www.w3.org/TR/html/dom.html#aria-role-attribute"><code>role</code> attribute</a>
+					[[html]]. In particular, the <code>doc-toc</code> role from the [[dpub-aria-1.0]] vocabulary
+					identifies the <code>nav</code> element as the Web Publications’s <a href="#wp-table-of-contents"
+						>table of contents</a>.</p>
+
+				<p>Including an identifiable table of contents is an accessible way to produce any publication, but due
+					to the flexibility of HTML markup, it also presents challenges for user agents trying to extract a
+					meaningful hierarchy of links (e.g., to provide a custom view available from any page). To avoid
+					duplicating the tables of contents for different uses, this section defines a syntax that is both
+					human friendly and commonly used while still providing enough structure for user agent
+					extraction.</p>
+
+				<p>Authors have a choice of lists (ordered or unordered) to construct their table of contents. By
+					tagging each link within these lists in anchor tags (<a
+						href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element"><code>a</code>
+						elements</a>), user agents can easily differentiate the information they need from any
+					peripheral content (asides) or stylistic tagging that has also been added. The table of contents can
+					consist of both active links (with an <code>href</code> attribute) and inactive links (excluding the
+						<code>href</code> attribute), providing additional flexibility in how the table of contents is
+					constructed (e.g., to omit links to certain headings or only link to certain content in a
+					preview).</p>
+			</section>
+
+			<section id="app-toc-html">
+				<h3>HTML Structure</h3>
+
+				<p>To optimize the machine processing of an HTML table of contents by user agents, authors SHOULD adhere
+					to the following structuring guidelines.</p>
+
+				<p class="note">The following content model identifies the elements that are processed by user agents
+					and need to be included; it does not disallow the inclusion of other elements or content. Such
+					unspecified content is ignored by user agents, as described in <a href="#app-toc-ua"></a>.</p>
+
+				<dl class="elemdef">
+					<dt>Processed Content Model</dt>
+					<dd>
+						<dl class="variablelist">
+							<dt><a href="https://www.w3.org/TR/html/sections.html#the-nav-element"
+								><code>nav</code></a></dt>
+							<dd>
+								<p>A <code>role</code> attribute with the value <code>doc-toc</code> is REQUIRED</p>
+								<p>In this order:</p>
+								<ul class="nomark">
+									<li><a href="https://www.w3.org/TR/html/dom.html#heading-content"><code>HTML Heading
+												content</code></a>
+										<code>[0 or 1]</code></li>
+									<li>
+										<code>ol</code> or <code>ul</code>
+										<code>[exactly 1]</code>
+									</li>
+								</ul>
+							</dd>
+							<dt><a href="https://www.w3.org/TR/html/grouping-content.html#the-ol-element"
+										><code>ol</code></a> and <a
+									href="https://www.w3.org/TR/html/grouping-content.html#the-ul-element"
+										><code>ul</code></a></dt>
+							<dd>
+								<p>In this order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<code>li</code>
+											<code>[1 or more]</code></p>
+									</li>
+								</ul>
+							</dd>
+							<dt><a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element"
+										><code>li</code></a></dt>
+							<dd>
+								<p>In this order:</p>
+								<ul class="nomark">
+									<li>
+										<p><code>a</code>
+											<code>[exactly 1]</code></p>
+									</li>
+									<li>
+										<p>
+											<code>ol</code> or <code>ul</code>
+											<code>[0 or 1]</code></p>
+									</li>
+								</ul>
+							</dd>
+							<dt><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element"
+										><code>a</code></a></dt>
+							<dd>
+								<p>In any order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="https://www.w3.org/TR/html/dom.html#phrasing-content"><code>HTML
+													Phrasing content</code></a>
+											<code>[1 or more]</code></p>
+									</li>
+								</ul>
+							</dd>
+						</dl>
+						<p>Note that there are no restrictions on the attributes allowed on these elements.</p>
+					</dd>
+				</dl>
+
+				<p>The content model of the <code>nav</code> element is interpreted as follows:</p>
+
+				<ul class="conformance-list">
+					<li>
+						<p>The first <code>ol</code> or <code>ul</code> descendant of the <code>nav</code> element
+							defines the set of table of contents links, and its child list item elements represent the
+							primary level of content navigation.</p>
+					</li>
+					<li>
+						<p>Each list item identifies a heading, structure or other item of interest. A child
+								<code>a</code> element identifies and/or describes the target location.</p>
+					</li>
+					<li>
+						<p>The <code>a</code> element MUST provide a non-zero length text label after concatenation of
+							all child content and application of white space normalization rules. If a meaningful label
+							cannot be constructed from the text content of the <code>a</code> element &#8212; for
+							example, because it contains non-textual elements or instances of <a
+								href="https://www.w3.org/TR/html/dom.html#embedded-content">HTML embedded content</a>
+							that do not provide intrinsic text alternatives &#8212; an <a
+								href="https://www.w3.org/TR/wai-aria/#aria-label"><code>aria-label</code> attribute</a>
+							[[!WAI-ARIA-1.1]] MUST be provided with an alternate text rendering of the link label.</p>
+					</li>
+					<li>
+						<p>The <code>a</code> element MAY omit an <code>href</code> attribute, in which case the element
+							represents an inactive link.</p>
+					</li>
+					<li>
+						<p>When the <code>href</code> attribute is present, the IRI reference provided in it MUST
+							resolve to a resource in the <a>default reading order</a> or <a>resource list</a>, or
+							fragment therein.</p>
+					</li>
+					<li>
+						<p>An <code>a</code> element MAY be followed by another list, in which case the list represents
+							a subsidiary content level (e.g., all the subsection headings of a section). Every such
+							sub-list MUST adhere to the content requirements defined in this section for constructing
+							the primary navigation list.</p>
+					</li>
+				</ul>
+
+				<section id="app-toc-html-examples" class="informative notoc">
+					<h4>Examples</h4>
+
+					<aside class="example" title="A basic multi-level table of contents.">
+						<p>Note that different list types can be used for the different levels.</p>
+						<pre>&lt;nav role="doc-toc">
+   &lt;h2>Contents&lt;/h2>
+   
+   &lt;ol>
+      &lt;li>
+        &lt;a href="discourses.html">ZARATHUSTRA’S DISCOURSES.&lt;/a>
+         &lt;ul>
+            &lt;li>&lt;a href="discourses.html#s01">THE THREE METAMORPHOSES.&lt;/a>&lt;/li>
+            &lt;li>&lt;a href="discourses.html#s02">THE ACADEMIC CHAIRS OF VIRTUE.&lt;/a>&lt;/li>
+            &lt;li>&lt;a href="discourses.html#s03">BACKWORLDSMEN.&lt;/a>&lt;/li>
+            &#8230;
+         &lt;/ul>
+      &lt;/li>
+      &#8230;
+   &lt;/ol>
+&lt;/nav></pre>
+					</aside>
+
+					<aside class="example" title="A table of contents with ignored content.">
+						<p>The supplementary descriptive information is ignored by user agents.</p>
+						<pre>&lt;nav role="doc-toc">
+   &lt;h2>Contents&lt;/h2>
+   
+   &lt;ol>
+      &lt;li>
+         &lt;div class="title">&lt;a href="c01.html">CHAPTER I&lt;/a>&lt;/div>
+         &lt;div class="description">Biographical and Introductory.&lt;/a>&lt;/div>
+      &lt;/li>
+      &lt;li>
+         &lt;div class="title">&lt;a href="c02.html">CHAPTER II&lt;/a>&lt;/div>
+         &lt;div class="description">A New System of Alternating Current Motors and Transformers.&lt;/a>&lt;/div>
+      &lt;/li>
+      &#8230;
+   &lt;/ol>
+&lt;/nav></pre>
+					</aside>
+
+					<aside class="example" title="A table of contents for a preview.">
+						<p>The <code>a</code> elements that link to content the user does not have access to do not
+							include <code>href</code> attributes.</p>
+						<pre>&lt;nav role="doc-toc">
+   &lt;h2>Contents&lt;/h2>
+   
+  &lt;ol>
+     &lt;li>&lt;a href="xmas_carol.html">Marley's Ghost&lt;/a>&lt;/li>
+     &lt;li>&lt;a>The First of Three Spirits&lt;/a>&lt;/li>
+     &lt;li>&lt;a>The Second of Three Spirits&lt;/a>&lt;/li>
+     &lt;li>&lt;a>The Last of the Spirits&lt;/a>&lt;/li>
+     &lt;li>&lt;a>The End of It&lt;/a>&lt;/li>
+  &lt;/ol>
+   
+   &#8230;
+&lt;/nav></pre>
+					</aside>
+
+					<aside class="example" title="A table of contents with unlinked headings.">
+						<p>In this example, the author names are not relevant link locations so <code>href</code>
+							attributes are not included on their enclosing <code>a</code> elements.</p>
+						<pre>&lt;nav role="doc-toc">
+   &lt;h2>Contents&lt;/h2>
+   
+   &lt;ol>
+      &lt;li>
+         &lt;a>Faraday, Michael&lt;/a>
+         &lt;ol>
+            &lt;li>&lt;a href="faraday.html#s01">Experimental Researches in Electricity&lt;/a>&lt;/li>
+            &lt;li>&lt;a href="faraday.html#s02">The Chemical History of a Candle&lt;/a>&lt;/li>
+         &lt;/ol>
+      &lt;/li>
+      &lt;li>
+         &lt;a>Forel, Auguste&lt;/a>
+         &lt;ol>
+            &lt;li>&lt;a href="forel.html">The Senses of Insects&lt;/a>&lt;/li>
+         &lt;/ol>
+      &lt;/li>
+      &#8230;
+   &lt;/ol>
+&lt;/nav></pre>
+					</aside>
+
+				</section>
+			</section>
+
+			<section id="app-toc-ua">
+				<h3>User Agent Processing</h3>
+
+				<p>The expected structure of the machine-readable table of contents is defined such that a hierarchical
+					tree of links can be extracted from it. The root list within the <code>nav</code> element represents
+					the root of the tree, and each list item is either a branch (if it contains a sub-list) or a leaf
+					(if it contains only a link). The following algorithm describes how to construct this tree. (It does
+					not define how the extracted table of contents is presented to users.)</p>
+
+				<p>Note that due to the flexibility that HTML markup provides authors, the HTML table of contents might
+					contain additional elements not described in this section (e.g., <code>div</code> elements used for
+					styling, or supplementary content). These elements MUST be ignored. In addition, the flexibility of
+					HTML markup also means that some inspection might be required to find the referenced elements.</p>
+
+				<ol>
+					<li>Locate the first instance of a <code>nav</code> element with the <code>role</code> attribute
+						value <code>doc-toc</code>. Any subsequent instances MUST be ignored, even if the first does not
+						produce a usable table of contents.</li>
+					<li>If needed, a title for the table of contents MAY be obtained from the first descendant instance
+						of <a href="https://www.w3.org/TR/html/dom.html#heading-content">heading content</a>.</li>
+					<li>Locate the first descendant list element (<code>ol</code> or <code>ul</code>) of the
+							<code>nav</code> element. This list is used to produce the hierarchical tree of links. Any
+						subsequent lists MUST be ignored.</li>
+					<li>
+						<p>Process each list item (<code>li</code>) into a branch or leaf node as follows:</p>
+						<ul>
+							<li>If the list item contains a descendant list (<code>ol</code> or <code>ul</code>), create
+								a branch node; otherwise, create a leaf node.</li>
+							<li>Locate the first descendant <code>a</code> element that is not the descendant of a
+								nested list. If no element is found, discard the node and continue processing with the
+								next list item.</li>
+							<li>
+								<p>Create the text label for the node as follows:</p>
+								<ul>
+									<li>If the <code>a</code> element has an <code>aria-label</code> attribute, use the
+										value of the attribute as the label.</li>
+									<li>Otherwise, use the <a href="https://www.w3.org/TR/domcore/#dom-node-textcontent"
+											>text content</a> [[!DOM4]] of the element as the label.</li>
+								</ul>
+							</li>
+							<li>If the <code>a</code> item has an <code>href</code> attribute, and the destination of
+								IRI contained in the attribute is a resource in the <a>default reading order</a> or
+									<code>resource list</code>, store the IRI. Otherwise, the node is not linkable and
+								no IRI is associated with it.</li>
+							<li>If the list item is a branch, its child nodes are created by processing the first
+								descendant list in the same manner. This process continues until there are no more
+								branch nodes.</li>
+						</ul>
+					</li>
+				</ol>
+
+				<p>If the table of contents <code>nav</code> uses a different content model, processing of it to obtain
+					a hierarchy of links is OPTIONAL. In such cases, the user agent MAY simply extract all
+						<code>a</code> elements and process them into a tree with only a single level of leaf nodes.</p>
+
+				<p>If a user agent is unable to obtain a set of one or more links from the table of contents
+						<code>nav</code>, the Web Publication does not have a table of contents.</p>
+			</section>
 		</section>
 		<section id="app-manifest-examples" class="appendix informative">
 			<h2>Manifest Examples</h2>


### PR DESCRIPTION
This PR contains an adaptation of the EPUB toc rules, but simplified in the following ways:

- either ```ol``` or ```ul``` can be used to construct the list of links, and can be used interchangeably throughout the toc
- the content model is described in terms of what elements get processed, so other tagging can be included to decorate or annotate the toc (it's just ignored when processing)
- the use of a span element is dropped - an ```a``` tag without an ```href``` attribute can be used for unlinked labels
- ```aria-label``` is required for links whose text content is not comprehensible due to images and/or embedded content (removes the more complex rules about title/alt attributes, etc.)

Feedback is, as always, welcome from everyone on these changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/371.html" title="Last updated on Dec 6, 2018, 9:49 PM GMT (86935ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/371/8e902b5...86935ff.html" title="Last updated on Dec 6, 2018, 9:49 PM GMT (86935ff)">Diff</a>