### PR TITLE
Clarify the primary entry page

### DIFF
--- a/index.html
+++ b/index.html
@@ -745,7 +745,7 @@ partial dictionary WebPublicationManifest {
 				<p>The <dfn>primary entry page</dfn> represents the preferred starting <a href="#wp-resources"
 						>resource</a> for a Web Publication and enables discovery of its <a>manifest</a>. It is the
 					resource that is returned when accessing the Web Publication's <a>address</a>, and MUST be included
-					either in the <a>default reading order</a> or <a>resource list</a>.</p>
+					in either the <a>default reading order</a> or the <a>resource list</a>.</p>
 
 				<p>Although any resource can link to the Web Publication manifest, the primary entry page typically
 					introduces the publication and provides access to the content. It might contain all the content, in

--- a/index.html
+++ b/index.html
@@ -742,10 +742,10 @@ partial dictionary WebPublicationManifest {
 			<section id="wp-primary-entry-page">
 				<h3>Primary Entry Page</h3>
 
-				<p>Every Web Publication MUST include a <dfn>primary entry page</dfn>, which is the resource that MUST
-					be returned when accessing the Web Publication's <a>address</a>. The primary entry page represents
-					the preferred starting <a href="#wp-resources">resource</a> for the Web Publication, and enables
-					discovery of the <a>manifest</a>.</p>
+				<p>The <dfn>primary entry page</dfn> represents the preferred starting <a href="#wp-resources"
+						>resource</a> for a Web Publication and enables discovery of its <a>manifest</a>. It is the
+					resource that is returned when accessing the Web Publication's <a>address</a>, and MUST be included
+					either in the <a>default reading order</a> or <a>resource list</a>.</p>
 
 				<p>Although any resource can link to the Web Publication manifest, the primary entry page typically
 					introduces the publication and provides access to the content. It might contain all the content, in

--- a/index.html
+++ b/index.html
@@ -757,7 +757,7 @@ partial dictionary WebPublicationManifest {
 						>default reading order</a>, nor that it be the first document listed when it is included. This
 					specification leaves the exact nature of the document intentionally underspecified to provide
 					flexibility for different approaches. If a default reading order is not provided, however, user
-					agents will use the primary entry page as the default entry.</p>
+					agents will <a href="#no-reading-order">create one using the primary entry page</a>.</p>
 
 				<p>The primary entry page is the only resource in which <a href="#manifest-embedding">a manifest can be
 						embedded</a>. To ensure discovery of the manifest, the primary entry page MUST provide a <a
@@ -3127,9 +3127,9 @@ partial dictionary WebPublicationManifest {
 			                </pre>
 						</details>
 					</li>
-					<li> (<a href="#default-reading-order"></a>) if <var>manifest["readingOrder"]</var> is
-							<code>undefined</code>, let <var>u</var> be the value of <a
-							data-cite="!dom#concept-document-url">document.URL</a>, and add<br />
+					<li id="no-reading-order"> (<a href="#default-reading-order"></a>) if
+							<var>manifest["readingOrder"]</var> is <code>undefined</code>, let <var>u</var> be the value
+						of <a data-cite="!dom#concept-document-url">document.URL</a>, and add<br />
 						<code class="json">"readingOrder": [{"type": ["LinkedResource"], "url": u}]</code><br /> to the
 							<var>manifest</var>
 						<details>

--- a/index.html
+++ b/index.html
@@ -742,9 +742,10 @@ partial dictionary WebPublicationManifest {
 			<section id="wp-primary-entry-page">
 				<h3>Primary Entry Page</h3>
 
-				<p>The <dfn>primary entry page</dfn> is a key [[!HTML]] document required of every Web Publication. It
-					represents the preferred starting <a href="#wp-resources">resource</a> for discovery of the Web
-					Publication and enables discovery of the <a>manifest</a>.</p>
+				<p>Every Web Publication MUST include a <dfn>primary entry page</dfn> which MUST be returned when
+					accessing the Web Publication's <a>address</a>. The primary entry page represents the preferred
+					starting <a href="#wp-resources">resource</a> for discovery of the Web Publication, and enables
+					discovery of the <a>manifest</a>.</p>
 
 				<p>Although any resource can link to the Web Publication manifest, the primary entry page typically
 					introduces the publication and provides access to the content. It might contain all the content, in
@@ -755,9 +756,8 @@ partial dictionary WebPublicationManifest {
 				<p>It is not required that the primary entry page be included in the <a href="#default-reading-order"
 						>default reading order</a>, nor that it be the first document listed when it is included. This
 					specification leaves the exact nature of the document intentionally underspecified to provide
-					flexibility for different approaches (e.g., the primary entry page could be a marketing document for
-					the Web Publication instead of a specific page of content). If a default reading order is not
-					provided, however, the primary entry page will be used as the default entry.</p>
+					flexibility for different approaches. If a default reading order is not provided, however, user
+					agents will use the primary entry page as the default entry.</p>
 
 				<p>The primary entry page is the only resource in which <a href="#manifest-embedding">a manifest can be
 						embedded</a>. To ensure discovery of the manifest, the primary entry page MUST provide a <a

--- a/index.html
+++ b/index.html
@@ -742,9 +742,9 @@ partial dictionary WebPublicationManifest {
 			<section id="wp-primary-entry-page">
 				<h3>Primary Entry Page</h3>
 
-				<p>Every Web Publication MUST include a <dfn>primary entry page</dfn> which MUST be returned when
-					accessing the Web Publication's <a>address</a>. The primary entry page represents the preferred
-					starting <a href="#wp-resources">resource</a> for discovery of the Web Publication, and enables
+				<p>Every Web Publication MUST include a <dfn>primary entry page</dfn>, which is the resource that MUST
+					be returned when accessing the Web Publication's <a>address</a>. The primary entry page represents
+					the preferred starting <a href="#wp-resources">resource</a> for the Web Publication, and enables
 					discovery of the <a>manifest</a>.</p>
 
 				<p>Although any resource can link to the Web Publication manifest, the primary entry page typically


### PR DESCRIPTION
This PR addresses two of the concerns raised in issue #386:

- more clearly state that the PEP is a required resource
- remove the parenthetical about what content the PEP might contain


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/389.html" title="Last updated on Dec 19, 2018, 2:27 PM UTC (0f1cda3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/389/ae7c8b2...0f1cda3.html" title="Last updated on Dec 19, 2018, 2:27 PM UTC (0f1cda3)">Diff</a>