### PR TITLE
Split the specification into parts

### DIFF
--- a/common/css/common.css
+++ b/common/css/common.css
@@ -1,4 +1,18 @@
 
+section.part > h2 > span.secno {
+	display: none;
+} 
+
+a.suppress {
+	display: inline-block !important;
+	margin-left: -4rem !important;
+	margin-bottom: 0.5rem !important;
+}
+
+a.suppress > span.secno {
+	display: none;
+} 
+
 ul.ack > li,
 ul.flat > li {
     display: inline;
@@ -19,8 +33,7 @@ ul.flat {
 	padding-left: 0;
 }
 
-:not(div) > dl > dt,
-:not(div) > dl > dd {
+dt, dd {
 	padding-top: 0.5em;
 }
 

--- a/common/js/parts.js
+++ b/common/js/parts.js
@@ -1,0 +1,13 @@
+
+function denumber_parts() {
+	
+	var toc_entries = document.querySelectorAll('nav#toc > ol.toc > li.tocline');
+	
+	for (var i = 0; i < toc_entries.length; i++) {
+		toc_label = toc_entries[i].querySelector('a.tocxref');
+		
+		if (toc_label.textContent.match(/part i+:/i)) {
+			toc_label.classList.add('suppress');
+		}
+	}
+}

--- a/index.html
+++ b/index.html
@@ -7,15 +7,15 @@
 		<script src="common/js/biblio.js" class="remove"></script>
 		<script src="common/js/orcid.js" class="remove"></script>
 		<script src="common/js/wp.js" class="remove"></script>
+		<script src="common/js/parts.js" class="remove"></script>
 		<link href="common/css/common.css" rel="stylesheet" type="text/css" />
 		<script class="remove">
 		  // <![CDATA[
           var respecConfig = {
-			  postProcess: [show_orcid, create_wp],
+			  postProcess: [show_orcid, create_wp, denumber_parts],
 			  wg: "Publishing Working Group",
               specStatus: "ED",
               shortName: "wpub",
-              subtitle: "Manifest and Structure",
               previousPublishDate: "2019-01-30",
   			  previousMaturity: "WD",
               edDraftURI: "https://w3c.github.io/wpub/",
@@ -61,19 +61,19 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This specification defines a collection of information that describes the structure of Web Publications
-				so that user agents can provide user experiences specially tailored to reading publications, such as
-				sequential navigation and offline reading. This information includes the default reading order, a list
-				of resources, and publication-wide metadata.</p>
+			<p>The primary objective of this specification is to define requirements for the production of <a>Web
+					Publications</a>. In doing so, it also defines a framework for creating packaged publication
+				formats, such as EPUB and audiobooks, where a pathway to the Web is highly desirable but not necessarily
+				the primary method of interchange or consumption.</p>
 		</section>
 		<section id="sotd">
-			<p>This draft provides a draft version of a Web Publication. Many details are under active consideration
-				within the Publishing Working Group and are subject to change. The most prominent known issues have been
-				identified in this document and links provided to comment on them.</p>
+			<p>Many details of this draft are under active consideration within the Publishing Working Group and are
+				subject to change. The most prominent known issues have been identified in this document and links
+				provided to comment on them.</p>
 
-			<p>The most significant change to this draft is the tightening of its focus on the Web Publication manifest
-				and structure. Removed are the sections on affordances and Web Publication locators. Rendering details
-				are instead described in [[PWP-UCR]].</p>
+			<p>The most significant change to this draft is the splitting of the manifest from the requirements for Web
+				Publications so that it can serve as a model for packaged formats that desire a slimmer set of default
+				requirements.</p>
 
 			<p>The Publishing Working Group is actively producing proofs of concept of Web Publications and the
 				technologies required to process them. For a list of these activities, please refer to the <a
@@ -82,70 +82,81 @@
 		<section id="intro">
 			<h2>Introduction</h2>
 
-			<section id="what-is-wp" class="informative">
-				<h3>What is a Web Publication</h3>
-
-				<p>A <a>Web Publication</a> is a discoverable and identifiable collection of resources. Information
-					about the Web Publication is expressed in a machine-readable document called a <a>manifest</a>,
-					which is what enables user agents to understand the bounds of the Web Publication and the connection
-					between its resources.</p>
-
-				<p>The manifest includes metadata that describe the Web Publication, as a publication has an identity
-					and nature beyond its constituent resources. The manifest also provides a list of all the resources
-					that belong to the Web Publication and a default reading order, which is how it connects resources
-					into a single contiguous work.</p>
-
-				<p>A Web Publication is discoverable in one of two ways: resources either include a link to the manifest
-					(via an HTTP Link header or an HTML <code>link</code> element&#160;[[html]]), or the manifest can be
-					loaded directly by a compatible user agent.</p>
-
-				<p>With the establishment of Web Publications, user agents can build new experiences tailored
-					specifically for their unique reading needs.</p>
-
-				<figure id="WP-diagram">
-					<object data="images/WP-diagram.svg" type="image/svg+xml" aria-describedby="wp-diagram-alt">
-						<p id="wp-diagram-alt">Flowchart depicts the resources of a Web Publication and their attachment
-							to a manifest.</p>
-					</object>
-					<figcaption>Simplified Diagram of the Structure of Web Publications. <br />A <a
-							href="#WP-diagram-descr">description of the structure diagram</a> is available in the
-						Appendix. Image available in <a href="images/WP-diagram.svg"
-							title="SVG image of the structure of Web Publications">SVG</a> and <a
-							title="PNG image of the structure of Web Publications" href="images/WP-diagram.png">PNG</a>
-						formats.</figcaption>
-				</figure>
-			</section>
-
-			<section id="scope" class="informative">
+			<section id="scope">
 				<h3>Scope</h3>
 
-				<p>This specification defines requirements for the production of <a>Web Publications</a>. It does not
-					attempt to constrain the nature of a Web Publication—any type of work that can be represented on the
-					Web constitutes a potential Web Publication. It is also designed to be adaptable to the needs of
-					specific areas of published, such as audiobook production, and encourages a modular approach for
-					creating specializations.</p>
+				<p>This specification defines three key concepts:</p>
+
+				<ol>
+					<li>a general manifest format to describe publications;</li>
+					<li>a concrete format using the manifest to represent publications on the Web (<a>Web
+							Publications</a>); and</li>
+					<li>the rules for using the manifest as the basis for modular extensions that desire a pathway to
+						the Web.</li>
+				</ol>
+
+				<p>This specification does not attempt to constrain the nature of the publications that can be
+					produced—any type of work that can be represented using Web technologies is in scope. It is also
+					designed to be adaptable to the needs of specific areas of publishing, such as audiobook production,
+					and encourages a modular approach for creating specializations.</p>
 
 				<p>As much as possible, this specification leverages existing Open Web Platform technologies to achieve
-					its goal—that being to allow for a measure of boundedness on the Web without changing the way that
-					the Web itself operates.</p>
+					its goal—that being to allow for a measure of boundedness — on and off the Web — without changing
+					the way that the Web itself operates.</p>
 
-				<p>Moreover, the specification is designed to adapt automatically to updates to Open Web Platform
-					technologies in order to ensure that Web Publications continue to interoperate seamlessly as the Web
-					evolves (e.g., by referencing the latest published versions instead of specific dated versions).</p>
+				<p>Moreover, this specification is designed to adapt automatically to updates to Open Web Platform
+					technologies in order to ensure that conforming publications continue to interoperate seamlessly as
+					the Web evolves (e.g., by referencing the latest published versions instead of specific dated
+					versions).</p>
 
-				<p>The specification is also intended to facilitate different user agent architectures for the
-					consumption of Web Publications. While a primary goal is that traditional Web user agents (browsers)
-					will be able to consume Web Publications, this should not limit the capabilities of any other
-					possible type of user agent (e.g., applications, whether standalone or running within a user agent,
-					or even Web Publications that include their own user interface). As a result, the specification does
-					not attempt to architect required solutions for situations whose expected outcome will vary
-					depending on the nature of the user agent and the expectations of the user (e.g., how to prompt to
-					initiate a Web Publication, or at what point or how much of a Web Publication to cache for offline
-					use).</p>
+				<p>This specification is also intended to facilitate different user agent architectures for the
+					consumption of Web Publications, or any format derived therefrom. While a primary goal is that
+					traditional Web user agents (browsers) will be able to consume Web Publications, this should not
+					limit the capabilities of any other possible type of user agent (e.g., applications, whether
+					standalone or running within a user agent, or even Web Publications that include their own user
+					interface). As a result, the specification does not attempt to architect required solutions for
+					situations whose expected outcome will vary depending on the nature of the user agent and the
+					expectations of the user (e.g., how to prompt to initiate a Web Publication, or at what point or how
+					much of a Web Publication to cache for offline use).</p>
 
 				<p>This specification does not define how user agents are expected to render Web Publications. Details
 					about the types of afforances that user agents can provide to enhance the reading experience for
 					users are instead defined in [[PWP-UCR]].</p>
+			</section>
+
+			<section id="org" class="informative">
+				<h3>Organization</h3>
+
+				<p>This specification organized into three distinct parts, each of which builds on the previous:</p>
+
+				<dl>
+					<dt><a href="#manifest">Part I — Publication Manifest</a></dt>
+					<dd>
+						<p>The first part of this specification defines a general manifest format for expressing
+							information about a <a>digital publication</a>. It uses [[Schema.org]] metadata augmented to
+							include various structural properties about publications, and is serialized in [[JSON-LD]].
+							This definition is designed to be the basis for all the specific implementations of digital
+							publications. It allows for interoperability between the formats while accommodating
+							variances in the information that needs to be expressed. The actual manifest requirements
+							for a digital publication format are defined by its respective specification.</p>
+					</dd>
+					<dt><a href="#webpub">Part II — Web Publications</a></dt>
+					<dd>
+						<p>The second part of this specification details the Web Publications format for defining and
+							deploying publications on the Web. It explains the requirements for expressing the Web
+							Publication manifest, as well as various implementation details such as the primary entry
+							page and the table of contents. Web Publications are the Web deployment format for all
+							digital publications based on a Publication Manifest, so all such extensions have to remain
+							compatible with the requirements defined in this section.</p>
+					</dd>
+					<dt><a href="#extensions">Part III — Modular Extensions</a></dt>
+					<dd>
+						<p>The third part of this specification defines how create new packaged digital publication
+							formats using the Publication Manifest model. While such formats are not required to be
+							conforming Web Publications in their native state, it has to be possible to create content
+							that can conform to both requirements.</p>
+					</dd>
+				</dl>
 			</section>
 
 			<section id="terminology">
@@ -160,6 +171,15 @@
 					>address</a>.</p>
 
 				<dl>
+					<dt>
+						<dfn data-lt="digital publications|digital publication's">Digital Publication</dfn>
+					</dt>
+					<dd>
+						<p>The term digital publication is used to refer to the encoding of a publication in any format
+							that conforms to this specification, whether a <a>Web Publication</a> or a <a
+								href="#extensions">modular extension</a>. All such digital publications share the common
+								<a>manifest</a> format, but differ in their structural and content requirements.</p>
+					</dd>
 					<dt>
 						<dfn data-lt="identifiers">Identifier</dfn>
 					</dt>
@@ -178,9 +198,9 @@
 						<dfn data-lt="Manifests">Manifest</dfn>
 					</dt>
 					<dd>
-						<p>A manifest represents structured information about a <a>Web Publication</a>, such as
-							informative metadata, a <a href="#resource-list">list of all resources</a>, and a <a>default
-								reading order</a>.</p>
+						<p>A manifest represents structured information about a publication, such as informative
+							metadata, a <a href="#resource-list">list of all resources</a>, and a <a>default reading
+								order</a>.</p>
 					</dd>
 
 					<dt>
@@ -216,163 +236,558 @@
 					</dd>
 				</dl>
 			</section>
+
+			<section id="conformance"></section>
 		</section>
-		<section id="conformance">
-			<section id="conformance-classes">
-				<h2>Conformance Classes</h2>
+		<section id="manifest" class="part">
+			<h2>PART I: Publication Manifest</h2>
 
-				<p>This specification defines two conformance classes: one for <a>Web Publications</a> and one for user
-					agents that process them.</p>
+			<section id="manifest-intro" class="informative">
+				<h3>Introduction</h3>
 
-				<p id="wp-conformance">A Web Publication conforms to this specification if it meets the following
-					criteria:</p>
+				<p>A <a>digital publication</a> is described by its <a>manifest</a>, which provides a set of properties
+					expressed using the JSON-LD&#160;[[json-ld]] format (a variant of JSON&#160;[[ecma-404]] for linked
+					data).</p>
 
-				<ul>
-					<li>it has a <a>manifest</a> that conforms to <a href="#wp-properties-req"></a>;</li>
-					<li>it adheres to the construction requirements defined in <a href="#wp-construction"></a>.</li>
-				</ul>
+				<p>The manifest includes both descriptive properties about the publication, such as its title and
+					author, as well as information about the nature and structure of the publication.</p>
 
-				<p id="ua-conformance">A user agent conforms to this specification if it meets the following
-					criteria:</p>
-
-				<ul>
-					<li>it is capable of <a href="#obtaining-manifest">obtaining a conforming manifest</a> for a Web
-						Publication.</li>
-				</ul>
+				<p>This section describes the construction requirements for manifests, and outlines the general set of
+					properties for use with them.</p>
 			</section>
-		</section>
-		<section id="wp-construction">
-			<h2>Web Publication Construction</h2>
 
-			<section id="wp-manifest">
-				<h3>Manifest</h3>
+			<section id="manifest-authored-canonical" class="informative">
+				<h3>Authored and Canonical Manifests</h3>
 
-				<section id="manifest-authored-canonical">
-					<h4>Authored and Canonical Manifests</h4>
+				<p>Depending on the state of a <a>digital publication</a>, its manifest exists in one of two forms:</p>
 
-					<p>A Web Publication is described by its <a>manifest</a>, which provides a set of properties
-						expressed using the JSON-LD&#160;[[json-ld]] format (a variant of JSON&#160;[[ecma-404]] for
-						linked data).</p>
+				<dl>
+					<dt>
+						<dfn data-lt="authored publication manifest">Authored Manifest</dfn>
+					</dt>
+					<dd>
+						<p>The Authored Publication Manifest is the serialization of the manifest that the author
+							provides with the digital publication (i.e., prior to be digital publication being processed
+							by a user agent. Note that the author does not have to be human; a machine could
+							automatically produce authored manifests for digital publications.</p>
+					</dd>
 
-					<p>The manifest is expressed in one of two forms depending on the state of the Web Publication:</p>
+					<dt>
+						<dfn data-lt="canonical manifest|canonical publication manifest">Canonical Manifest</dfn>
+					</dt>
+					<dd>
+						<p>The Canonical Publication Manifest is a version of the manifest created by user agents when
+							they <a href="#obtaining-manifest">obtain the authored manifest</a> and remove all possible
+							ambiguities and incorporate any missing values that can be inferred from another source.</p>
+					</dd>
+				</dl>
 
-					<dl>
-						<dt>
-							<dfn data-lt="authored web publication manifest">Authored Manifest</dfn>
-						</dt>
-						<dd>
-							<p>The Authored Web Publication Manifest, as its name suggests, is the serialization of the
-								manifest that the author provides with the Web Publication (note that the author does
-								not have to be human).</p>
-						</dd>
+				<p>It is possible that an authored manifest is the equivalent of the canonical manifest if there are no
+					ambiguities or missing information, but a canonical manifest only exists after a user agent has
+					inspected the authored manifest as part of the process of obtaining it.</p>
 
-						<dt>
-							<dfn data-lt="canonical manifest|canonical web publication manifest">Canonical
-								Manifest</dfn>
-						</dt>
-						<dd>
-							<p>The Canonical Web Publication Manifest is a version of the Web Publication
-									<a>Manifest</a> created by user agents when they <a href="#obtaining-manifest"
-									>obtain the authored manifest</a> and remove all possible ambiguities and
-								incorporate any missing values that can be inferred from another source.</p>
-						</dd>
-					</dl>
+				<p>This part of the specification describes the requirements for creating an authored manifest,
+					regardless of the format of the digital publication. Rules for constructing a canonical manifest
+					from the authored manifest are defined for each specific implementation (e.g., the process for
+						<a>Web Publications</a> is described in <a href="#canonical-manifest"></a>).</p>
 
-					<p>It is possible that an authored manifest is the equivalent of the canonical manifest if there are
-						no ambiguities or missing information, but a canonical manifest only exists after a user agent
-						has inspected the authored manifest as part of the process of obtaining it.</p>
+			</section>
 
-					<p>This specification describes the requirements for creating both authored and canonical manifests.
-						This section, in particular, details how to create the authored manifest, while <a
-							href="#wp-properties"></a> provides the various property definitions. These definitions
-						include the rules user agents uses to supplement the canonical manifest. The algorithm for
-						transforming an <a>Authored Manifest</a> into a <a>Canonical Manifest</a> is described in the
-						separate section <a href="#canonical-manifest"></a>.</p>
+			<section id="webidl">
+				<h3>WebIDL</h3>
 
+				<section id="webidl-intro" class="informative">
+					<h4>Introduction</h4>
+
+					<p>Although a <a>digital publication</a>'s manifest is authored as [[json-ld]], a user agent
+						processes this information into an internal data structure in order to utilize the properties.
+						The exact manner in which this processing occurs, and how the data is used internally, is user
+						agent-dependent.</p>
+
+					<p>To ensure interoperability when exposing the items, this specification defines an abstract
+						representation of the data structures using the Web Interface Definition Language (WebIDL)
+						[[webidl-1]]. The WebIDL definitions express the expected names, datatypes, and possible
+						restrictions for each member of the manifest. (A WebIDL representation can be mapped onto
+						ECMAScript, C, or other programming languages.)</p>
+
+					<p class="note">Authors of digital publications are encouraged to review these definitions, but they
+						are not necessary to understand.</p>
 				</section>
 
-				<section id="webidl">
-					<h4>WebIDL</h4>
+				<section id="webidl-wpm">
+					<h4>The <dfn><code>PublicationManifest</code></dfn> Dictionary</h4>
 
-					<section id="webidl-intro" class="informative">
-						<h5>Explanation</h5>
-
-						<p>Although a Web Publication manifest is authored as [[json-ld]], a user agent processes this
-							information into an internal data structure in order to utilize the properties. The exact
-							manner in which this processing occurs, and how the data is used internally, is user
-							agent-dependent.</p>
-
-						<p>To ensure interoperability when exposing the items, this specification defines an abstract
-							representation of the data structures using the Web Interface Definition Language (WebIDL)
-							[[webidl-1]]. The WebIDL definitions express the expected names, datatypes, and possible
-							restrictions for each member of the manifest. (A WebIDL representation can be mapped onto
-							ECMAScript, C, or other programming languages.)</p>
-
-						<p class="note">Authors of Web Publications are encouraged to review these definitions, but they
-							are not necessary to understand.</p>
-					</section>
-
-					<section id="webidl-wpm">
-						<h5>The <dfn><code>WebPublicationManifest</code></dfn> Dictionary</h5>
-
-						<pre class="idl" id="wpm">
-dictionary WebPublicationManifest {
+					<pre class="idl" id="wpm">
+dictionary PublicationManifest {
 
 };</pre>
 
-						<p>The <code>WebPublicationManifest</code> dictionary is the [[!webidl-1]] representation of the
-							collection of Web Publication manifest properties. WebIDL definitions are also provided at
-							the end of each property that belongs to the dictionary &#8212; these represent the members
-							of the <code>WebPublicationManifest</code> dictionary.</p>
+					<p>The <code>PublicationManifest</code> dictionary is the [[!webidl-1]] representation of the
+						collection of manifest properties. WebIDL definitions are also provided at the end of each
+						property that belongs to the dictionary — these represent the members of the
+							<code>PublicationManifest</code> dictionary.</p>
 
-						<p class="note">Refer to <a href="#idl-index"></a> for a complete listing of the
-								<code>WebPublicationManifest</code> dictionary.</p>
-					</section>
+					<p class="note">Refer to <a href="#idl-index"></a> for a complete listing of the
+							<code>PublicationManifest</code> dictionary.</p>
 				</section>
+			</section>
 
-				<section id="manifest-context">
-					<h4>Manifest Contexts</h4>
+			<section id="manifest-context">
+				<h3>Manifest Contexts</h3>
 
-					<p>A Web Publication Manifest MUST start by setting the JSON-LD context [[!json-ld]]. The context
-						has the following two major components:</p>
+				<p>A <a>digital publication's</a>
+					<a>manifest</a> MUST start by setting the JSON-LD context [[!json-ld]]. The context has the
+					following two major components:</p>
 
-					<ul>
-						<li>the [[!schema.org]] context: <code>https://schema.org</code></li>
-						<li>the Web Publication context: <code>https://www.w3.org/ns/wp-context</code></li>
-					</ul>
+				<ul>
+					<li>the [[!schema.org]] context: <code>https://schema.org</code></li>
+					<li>the publication context: <code>https://www.w3.org/ns/wp-context</code></li>
+				</ul>
 
-					<pre class="example" title="The context declaration.">
+				<pre class="example" title="The context declaration.">
 {
     "@context" : ["https://schema.org", "https://www.w3.org/ns/wp-context"],
     &#8230;
 }
 </pre>
 
-					<p>The Web Publication context document adds features to the properties defined in Schema.org (e.g.,
-						the requirement for the <a href="https://schema.org/creator">creator</a> property to be order
-						preserving).</p>
+				<p>The publication context document adds features to the properties defined in Schema.org (e.g., the
+					requirement for the <a href="https://schema.org/creator">creator</a> property to be order
+					preserving).</p>
 
-					<p class="ednote">As part of the continuous contacts with Schema.org the additional features defined
-						in the Web Publication context file could migrate to the core Schema.org vocabulary.</p>
+				<p class="ednote">As part of the continuous contacts with Schema.org the additional features defined in
+					the publication context file could migrate to the core Schema.org vocabulary.</p>
 
-					<p class="note">Although Schema.org is often referenced using the <code>http</code> URI scheme, <a
-							href="https://schema.org/docs/faq.html#19">the vocabulary is being migrated</a> to use the
-						secure <code>https</code> scheme as its default. This specification requires the use
-							<code>https</code> when referencing Schema.org in the manifest.</p>
+				<p class="note">Although Schema.org is often referenced using the <code>http</code> URI scheme, <a
+						href="https://schema.org/docs/faq.html#19">the vocabulary is being migrated</a> to use the
+					secure <code>https</code> scheme as its default. This specification requires the use of
+						<code>https</code> when referencing Schema.org in the manifest.</p>
+			</section>
+
+			<section id="publication-types">
+				<h4>Publication Types</h4>
+
+				<p>A <a>digital publication's</a>
+					<a>manifest</a> MUST define its <dfn>Publication Type</dfn> using the <code
+						data-dfn-for="PublicationManifest"><dfn>type</dfn></code> term&#160;[[!json-ld]]. The type MAY
+					be mapped onto <a href="https://schema.org/CreativeWork"
+					><code>CreativeWork</code></a>&#160;[[!schema.org]].</p>
+
+				<pre class="example" title="Setting a publication's type to CreativeWork.">
+{
+    "@context" : ["https://schema.org", "https://www.w3.org/ns/wp-context"],
+    "type"     : "CreativeWork"
+    &#8230;
+}
+</pre>
+
+				<p>Schema.org also includes a number of more specific subtypes of <code>CreativeWork</code>, such as <a
+						href="https://schema.org/Article"><code>Article</code></a>, <a href="https://schema.org/Book"
+							><code>Book</code></a>, <a href="https://schema.org/TechArticle"
+						><code>TechArticle</code></a>, and <a href="https://schema.org/Course"><code>Course</code></a>.
+					These MAY be used instead of, or in addition to, <code>CreativeWork</code>.</p>
+
+				<pre class="example" title="Setting a publication's type to Book.">
+{
+    "@context" : ["https://schema.org", "https://www.w3.org/ns/wp-context"],
+    "type"     : "Book"
+    &#8230;
+}
+</pre>
+
+				<p>Each Schema.org type defines a set of properties that are valid for use with it. To ensure that the
+					manifest can be validated and processed by Schema.org aware processors, the manifest SHOULD contain
+					only the properties associated with the selected type.</p>
+
+				<p>If properties from more than one type are needed, the manifest MAY include multiple type
+					declarations.</p>
+
+				<pre class="example" title="A publication that combines properties from both Book and VisualArtwork.">
+{
+    "@context" : ["https://schema.org", "https://www.w3.org/ns/wp-context"],
+    "type"     : ["Book", "VisualArtwork"],
+    &#8230;
+}
+</pre>
+
+				<p>User agents SHOULD NOT fail to process manifests that are not valid to their declared Schema.org
+					type(s).</p>
+
+				<p class="note">Refer to the Schema.org site for the complete <a href="https://schema.org/CreativeWork"
+						>list of <code>CreativeWork</code> subtypes</a>.</p>
+
+				<pre class="idl">
+partial dictionary PublicationManifest {
+    required sequence&lt;DOMString&gt; type;
+};</pre>
+			</section>
+
+			<section id="manifest-properties">
+				<h3>Properties</h3>
+
+				<section id="properties-intro" class="informative">
+					<h4>Introduction</h4>
+
+					<p>A <a>digital publication's</a>
+						<a>manifest</a> is defined by a set of properties that describe the basic information a user
+						agent requires to process and render the publication. These properties are categorized as
+						followed:</p>
+
+					<dl>
+						<dt>
+							<a href="#descriptive-properties">descriptive properties</a>
+						</dt>
+						<dd>
+							<p>Descriptive properties describe aspects of a digital publication, such as its <a
+									href="#pub-title">title</a>, <a href="#creators">creator</a>, and <a
+									href="#language-and-dir">language</a>. These properties are primarily drawn from <a
+									href="https://schema.org">Schema.org</a> and its <a
+									href="https://schema.org/docs/schemas.html">hosted
+								extensions</a>&#160;[[schema.org]], so they map to one or several Schema.org properties
+								and inherit their syntax and semantics. (The following property categories typically do
+								not have Schema.org equivalents, so are defined specifically for publications.)</p>
+						</dd>
+						<dt>
+							<a href="#resource-categorization-properties">resource categorization</a>
+						</dt>
+						<dd>
+							<p>Resource categorization properties describe or identify common sets of resources, such as
+								the <a href="#resource-list">resource list</a> and <a href="#default-reading-order"
+									>default reading order</a>. These properties refer to one or more resources, such as
+								HTML documents, images, script files, and separate metadata files.</p>
+						</dd>
+						<dt>
+							<a href="#informative-properties">informative properties</a>
+						</dt>
+						<dd>
+							<p>Informative properties identify resources that contain additional information about the
+								publication, such as its <a href="#privacy-policy">privacy policy</a> or <a
+									href="#accessibility-report">accessibility report</a>.</p>
+						</dd>
+						<dt>
+							<a href="#structural-properties">structural properties</a>
+						</dt>
+						<dd>
+							<p>Structural properties identify key meta structures of the publication, such as the <a
+									href="#cover">cover image</a>, <a href="#table-of-contents">table of contents</a>,
+								and <a href="#page-list">page list</a>.</p>
+						</dd>
+					</dl>
+
+					<p class="note">The categorization of properties is done to simplify comprehension of their purpose;
+						the groupings have no relevance outside this specification (i.e., the groupings do not exist in
+						the manifest).</p>
+
+					<div class="note">
+						<p>Each manifest item drawn from schema.org identifies the property it maps to and includes its
+							defining type in parentheses. Properties are often available in many types, however, as a
+							result of the schema.org inheritance model. Refer to each property definition for more
+							detailed information about where it is valid to use.</p>
+
+						<p>Schema.org additionally includes a large number of properties that, though relevant for
+							publishing, are not mentioned in this specification — publication authors can use any of
+							these properties. This document defines only the minimal set of manifest items.</p>
+					</div>
+
+					<p class="ednote">There are discussion on whether a best practices document would be created,
+						referring to more schema.org terms. If so, it should be linked from here.</p>
 				</section>
 
-				<section id="manifest-values">
+				<section id="properties-mapping" class="informative">
+					<h4>Quick Reference</h4>
+
+					<p>The way that properties are expressed in the manifest often differs from how they are referred to
+						using natural language. The following table provides a mapping between property names and the
+						sections where they are explained to help clarify the differing nomenclature:</p>
+
+					<table class="zebra">
+						<thead>
+							<tr>
+								<th>Property Name</th>
+								<th>Defined In</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td>
+									<code>accessMode</code>
+								</td>
+								<td>
+									<a href="#accessibility">Accessibility</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>accessModeSufficient</code>
+								</td>
+								<td>
+									<a href="#accessibility">Accessibility</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>accessibilityAPI</code>
+								</td>
+								<td>
+									<a href="#accessibility">Accessibility</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>accessibilityControl</code>
+								</td>
+								<td>
+									<a href="#accessibility">Accessibility</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>accessibilityFeature</code>
+								</td>
+								<td>
+									<a href="#accessibility">Accessibility</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>accessibilityHazard</code>
+								</td>
+								<td>
+									<a href="#accessibility">Accessibility</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>accessibilitySummary</code>
+								</td>
+								<td>
+									<a href="#accessibility">Accessibility</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>artist</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>author</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>contents</code>
+								</td>
+								<td>
+									<a href="#table-of-contents">Table of Contents</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>contributor</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>creator</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>dateModified</code>
+								</td>
+								<td>
+									<a href="#last-modification-date">Last Modification Date</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>datePublished</code>
+								</td>
+								<td>
+									<a href="#publication-date">Publication Date</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>editor</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>https://www.w3.org/ns/wp#accessibility-report</code>
+								</td>
+								<td>
+									<a href="#accessibility-report">Accessibility Report</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>https://www.w3.org/ns/wp#cover</code>
+								</td>
+								<td>
+									<a href="#cover">Cover</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>https://www.w3.org/ns/wp#pagelist</code>
+								</td>
+								<td>
+									<a href="#page-list">Pagelist</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>illustrator</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>inDirection</code>
+								</td>
+								<td>
+									<a href="#language-and-dir">Direction</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>inker</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>inLanguage</code>
+								</td>
+								<td>
+									<a href="#language-and-dir">Language</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>letterer</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>link</code>
+								</td>
+								<td>
+									<a href="#links">Links</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>name</code>
+								</td>
+								<td>
+									<a href="#pub-title">Title</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>penciler</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>privacy-policy</code>
+								</td>
+								<td>
+									<a href="#privacy-policy">Privacy Policy</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>publisher</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>readBy</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>readingOrder</code>
+								</td>
+								<td>
+									<a href="#default-reading-order">Default Reading Order</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>readingProgression</code>
+								</td>
+								<td>
+									<a href="#reading-progression-direction">Reading Progression Direction</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>resources</code>
+								</td>
+								<td>
+									<a href="#resource-list">Resource List</a>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>translator</code>
+								</td>
+								<td>
+									<a href="#creators">Creators</a>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section id="properties-values">
 					<h4>Values</h4>
 
 					<section id="arrays-and-single-values">
 						<h5>Arrays and Single Values</h5>
 
-						<p>Various manifest properties can have one or more values. As a general rule, these values can
-							be expressed as [[!json]]&#160;arrays. When the property value is an array with a single
-							element, however, the array syntax MAY be omitted.</p>
+						<p>Various <a href="#manifest-properties">manifest properties</a> can have one or more values.
+							As a general rule, these values can be expressed as [[!json]]&#160;arrays. When the property
+							value is an array with a single element, however, the array syntax MAY be omitted.</p>
 
 						<aside class="example" title="Using a text string instead of an array">
-							<p>As a Web Publication typically contains many resources, this declaration of a single
+							<p>As a digital publication typically contains many resources, this declaration of a single
 								resource:</p>
 
 							<pre>
@@ -394,7 +809,7 @@ dictionary WebPublicationManifest {
 						<h5>Text Values or Objects</h5>
 
 						<p>Various manifest properties are expected to be expressed as [[!json]]&#160;objects. Although
-							the use of objects is usually RECOMMENDED, it is also acceptable to use string values that
+							the use of objects is usually recommended, it is also acceptable to use string values that
 							are interpreted as objects depending on the context. The exact mapping of text values to
 							objects is part of the property or object definitions.</p>
 
@@ -423,9 +838,9 @@ dictionary WebPublicationManifest {
 					<section id="link-values">
 						<h5>Link Values</h5>
 
-						<p>With the exception of the <a href="#descriptive-properties">descriptive properties</a>, Web
-							Publication properties typically link to one or more resources. When a property requires a
-							link value, the link MUST be expressed in one of the following two ways:</p>
+						<p>With the exception of the <a href="#descriptive-properties">descriptive properties</a>,
+							manifest properties typically link to one or more resources. When a property requires a link
+							value, the link MUST be expressed in one of the following two ways:</p>
 
 						<ol>
 							<li>as a string encoding the (absolute or relative) URL of the resources&#160;[[!url]];
@@ -462,7 +877,7 @@ dictionary WebPublicationManifest {
 </pre>
 
 						<section id="linkedResource">
-							<h6><code>LinkedResource</code> Definition</h6>
+							<h5><code>LinkedResource</code> Definition</h5>
 
 							<p id="publication-link-def">This specification defines a new type for links called
 										<code><dfn>LinkedResource</dfn></code>. It consists of the following
@@ -546,7 +961,7 @@ dictionary WebPublicationManifest {
 												<dfn>rel</dfn>
 											</code>
 										</td>
-										<td>The relationship of the resource to the Web Publication.</td>
+										<td>The relationship of the resource to the publication.</td>
 										<td>
 											<p>One or more relations. The values are either the relevant relationship
 												terms of the IANA link registry&#160;[[!iana-link-relations]], or
@@ -560,907 +975,201 @@ dictionary WebPublicationManifest {
 
 							<pre class="idl">
 dictionary LinkedResource {
-    required DOMString           url;
-             DOMString           encodingFormat;
-             sequence&lt;LocalizableString>   name;
-             LocalizableString   description;
-             sequence&lt;DOMString> rel;
+    DOMString           url;
+    DOMString           encodingFormat;
+    sequence&lt;LocalizableString>   name;
+    LocalizableString   description;
+    sequence&lt;DOMString> rel;
 };</pre>
 						</section>
 					</section>
-				</section>
 
-				<section id="manifest-pub-types">
-					<h4>Publication Types</h4>
+					<section id="manifest-relative-urls">
+						<h5>Relative URLs</h5>
 
-					<p>The Web Publication Manifest MUST include a <dfn>Publication Type</dfn> using the <code
-							data-dfn-for="WebPublicationManifest"><dfn>type</dfn></code> term&#160;[[!json-ld]]. The
-						type MAY be mapped onto <a href="https://schema.org/CreativeWork"
-						><code>CreativeWork</code></a>&#160;[[!schema.org]].</p>
+						<p><a href="https://url.spec.whatwg.org/#relative-url-string">Relative URL strings</a> MAY be
+							used in the manifest. These URLs are resolved to <a
+								href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL strings</a> using a
+								<a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a>&#160;[[!url]].</p>
 
-					<pre class="example" title="Setting a Web Publication's type to CreativeWork.">
-{
-    "@context" : ["https://schema.org", "https://www.w3.org/ns/wp-context"],
-    "type"     : "CreativeWork"
-    &#8230;
-}
-</pre>
+						<p>The base URL for relative URLs is determined as follows:</p>
 
-					<p>Schema.org also includes a number of more specific subtypes of <code>CreativeWork</code>, such as
-							<a href="https://schema.org/Article"><code>Article</code></a>, <a
-							href="https://schema.org/Book"><code>Book</code></a>, <a
-							href="https://schema.org/TechArticle"><code>TechArticle</code></a>, and <a
-							href="https://schema.org/Course"><code>Course</code></a>. These MAY be used instead of, or
-						in addition to, <code>CreativeWork</code>.</p>
-
-					<pre class="example" title="Setting a Web Publication's type to Book.">
-{
-    "@context" : ["https://schema.org", "https://www.w3.org/ns/wp-context"],
-    "type"     : "Book"
-    &#8230;
-}
-</pre>
-
-					<p>Each Schema.org type defines a set of properties that are valid for use with it. To ensure that
-						the manifest can be validated and processed by Schema.org aware processors, the manifest SHOULD
-						contain only the properties associated with the selected type.</p>
-
-					<p>If properties from more than one type are needed, the manifest MAY include multiple type
-						declarations.</p>
-
-					<pre class="example" title="A Web Publication that combines properties from both Book and VisualArtwork.">
-{
-    "@context" : ["https://schema.org", "https://www.w3.org/ns/wp-context"],
-    "type"     : ["Book", "VisualArtwork"],
-    &#8230;
-}
-</pre>
-
-					<p>User agents SHOULD NOT fail to process manifests that are not valid to their declared Schema.org
-						type(s).</p>
-
-					<p class="note">Refer to the Schema.org site for the complete <a
-							href="https://schema.org/CreativeWork">list of <code>CreativeWork</code> subtypes</a>.</p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
-    required sequence&lt;DOMString&gt; type;
-};</pre>
-				</section>
-
-				<section id="manifest-properties">
-					<h4>Properties</h4>
-
-					<p>The naming, syntax, and requirements for manifest properties are defined in <a
-							href="#wp-properties"></a>.</p>
-
-					<p class="note">Although authors only have to understand the serialization requirements for manifest
-						terms, they are encouraged to read through the full definitions for each property. The
-						definitions describe, in some cases, how items are compiled into the <a>Canonical Manifest</a>
-						in the absence of explicit information.</p>
-				</section>
-
-				<section id="manifest-relative-urls">
-					<h4>Relative URLs</h4>
-
-					<p>
-						<a href="https://url.spec.whatwg.org/#relative-url-string">Relative URL strings</a> MAY be used
-						in the manifest. These URLs are resolved to <a
-							href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL strings</a> using a <a
-							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a>&#160;[[!url]].</p>
-
-					<p>The base URL for relative URLs is determined as follows:</p>
-
-					<ul>
-						<li>In the case of an <a href="#manifest-embedding">embedded manifest</a>, the base URL is the
-								<a data-cite="!html#the-base-element">document base URL</a>&#160;[[!html]] of the
-								<a>primary entry page</a> of the Web Publication;</li>
-						<li>In the case of a <a href="#manifest-linking">linked manifest</a>, the base URL is URL of the
-							manifest resource.</li>
-					</ul>
-
-					<p>By consequence, relative URLs in embedded manifests are resolved against the URL of the primary
-						entry page <em>unless</em> the page declares a base direction (i.e., in a <a
-							data-cite="!html#the-base-element"><code>&lt;base&gt;</code> element</a> in its header).</p>
-
-					<p class="issue">The usage (or not) of the <code>&lt;base&gt;</code> element for embedded manifests
-						is currently the subject of several issues in the <a href="https://www.w3.org/2018/json-ld-wg/"
-							>JSON-LD Working Group</a>: <a href="https://github.com/w3c/json-ld-syntax/issues/22"
-							>JSON-LD #22</a>, <a href="https://github.com/w3c/json-ld-syntax/issues/57">JSON-LD #57</a>,
-						and, ultimately, <a href="https://github.com/w3ctag/design-reviews/issues/312">TAG #312</a>.</p>
-
-				</section>
-
-				<section id="manifest-embedding">
-					<h3>Embedding</h3>
-
-					<p>A manifest MAY be embedded only in the <a href="#wp-primary-entry-page">primary entry page</a>.
-						In this case, the manifest MUST be included in a <a
-							href="https://www.w3.org/TR/html5/semantics-scripting.html#the-script-element"
-								><code>script</code> element</a>&#160;[[!html]] whose <code>type</code> attribute is set
-						to <code>application/ld+json</code>.</p>
-
-					<p>Additionally, the <code>script</code> element MUST include a unique identifier in an
-							<code>id</code> attribute&#160;[[!html]]. This identifier ensures that the manifest <a
-							href="#manifest-linking">can be referenced</a>.</p>
-
-					<pre class="example" title="A Web Publication Manifest included in an HTML document">
-&lt;script id="example_manifest" type="application/ld+json"&gt;
-   {
-      &#8230;
-   }
-&lt;/script&gt;
-</pre>
-				</section>
-
-				<section id="manifest-linking">
-					<h2>Linking To a Manifest</h2>
-
-					<p>With the exception of the <a>primary entry page</a>, linking a resource to its Web Publication
-						manifest is OPTIONAL. Including a link is encouraged whenever possible, however, as it allows
-						user agents to immediately ascertain that a resource belongs to a Web Publication regardless of
-						how the user reaches the resource.</p>
-
-					<p>Links to a Web Publication manifest MUST take one or both of the following forms:</p>
-
-					<ul>
-						<li>
-							<p>An HTTP <code>Link</code> header field&#160;[[!rfc5988]] with its <code>rel</code>
-								parameter set to the value "<code>publication</code>".</p>
-							<pre class="example">Link: &lt;https://example.com/webpub/manifest>; rel=publication</pre>
-						</li>
-						<li>
-							<p>A <code>link</code> element&#160;[[!html]] with its <code>rel</code> attribute set to the
-								value "<code>publication</code>".</p>
-							<pre class="example">&lt;link href="https://example.com/webpub/manifest" rel="publication"/></pre>
-						</li>
-					</ul>
-
-					<p>When a manifest is embedded within an HTML document, the link MUST include a fragment identifier
-						that references the <code>script</code> element that contains the manifest (see <a
-							href="#manifest-embedding"></a>).</p>
-
-					<pre class="example" title="Link to a manifest within the same HTML resource">
-	&lt;link href="#example_manifest" rel="publication"&gt;
-	&#8230;
-	&lt;script id="example_manifest" type="application/ld+json"&gt;
-	{
-        "@context" : ["https://schema.org", "https://www.w3.org/ns/wp-context"],
-        &#8230;
-	}
-	&lt;/script&gt;
-</pre>
-
-					<p class="issue" data-number="132">The exact value of <code>rel</code> is still to be agreed upon
-						and should be registered by IANA.</p>
-
-					<p class="ednote">The following details might be moved to the lifecycle section in a future
-						draft.</p>
-
-					<p>When a resource links to multiple manifests, a user agent MAY choose to present one or more
-						alternatives to the end user, or choose a single alternative on its own. The user agent MAY
-						choose to present any manifest based upon information that it possesses, even one that is not
-						explicitly listed as a parent (e.g., based upon information it calculates or acquires out of
-						band). In the absence of a preference by user agent implementers, selection of the first
-						manifest listed is suggested as a default.</p>
-
-				</section>
-			</section>
-
-			<section id="wp-bounds">
-				<h2>Web Publication Bounds</h2>
-
-				<p>A Web Publication consists of a finite set of <a href="#wp-resources">resources</a> that represent
-					its content. This extent is known as its bounds and is defined within its manifest &#8212; it is
-					obtained from the union of resources listed in the <a href="#default-reading-order">default reading
-						order</a> and <a href="#resource-list">resource list</a>.</p>
-
-				<p>To determine whether a resource is within the bounds of a Web Publication, user agents MUST compare
-					the absolute URL of a resource to the absolute URLs of the resources obtained from the union. If the
-					resource is identified in the enumeration, it is within the bounds of the Web Publication. All other
-					resources are external to the Web Publication.</p>
-
-				<p>Resources within the bounds of a Web Publication do not have to share the same domain.</p>
-			</section>
-
-			<section id="wp-resources">
-				<h2>Resources</h2>
-
-				<p>A <a>Web Publication</a> MUST include at least one HTML document&#160;[[!html]]&#8212;the <a>primary
-						entry page</a>.</p>
-
-				<p>There are no restrictions on a Web Publication beyond this requirement. The Web Publication MAY
-					include references to resources of any media type, both in the <a>default reading order</a> and as
-					dependencies of other resources.</p>
-
-				<p class="note">When adding resources to a Web Publication, consider support in user agents. The use of
-					progressive enhancement techniques and the provision of fallback content, as appropriate, will
-					ensure a more consistent reading experience for users regardless of their preferred user agent.</p>
-			</section>
-
-			<section id="wp-primary-entry-page">
-				<h3>Primary Entry Page</h3>
-
-				<p>The <dfn>primary entry page</dfn> represents the preferred starting <a href="#wp-resources"
-						>resource</a> for a Web Publication and enables discovery of its <a>manifest</a>. It is the
-					resource that is returned when accessing the Web Publication's <a>address</a>, and MUST be included
-					in either the <a>default reading order</a> or the <a>resource list</a>.</p>
-
-				<p>Although any resource can link to the Web Publication manifest, the primary entry page typically
-					introduces the publication and provides access to the content. It might contain all the content, in
-					the case of a single-page Web Publication, or provide navigational aids to begin reading a
-					multi-document Web Publication. To facilitate the user ease of consumption, the primary entry page
-					SHOULD contain the <a href="#wp-table-of-contents">table of contents</a>.</p>
-
-				<p>It is not required that the primary entry page be included in the <a href="#default-reading-order"
-						>default reading order</a>, nor that it be the first document listed when it is included. This
-					specification leaves the exact nature of the document intentionally underspecified to provide
-					flexibility for different approaches. If a default reading order is not provided, however, user
-					agents will <a href="#no-reading-order">create one using the primary entry page</a>.</p>
-
-				<p>The primary entry page is the only resource in which <a href="#manifest-embedding">a manifest can be
-						embedded</a>. To ensure discovery of the manifest, the primary entry page MUST provide a <a
-						href="#manifest-linking">link to the manifest</a>, regardless of whether the manifest is
-					embedded within the page or external to it.</p>
-
-				<p>The address of the primary entry page is also the <a>canonical identifier</a> for the Web Publication
-					(i.e., it serves as the unique identifier for the Web Publication).</p>
-
-				<p>In certain cases where information has been omitted from the manifest, user agents will sometimes use
-					the primary entry page as a fallback source of information (see <a href="#language-and-dir">language
-						and base direction</a> and <a href="#title">title</a>).</p>
-			</section>
-
-			<section id="wp-table-of-contents">
-				<h3>Table of Contents</h3>
-
-				<p>The table of contents provides a hierarchical list of links that reflects the structural outline of
-					the major sections of the Web Publication.</p>
-
-				<p>The table of contents is expressed via an [[!html]]&#160;element (typically a <a
-						href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code> element</a>) in
-					one of the <a href="#wp-resources">resources</a>. This element MUST be identified by the
-						<code>role</code> attribute&#160;[[!html]] value "<code>doc-toc</code>"&#160;[[!dpub-aria-1.0]],
-					and MUST be the first element in the document &#8212; in <a
-						href="https://dom.spec.whatwg.org/#concept-tree-order">document tree order</a>&#160;[[!dom]]
-					&#8212; with that <code>role</code> value.</p>
-
-				<p>If the table of contents is not located in the <a href="#wp-primary-entry-page">primary entry
-						page</a>, the manifest SHOULD <a href="#table-of-contents">identify the resource</a> that
-					contains the structure.</p>
-
-				<p> When specified, the table of content MUST include a link to at least one <a href="#wp-resources"
-						>resource</a>, and all links SHOULD refer to <a href="#wp-resources">resources</a> within <a
-						href="#wp-bounds">publication bounds</a>. </p>
-
-				<p>Refer to the <a href="#table-of-contents">table of contents property definition</a> for more
-					information on how to identify which resource contains the table of contents.</p>
-
-			</section>
-
-			<section id="wp-pagelist">
-				<h3>Page List</h3>
-
-				<p>The page list is a list of links that provides navigation to static page demarcation points within
-					the content. These locations allow users to coordinate access into the content, for example. The
-					exact nature of these locations is left to content creators to define. They usually correspond to
-					pages of a print document which is the source of the digital publication, but might be a purely
-					digital creation added to ease navigation.</p>
-
-				<p>The page list is expressed via an [[!html]] element (typically a <a
-						href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code> element</a>) in
-					one of the <a href="#wp-resources">resources</a>. This element MUST be identified by the
-						<code>role</code> attribute&#160;[[!html]] value
-					"<code>doc-pagelist</code>"&#160;[[!dpub-aria-1.0]], and MUST be the first element in the document
-					&#8212; in <a href="https://dom.spec.whatwg.org/#concept-tree-order">document tree
-					order</a>&#160;[[!dom]] &#8212; with that <code>role</code> value.</p>
-
-				<p>If the page list is not located in the <a href="#wp-primary-entry-page">primary entry page</a>, the
-					manifest SHOULD <a href="#page-list">identify the resource</a> that contains the structure.</p>
-
-				<p>There are no requirements on the page list itself, except that, when specified, it MUST include a
-					link to at least one <a href="#wp-resources">resource</a>.</p>
-
-				<p>Refer to the <a href="#page-list"><code>pagelist</code> property definition</a> for more information
-					on how to identify which resource contains the page list.</p>
-			</section>
-		</section>
-		<section id="wp-properties">
-			<h2>Web Publication Properties</h2>
-
-			<section id="properties-intro" class="informative">
-				<h3>Introduction</h3>
-
-				<p>The Web Publication manifest is defined by a set of properties that describe the basic information a
-					user agent requires to process and render a Web Publication. These properties are categorized as
-					followed:</p>
-
-				<dl>
-					<dt>
-						<a href="#descriptive-properties">descriptive properties</a>
-					</dt>
-					<dd>
-						<p>Descriptive properties describe aspects of a Web Publication, such as its <a href="#wp-title"
-								>title</a>, <a href="#creators">creator</a>, and <a href="#language-and-dir"
-								>language</a>. These properties are primarily drawn from <a href="https://schema.org"
-								>Schema.org</a> and its <a href="https://schema.org/docs/schemas.html">hosted
-								extensions</a>&#160;[[schema.org]], so they map to one or several Schema.org properties
-							and inherit their syntax and semantics. (The following property categories typically do not
-							have Schema.org equivalents, so are defined specifically for Web Publications.)</p>
-					</dd>
-					<dt>
-						<a href="#resource-categorization-properties">resource categorization</a>
-					</dt>
-					<dd>
-						<p>Resource categorization properties describe or identify common sets of resources, such as the
-								<a href="#resource-list">resource list</a> and <a href="#default-reading-order">default
-								reading order</a>. These properties refer to one or more resources, such as HTML
-							documents, images, script files, and separate metadata files.</p>
-					</dd>
-					<dt>
-						<a href="#informative-properties">informative properties</a>
-					</dt>
-					<dd>
-						<p>Informative properties identify resources that contain additional information about the Web
-							Publication, such as its <a href="#privacy-policy">privacy policy</a> or <a
-								href="#accessibility-report">accessibility report</a>.</p>
-					</dd>
-					<dt>
-						<a href="#structural-properties">structural properties</a>
-					</dt>
-					<dd>
-						<p>Structural properties identify key meta structures of the Web Publication, such as the <a
-								href="#cover">cover image</a>, <a href="#table-of-contents">table of contents</a>, and
-								<a href="#page-list">page list</a>.</p>
-					</dd>
-				</dl>
-
-				<p class="note">The categorization of properties is done to simplify comprehension of their purpose; the
-					groupings have no relevance outside this specification (i.e., the groupings do not exist in the
-					manifest).</p>
-
-				<div class="note">
-					<p>Each manifest item drawn from schema.org identifies the property it maps to and includes its
-						defining type in parentheses. Properties are often available in many types, however, as a result
-						of the schema.org inheritance model. Refer to each property definition for more detailed
-						information about where it is valid to use.</p>
-
-					<p>Schema.org additionally includes a large number of properties that, though relevant for
-						publishing, are not mentioned in this specification &#8212; Web Publication authors can use any
-						of these properties. This document defines only the minimal set of manifest items.</p>
-				</div>
-
-				<p class="ednote">There are discussion on whether a best practices document would be created, referring
-					to more schema.org terms. If so, it should be linked from here.</p>
-			</section>
-
-			<section id="wp-properties-req">
-				<h3>Requirements</h3>
-
-				<p>The requirements for the expression of Web Publication properties are defined as follows:</p>
-
-				<dl>
-					<dt>REQUIRED:</dt>
-					<dd>
 						<ul>
-							<li>
-								<a href="#address">address</a>
-							</li>
-							<li>
-								<a href="#default-reading-order">default reading order</a>
-							</li>
-							<li>
-								<a href="#wp-title">title</a>
-							</li>
+							<li>In the case of an <a href="#manifest-embedding">embedded manifest</a>, the base URL is
+								the <a data-cite="!html#the-base-element">document base URL</a>&#160;[[!html]] of the
+									<a>primary entry page</a> of the publication;</li>
+							<li>In the case of a <a href="#manifest-linking">linked manifest</a>, the base URL is URL of
+								the manifest resource.</li>
 						</ul>
-					</dd>
-					<dt>RECOMMENDED:</dt>
-					<dd>
-						<ul>
-							<li>
-								<a href="#accessibility">accessibility</a>
-							</li>
-							<li>
-								<a href="#accessibility-report">accessibility report</a>
-							</li>
-							<li>
-								<a href="#language-and-dir">base direction</a>
-							</li>
-							<li>
-								<a href="#canonical-identifier">canonical identifier</a>
-							</li>
-							<li>
-								<a href="#cover">cover</a>
-							</li>
-							<li>
-								<a href="#creators">creators</a>
-							</li>
-							<li>
-								<a href="#language-and-dir">language and base direction</a>
-							</li>
-							<li>
-								<a href="#links">links</a>
-							</li>
-							<li>
-								<a href="#last-modification-date">last modification date</a>
-							</li>
-							<li>
-								<a href="#publication-date">publication date</a>
-							</li>
-							<li>
-								<a href="#privacy-policy">privacy policy</a>
-							</li>
-							<li>
-								<a href="#reading-progression-direction">reading progression direction</a>
-							</li>
-							<li>
-								<a href="#resource-list">resource list</a>
-							</li>
-							<li>
-								<a href="#table-of-contents">table of contents</a>
-							</li>
-							<li>
-								<a href="#page-list">page list</a>
-							</li>
-						</ul>
-					</dd>
-				</dl>
 
-				<p>These properties do not all have to be serialized in the <a>authored manifest</a>. Refer to each
-					property's definition to determine whether it is required in the manifest or can be compiled into
-					the <a>canonical manifest</a> from other information.</p>
-			</section>
+						<p>By consequence, relative URLs in embedded manifests are resolved against the URL of the
+							primary entry page <em>unless</em> the page declares a base direction (i.e., in a <a
+								data-cite="!html#the-base-element"><code>&lt;base&gt;</code> element</a> in its
+							header).</p>
 
-			<section id="wp-properties-mapping" class="informative">
-				<h3>Quick Reference</h3>
+						<p class="issue">The usage (or not) of the <code>&lt;base&gt;</code> element for embedded
+							manifests is currently the subject of several issues in the <a
+								href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a>: <a
+								href="https://github.com/w3c/json-ld-syntax/issues/22">JSON-LD #22</a>, <a
+								href="https://github.com/w3c/json-ld-syntax/issues/57">JSON-LD #57</a>, and, ultimately,
+								<a href="https://github.com/w3ctag/design-reviews/issues/312">TAG #312</a>.</p>
 
-				<p>The way that properties are expressed in the manifest often differs from how they are referred to
-					using natural language. The following table provides a mapping between property names and the
-					sections where they are explained to help clarify the differing nomenclature:</p>
+					</section>
+				</section>
 
-				<table class="zebra">
-					<thead>
-						<tr>
-							<th>Property Name</th>
-							<th>Defined In</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>
-								<code>accessMode</code>
-							</td>
-							<td>
-								<a href="#accessibility">Accessibility</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>accessModeSufficient</code>
-							</td>
-							<td>
-								<a href="#accessibility">Accessibility</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>accessibilityAPI</code>
-							</td>
-							<td>
-								<a href="#accessibility">Accessibility</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>accessibilityControl</code>
-							</td>
-							<td>
-								<a href="#accessibility">Accessibility</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>accessibilityFeature</code>
-							</td>
-							<td>
-								<a href="#accessibility">Accessibility</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>accessibilityHazard</code>
-							</td>
-							<td>
-								<a href="#accessibility">Accessibility</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>accessibilitySummary</code>
-							</td>
-							<td>
-								<a href="#accessibility">Accessibility</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>artist</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>author</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>contents</code>
-							</td>
-							<td>
-								<a href="#table-of-contents">Table of Contents</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>contributor</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>creator</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>dateModified</code>
-							</td>
-							<td>
-								<a href="#last-modification-date">Last Modification Date</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>datePublished</code>
-							</td>
-							<td>
-								<a href="#publication-date">Publication Date</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>editor</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>https://www.w3.org/ns/wp#accessibility-report</code>
-							</td>
-							<td>
-								<a href="#accessibility-report">Accessibility Report</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>https://www.w3.org/ns/wp#cover</code>
-							</td>
-							<td>
-								<a href="#cover">Cover</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>https://www.w3.org/ns/wp#pagelist</code>
-							</td>
-							<td>
-								<a href="#page-list">Pagelist</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>id</code>
-							</td>
-							<td>
-								<a href="#canonical-identifier">Canonical Identifier</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>illustrator</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>inDirection</code>
-							</td>
-							<td>
-								<a href="#language-and-dir">Direction</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>inker</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>inLanguage</code>
-							</td>
-							<td>
-								<a href="#language-and-dir">Language</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>letterer</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>link</code>
-							</td>
-							<td>
-								<a href="#links">Links</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>name</code>
-							</td>
-							<td>
-								<a href="#wp-title">Title</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>penciler</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>privacy-policy</code>
-							</td>
-							<td>
-								<a href="#privacy-policy">Privacy Policy</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>publisher</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>readBy</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>readingOrder</code>
-							</td>
-							<td>
-								<a href="#default-reading-order">Default Reading Order</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>readingProgression</code>
-							</td>
-							<td>
-								<a href="#reading-progression-direction">Reading Progression Direction</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>resources</code>
-							</td>
-							<td>
-								<a href="#resource-list">Resource List</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>translator</code>
-							</td>
-							<td>
-								<a href="#creators">Creators</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>url</code>
-							</td>
-							<td>
-								<a href="#address">Address</a>
-							</td>
-						</tr>
-					</tbody>
-				</table>
-			</section>
+				<section id="descriptive-properties">
+					<h4>Descriptive Properties</h4>
 
-			<section id="descriptive-properties">
-				<h3>Descriptive Properties</h3>
+					<section id="accessibility">
+						<h5>Accessibility</h5>
 
-				<section id="accessibility">
-					<h4>Accessibility</h4>
+						<p>The accessibility properties provides information about the suitability of a <a>digital
+								publication</a> for consumption by users with varying preferred reading modalities.
+							These properties typically supplement an evaluation against established accessibility
+							criteria, such as those provided in [[WCAG20]]. (For linking to a detailed accessibility
+							report, see <a href="#accessibility-report"></a>.)</p>
 
-					<p>The accessibility properties provides information about the suitability of a <a>Web
-							Publication</a> for consumption by users with varying preferred reading modalities. These
-						properties typically supplement an evaluation against established accessibility criteria, such
-						as those provided in [[WCAG20]]. (For linking to a detailed accessibility report, see <a
-							href="#accessibility-report"></a>.)</p>
+						<p>The following properties are categorized as accessibility properties:</p>
 
-					<p>The following properties are categorized as accessibility properties:</p>
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th>Term</th>
+									<th>Description</th>
+									<th>Required Value</th>
+									<th>[[!schema.org]] Mapping</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>accessMode</dfn>
+										</code>
+									</td>
+									<td> The human sensory perceptual system or cognitive faculty through which a person
+										may process or perceive information. </td>
+									<td> One or more text(s). <a
+											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
+											>Expected values</a>. </td>
+									<td>
+										<a href="https://schema.org/accessMode"><code>accessMode</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>accessModeSufficient</dfn>
+										</code>
+									</td>
+									<td> A list of single or combined accessModes that are sufficient to understand all
+										the intellectual content of a resource. </td>
+									<td> One or more <a href="https://schema.org/ItemList">ItemList</a>. <a
+											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
+											>Expected values</a>. </td>
+									<td>
+										<a href="https://schema.org/accessModeSufficient"
+												><code>accessModeSufficient</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>accessibilityAPI</dfn>
+										</code>
+									</td>
+									<td>Indicates that the resource is compatible with the referenced accessibility
+										APIs. </td>
+									<td>One or more text(s).<a
+											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
+											>Expected values</a>. </td>
+									<td>
+										<a href="https://schema.org/accessibilityAPI"><code>accessibilityAPI</code></a>
+											(<a href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>accessibilityControl</dfn>
+										</code>
+									</td>
+									<td>Identifies input methods that are sufficient to fully control the described
+										resource. </td>
+									<td> One or more text(s). <a
+											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
+											>Expected values</a>. </td>
+									<td>
+										<a href="https://schema.org/accessibilityControl"
+												><code>accessibilityControl</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>accessibilityFeature</dfn>
+										</code>
+									</td>
+									<td> Content features of the resource, such as accessible media, alternatives and
+										supported enhancements for accessibility. </td>
+									<td> One or more text(s). <a
+											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
+											>Expected values</a>. </td>
+									<td>
+										<a href="https://schema.org/accessibilityFeature"
+												><code>accessibilityFeature</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>accessibilityHazard</dfn>
+										</code>
+									</td>
+									<td> A characteristic of the described resource that is physiologically dangerous to
+										some users. </td>
+									<td> One or more text(s).<a
+											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
+											>Expected values</a>. </td>
+									<td>
+										<a href="https://schema.org/accessibilityHazard"
+												><code>accessibilityHazard</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>accessibilitySummary</dfn>
+										</code>
+									</td>
+									<td>A human-readable summary of specific accessibility features or deficiencies,
+										consistent with the other accessibility metadata but expressing subtleties such
+										as “short descriptions are present but long descriptions will be needed for
+										non-visual users” or “short descriptions are present and no long descriptions
+										are needed.” </td>
+									<td>Text.</td>
+									<td>
+										<a href="https://schema.org/accessibilitySummary"
+												><code>accessibilitySummary</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+							</tbody>
+						</table>
 
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th>Term</th>
-								<th>Description</th>
-								<th>Required Value</th>
-								<th>[[!schema.org]] Mapping</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>accessMode</dfn>
-									</code>
-								</td>
-								<td> The human sensory perceptual system or cognitive faculty through which a person may
-									process or perceive information. </td>
-								<td> One or more text(s). <a
-										href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-										>Expected values</a>. </td>
-								<td>
-									<a href="https://schema.org/accessMode"><code>accessMode</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>accessModeSufficient</dfn>
-									</code>
-								</td>
-								<td> A list of single or combined accessModes that are sufficient to understand all the
-									intellectual content of a resource. </td>
-								<td> One or more <a href="https://schema.org/ItemList">ItemList</a>. <a
-										href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-										>Expected values</a>. </td>
-								<td>
-									<a href="https://schema.org/accessModeSufficient"
-										><code>accessModeSufficient</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>accessibilityAPI</dfn>
-									</code>
-								</td>
-								<td>Indicates that the resource is compatible with the referenced accessibility APIs. </td>
-								<td>One or more text(s).<a
-										href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-										>Expected values</a>. </td>
-								<td>
-									<a href="https://schema.org/accessibilityAPI"><code>accessibilityAPI</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>accessibilityControl</dfn>
-									</code>
-								</td>
-								<td>Identifies input methods that are sufficient to fully control the described
-									resource. </td>
-								<td> One or more text(s). <a
-										href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-										>Expected values</a>. </td>
-								<td>
-									<a href="https://schema.org/accessibilityControl"
-										><code>accessibilityControl</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>accessibilityFeature</dfn>
-									</code>
-								</td>
-								<td> Content features of the resource, such as accessible media, alternatives and
-									supported enhancements for accessibility. </td>
-								<td> One or more text(s). <a
-										href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-										>Expected values</a>. </td>
-								<td>
-									<a href="https://schema.org/accessibilityFeature"
-										><code>accessibilityFeature</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>accessibilityHazard</dfn>
-									</code>
-								</td>
-								<td> A characteristic of the described resource that is physiologically dangerous to
-									some users. </td>
-								<td> One or more text(s).<a
-										href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-										>Expected values</a>. </td>
-								<td>
-									<a href="https://schema.org/accessibilityHazard"
-										><code>accessibilityHazard</code></a> (<a href="https://schema.org/CreativeWork"
-										>CreativeWork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>accessibilitySummary</dfn>
-									</code>
-								</td>
-								<td>A human-readable summary of specific accessibility features or deficiencies,
-									consistent with the other accessibility metadata but expressing subtleties such as
-									“short descriptions are present but long descriptions will be needed for non-visual
-									users” or “short descriptions are present and no long descriptions are needed.” </td>
-								<td>Text.</td>
-								<td>
-									<a href="https://schema.org/accessibilitySummary"
-										><code>accessibilitySummary</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-						</tbody>
-					</table>
+						<p>Detailed descriptions of these properties are available on the <a
+								href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas Wiki site</a>.</p>
 
-					<p>Detailed descriptions of these properties are available on the <a
-							href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas Wiki site</a>.</p>
+						<p>Values SHOULD be drawn from the <a
+								href="https://www.w3.org/wiki/WebSchemas/Accessibility#property-table">preferred
+								vocabulary</a> for each accessibility property, but user agents MUST NOT omit values
+							from that are not included in the lists when <a href="#canonical-manifest">generating the
+								canonical manifest</a>.</p>
 
-					<p>Values SHOULD be drawn from the <a
-							href="https://www.w3.org/wiki/WebSchemas/Accessibility#property-table">preferred
-							vocabulary</a> for each accessibility property, but user agents MUST NOT omit values from
-						that are not included in the lists when <a href="#canonical-manifest">generating the canonical
-							manifest</a>.</p>
+						<p class="note">The author can also provide a reference to a detailed <a
+								href="#accessibility-report">Accessibility Report</a> if more information is needed than
+							can be expressed by these properties.</p>
 
-					<p class="note">The author can also provide a reference to a detailed <a
-							href="#accessibility-report">Accessibility Report</a> if more information is needed than can
-						be expressed by these properties.</p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
+						<pre class="idl">
+partial dictionary PublicationManifest {
     sequence&lt;DOMString> accessMode;
     sequence&lt;DOMString> accessModeSufficient;
     sequence&lt;DOMString> accessibilityAPI;
@@ -1470,7 +1179,7 @@ partial dictionary WebPublicationManifest {
     LocalizableString      accessibilitySummary;
 };</pre>
 
-					<pre class="example" title="Example accessiblity metadata for a document with text and images. The publication provides alternative text and long descriptions appropriate for each image, so can also be read in purely textual form.">
+						<pre class="example" title="Example accessiblity metadata for a document with text and images. The publication provides alternative text and long descriptions appropriate for each image, so can also be read in purely textual form.">
 {
     "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"     : "CreativeWork",
@@ -1491,390 +1200,244 @@ partial dictionary WebPublicationManifest {
 }
 </pre>
 
-				</section>
+					</section>
 
-				<section id="address">
-					<h4>Address</h4>
+					<section id="creators">
+						<h5>Creators</h5>
 
-					<p>A <a>Web Publication's</a>
-						<dfn>address</dfn> is a <abbr title="Uniform Resource Locator">URL</abbr>&#160;[[!url]] that
-						represents the <a>primary entry page</a> for the Web Publication. It is expressed using the
-							<code>url</code> property.</p>
+						<p>A <dfn>creator</dfn> is an individual or entity responsible for the creation of the
+								<a>digital publication</a>.</p>
 
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th>Term</th>
-								<th>Description</th>
-								<th>Required Value</th>
-								<th>[[!schema.org]] Mapping</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>url</dfn>
-									</code>
-								</td>
-								<td>URL of the primary entry page.</td>
-								<td>A URL [[!url]].</td>
-								<td>
-									<a href="https://schema.org/url"><code>url</code></a> (<a
-										href="https://schema.org/Thing">Thing</a>) </td>
-							</tr>
-						</tbody>
-					</table>
+						<p>The following properties are categorized as creators:</p>
 
-					<p>If the address does not resolve to an <abbr title="Hypertext Markup Language">HTML</abbr>
-						document&#160;[[!html]], user agents SHOULD NOT provide access to the resource to users. A Web
-						Publication MAY have more than one address, but all the addresses MUST resolve to the same
-						document.</p>
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th>Term</th>
+									<th>Description</th>
+									<th>Required Value</th>
+									<th>[[!schema.org]] Mapping</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>artist</dfn>
+										</code>
+									</td>
+									<td>The primary artist for the publication, in a medium other than pencils or
+										digital line art.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>
+										<a href="https://bib.schema.org/artist"><code>artist</code></a> (<a
+											href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>author</dfn>
+										</code>
+									</td>
+									<td>The author of the publication.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
+											<a href="https://schema.org/Organization"
+										><code>Organization</code></a>.</td>
+									<td>
+										<a href="https://schema.org/author"><code>author</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>colorist</dfn>
+										</code>
+									</td>
+									<td>The individual who adds color to inked drawings.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>
+										<a href="https://bib.schema.org/colorist"><code>colorist</code></a> (<a
+											href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>contributor</dfn>
+										</code>
+									</td>
+									<td>Contributor whose role does not fit to one of the other roles in this
+										table.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
+											<a href="https://schema.org/Organization"
+										><code>Organization</code></a>.</td>
+									<td>
+										<a href="https://schema.org/contributor"><code>contributor</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>creator</dfn>
+										</code>
+									</td>
+									<td>The creator of the publication.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
+											<a href="https://schema.org/Organization"
+										><code>Organization</code></a>.</td>
+									<td>
+										<a href="https://schema.org/creator"><code>creator</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>editor</dfn>
+										</code>
+									</td>
+									<td>The editor of the publication.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>
+										<a href="https://schema.org/editor"><code>editor</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>illustrator</dfn>
+										</code>
+									</td>
+									<td>The illustrator of the publication.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>
+										<a href="https://schema.org/illustrator"><code>illustrator</code></a> (<a
+											href="https://schema.org/Book">Book</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>inker</dfn>
+										</code>
+									</td>
+									<td>The individual who traces over the pencil drawings in ink.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>
+										<a href="https://bib.schema.org/inker"><code>inker</code></a> (<a
+											href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>letterer</dfn>
+										</code>
+									</td>
+									<td>The individual who adds lettering, including speech balloons and sound effects,
+										to artwork.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>
+										<a href="https://bib.schema.org/letterer"><code>letterer</code></a> (<a
+											href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>penciler</dfn>
+										</code>
+									</td>
+									<td>The individual who draws the primary narrative artwork.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
+									<td>
+										<a href="https://bib.schema.org/penciler"><code>penciler</code></a> (<a
+											href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>publisher</dfn>
+										</code>
+									</td>
+									<td>The publisher of the publication.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
+											<a href="https://schema.org/Organization"
+										><code>Organization</code></a>.</td>
+									<td>
+										<a href="https://schema.org/publisher"><code>publisher</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>readBy</dfn>
+										</code>
+									</td>
+									<td>A person who reads (performs) the publication (for audiobooks).</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>. </td>
+									<td>
+										<a href="https://bib.schema.org/readBy"><code>readBy</code></a> (<a
+											href="https://bib.schema.org/Audiobook">Audiobook</a>) </td>
+								</tr>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>translator</dfn>
+										</code>
+									</td>
+									<td>The translator of the publication.</td>
+									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
+											<a href="https://schema.org/Organization"><code>Organization</code></a>. </td>
+									<td>
+										<a href="https://schema.org/translator"><code>translator</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+							</tbody>
+						</table>
 
-					<p>The referenced document SHOULD be a resource of the Web Publication. It can be any resource,
-						including one that is not listed in the <a>default reading order</a>. This document MUST include
-						a <a href="#manifest-linking">link to the manifest</a> to ensure a bidirectional linking
-						relationship (i.e., that user agents can also locate the manifest from the document at the
-						address).</p>
+						<p>Creators are represented in one of the following two ways:</p>
 
-					<p>If the document is not a Web Publication resource, user agents SHOULD load the first document in
-						the <a>default reading order</a> when initiating the Web Publication.</p>
+						<ol>
+							<li>as a string encoding the name of a <a href="https://schema.org/Person"
+										><code>Person</code></a> [[!schema.org]]; or</li>
+							<li>as an instance of a <a href="https://schema.org/Person"><code>Person</code></a> or <a
+									href="https://schema.org/Organization"><code>Organization</code></a>
+								[[!schema.org]].</li>
+						</ol>
 
-					<p class="note"> To improve the usability of Web Publications, particularly in user agents that do
-						not support Web Publications, authors are encouraged to include navigation aids in the
-						referenced document that facilitate consumption of the content, (e.g., provide a table of
-						contents or a link to one).</p>
+						<p>In other words, a single string value is a shorthand for a [[!schema.org]]
+								<code>Person</code> whose <code>name</code> property is set to that string value. (See
+							also <a href="#strings-vs-objects"></a>.)</p>
 
-					<div class="note">The Web Publication's address can also be used as value for an identifier link
-						relation&#160;[[link-relation]].</div>
+						<p>When compiling each set of <dfn data-lt="CreatorInfo">creator information</dfn> from a
+							[[!schema.org]] <a href="https://schema.org/Person"><code>Person</code></a> or <a
+								href="https://schema.org/Organization"><code>Organization</code></a> type, user agents
+							MUST retain the following information when available:</p>
 
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
-    required DOMString url;
-};</pre>
+						<dl data-dfn-for="CreatorInfo">
+							<dt>
+								<dfn>type</dfn>
+							</dt>
+							<dd>One or more strings that identifies the type of creator. This sequence SHOULD include
+								"Person" or "Organization".</dd>
+							<dt>
+								<dfn>name</dfn>
+							</dt>
+							<dd>One or more localizable strings for the name of the creator.</dd>
+							<dt>
+								<dfn>id</dfn>
+							</dt>
+							<dd>A canonical identifier of the creator as a URL.&#160;[[!url]]</dd>
 
-					<pre class="example" title="Setting the address of the main entry page">
-{
-    "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
-    "type"     : "Book",
-    &#8230;
-    "url"      : "https://publisher.example.org/mobydick",
-    &#8230;
-}
-</pre>
-				</section>
+							<dt>
+								<dfn>url</dfn>
+							</dt>
+							<dd>An address for the creator in the form of a URL.&#160;[[!url]]</dd>
+						</dl>
 
-				<section id="canonical-identifier">
-					<h4>Canonical Identifier</h4>
+						<p>Note that user agents MAY interpret a wider range of creator properties defined by Schema.org
+							than the ones in the preceding list.</p>
 
-					<p>A <a>Web Publication's</a>
-						<dfn>canonical identifier</dfn> is a unique identifier that resolves to the preferred version of
-						the Web Publication. It is expressed using the <code>id</code> property.</p>
+						<p>The manifest MAY include more than one of each type of creator.</p>
 
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th>Term</th>
-								<th>Description</th>
-								<th>Required Value</th>
-								<th>[[!schema.org]] Mapping</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>id</dfn>
-									</code>
-								</td>
-								<td>Preferred version of the Web Publication.</td>
-								<td>A URL [[!url]].</td>
-								<td>(None)</td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p class="note">Ensuring uniqueness of canonical identifiers is outside the scope of this
-						specification. The actual achievable uniqueness depends on such factors as the conventions of
-						the identifier scheme used and the degree of control over assignment of identifiers.</p>
-
-					<p>The canonical identifier is intended to provide a measure of permanence above and beyond the Web
-						Publication's <a href="#address">address(es)</a>. If a Web Publication is permanently relocated
-						to a new URL, for example, the canonical identifier provides a way of discovering the new
-						location (e.g., a <abbr title="Digital Object Identifier">DOI</abbr> registry could be updated
-						with the new <abbr title="Uniform Resource Locator">URL</abbr>, or a redirect could be added to
-						the <abbr title="Uniform Resource Locator">URL</abbr> of the canonical identifier). It is also
-						intended to provide a means of identifying instances of the same Web Publication hosted at
-						different URLs.</p>
-
-					<p>If a URL is not provided in the manifest, or the value is an invalid URL, the Web Publication
-						does not have a canonical identifier. User agents MUST NOT attempt to construct a canonical
-						identifier from any other identifiers provided in the manifest for the canonical manifest.</p>
-
-					<p>The specification of the canonical identifier MAY be complemented by the inclusion of additional
-						types of identifiers for the Web Publication using the <a href="https://schema.org/identifier"
-								><code>identifier</code> property</a>&#160;[[!schema.org]] and/or its subtypes.</p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
-    DOMString id;
-};</pre>
-
-					<pre class="example" title="Example for setting both the canonical identifier as URL and the address of the same document">
-{
-    "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
-    "type"     : "TechArticle",
-    &#8230;
-    "id"       : "http://www.w3.org/TR/tabular-data-model/",
-    "url"      : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
-    &#8230;
-}
-</pre>
-
-					<pre class="example" title="Example for setting both the ISBN and the address of the same document">
-{
-    "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
-    "type"     : "Book",
-    &#8230;
-    "isbn"     : "9780123456789",
-    "url"      : "https://publisher.example.org/mobydick",
-    &#8230;
-}
-</pre>
-
-				</section>
-
-				<section id="creators">
-					<h4>Creators</h4>
-
-					<p>A <dfn>creator</dfn> is an individual or entity responsible for the creation of the <a>Web
-							Publication</a>.</p>
-
-					<p>The following properties are categorized as creators:</p>
-
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th>Term</th>
-								<th>Description</th>
-								<th>Required Value</th>
-								<th>[[!schema.org]] Mapping</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>artist</dfn>
-									</code>
-								</td>
-								<td>The primary artist for the publication, in a medium other than pencils or digital
-									line art.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
-								<td>
-									<a href="https://bib.schema.org/artist"><code>artist</code></a> (<a
-										href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>author</dfn>
-									</code>
-								</td>
-								<td>The author of the publication.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or <a
-										href="https://schema.org/Organization"><code>Organization</code></a>.</td>
-								<td>
-									<a href="https://schema.org/author"><code>author</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>colorist</dfn>
-									</code>
-								</td>
-								<td>The individual who adds color to inked drawings.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
-								<td>
-									<a href="https://bib.schema.org/colorist"><code>colorist</code></a> (<a
-										href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>contributor</dfn>
-									</code>
-								</td>
-								<td>Contributor whose role does not fit to one of the other roles in this table.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or <a
-										href="https://schema.org/Organization"><code>Organization</code></a>.</td>
-								<td>
-									<a href="https://schema.org/contributor"><code>contributor</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>creator</dfn>
-									</code>
-								</td>
-								<td>The creator of the publication.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or <a
-										href="https://schema.org/Organization"><code>Organization</code></a>.</td>
-								<td>
-									<a href="https://schema.org/creator"><code>creator</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>editor</dfn>
-									</code>
-								</td>
-								<td>The editor of the publication.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
-								<td>
-									<a href="https://schema.org/editor"><code>editor</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>illustrator</dfn>
-									</code>
-								</td>
-								<td>The illustrator of the publication.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
-								<td>
-									<a href="https://schema.org/illustrator"><code>illustrator</code></a> (<a
-										href="https://schema.org/Book">Book</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>inker</dfn>
-									</code>
-								</td>
-								<td>The individual who traces over the pencil drawings in ink.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
-								<td>
-									<a href="https://bib.schema.org/inker"><code>inker</code></a> (<a
-										href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>letterer</dfn>
-									</code>
-								</td>
-								<td>The individual who adds lettering, including speech balloons and sound effects, to
-									artwork.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
-								<td>
-									<a href="https://bib.schema.org/letterer"><code>letterer</code></a> (<a
-										href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>penciler</dfn>
-									</code>
-								</td>
-								<td>The individual who draws the primary narrative artwork.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
-								<td>
-									<a href="https://bib.schema.org/penciler"><code>penciler</code></a> (<a
-										href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>publisher</dfn>
-									</code>
-								</td>
-								<td>The publisher of the publication.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or <a
-										href="https://schema.org/Organization"><code>Organization</code></a>.</td>
-								<td>
-									<a href="https://schema.org/publisher"><code>publisher</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>readBy</dfn>
-									</code>
-								</td>
-								<td>A person who reads (performs) the publication (for audiobooks).</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>. </td>
-								<td>
-									<a href="https://bib.schema.org/readBy"><code>readBy</code></a> (<a
-										href="https://bib.schema.org/Audiobook">Audiobook</a>) </td>
-							</tr>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>translator</dfn>
-									</code>
-								</td>
-								<td>The translator of the publication.</td>
-								<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or <a
-										href="https://schema.org/Organization"><code>Organization</code></a>. </td>
-								<td>
-									<a href="https://schema.org/translator"><code>translator</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>Creators are represented in one of the following two ways:</p>
-
-					<ol>
-						<li>as a string encoding the name of a <a href="https://schema.org/Person"
-								><code>Person</code></a> [[!schema.org]]; or</li>
-						<li>as an instance of a <a href="https://schema.org/Person"><code>Person</code></a> or <a
-								href="https://schema.org/Organization"><code>Organization</code></a>
-							[[!schema.org]].</li>
-					</ol>
-
-					<p>In other words, a single string value is a shorthand for a [[!schema.org]] <code>Person</code>
-						whose <code>name</code> property is set to that string value. (See also <a
-							href="#strings-vs-objects"></a>.)</p>
-
-					<p>When compiling each set of <dfn data-lt="CreatorInfo">creator information</dfn> from a
-						[[!schema.org]] <a href="https://schema.org/Person"><code>Person</code></a> or <a
-							href="https://schema.org/Organization"><code>Organization</code></a> type, user agents MUST
-						retain the following information when available:</p>
-
-					<dl data-dfn-for="CreatorInfo">
-						<dt>
-							<dfn>type</dfn>
-						</dt>
-						<dd>One or more strings that identifies the type of creator. This sequence SHOULD include
-							"Person" or "Organization".</dd>
-						<dt>
-							<dfn>name</dfn>
-						</dt>
-						<dd>One or more localizable strings for the name of the creator.</dd>
-						<dt>
-							<dfn>id</dfn>
-						</dt>
-						<dd>A canonical identifier of the creator as a URL.&#160;[[!url]]</dd>
-
-						<dt>
-							<dfn>url</dfn>
-						</dt>
-						<dd>An address for the creator in the form of a URL.&#160;[[!url]]</dd>
-					</dl>
-
-					<p>Note that user agents MAY interpret a wider range of creator properties defined by Schema.org
-						than the ones in the preceding list.</p>
-
-					<p>The manifest MAY include more than one of each type of creator.</p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
+						<pre class="idl">
+partial dictionary PublicationManifest {
     sequence&lt;CreatorInfo> artist;
     sequence&lt;CreatorInfo> author;
     sequence&lt;CreatorInfo> colorist;
@@ -1898,10 +1461,10 @@ dictionary CreatorInfo {
              DOMString                      url;
 };</pre>
 
-					<pre class="example" title="Author of a book">
+						<pre class="example" title="Author of a book">
 {
-    "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"     : "Book",
+    "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     &#8230;
     "url"      : "https://publisher.example.org/mobydick",
     "author"   : {
@@ -1910,7 +1473,7 @@ dictionary CreatorInfo {
     }
 }
 </pre>
-					<pre class="example" title="Separate listing of editors, authors, and publisher, with some persons expressed as simple strings">
+						<pre class="example" title="Separate listing of editors, authors, and publisher, with some persons expressed as simple strings">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"       : "TechArticle",
@@ -1943,143 +1506,143 @@ dictionary CreatorInfo {
     &#8230;
 }
 </pre>
-				</section>
+					</section>
 
-				<section id="language-and-dir">
-					<h4>Language and Base Direction</h4>
+					<section id="language-and-dir">
+						<h5>Language and Base Direction</h5>
 
-					<p>The <a>Web Publication</a> has a natural language value (e.g., English, French, Chinese), as well
-						as a natural base writing direction (the display direction, either left-to-right or
-						right-to-left). The manifest has entries to set these values, which can influence, for example,
-						the behavior of a user agent (e.g., it might place a pop-up for a table of contents on the right
-						hand side for publications whose natural base direction is right-to-left).</p>
+						<p>A <a>digital publication</a> has at least one natural <dfn>language</dfn>, which is the
+							language that the content is expressed in (e.g., English, French, Chinese). It also has a
+							natural <dfn>base direction</dfn> in which it is written — the display direction, either
+							left-to-right or right-to-left.</p>
 
-					<p>Similarly, each natural language property value in the <a>Web Publication's</a> manifest (e.g.,
-							<a href="#wp-title">title</a>, <a href="#creators">creators</a>) is <a
-							href="https://w3c.github.io/string-meta/#dom-localizable"
-						>localizable</a>&#160;[[string-meta]], meaning that the same information is available for
-						each.</p>
+						<p>The digital publication manifest includes entries to set both these concepts, which can
+							influence, for example, the behavior of a user agent (e.g., it might place a pop-up for a
+							table of contents on the right hand side for publications whose natural base direction is
+							right-to-left).</p>
 
-					<p>As a result, the manifest has entries to set:</p>
+						<p>Similarly, each natural language property value in the publication's manifest (e.g., <a
+								href="#pub-title">title</a>, <a href="#creators">creators</a>) is <a
+								href="https://w3c.github.io/string-meta/#dom-localizable"
+							>localizable</a>&#160;[[string-meta]], meaning that the same information is available for
+							each.</p>
 
-					<ul>
-						<li>the natural <dfn>language</dfn>, and </li>
-						<li>the <dfn>base direction</dfn></li>
-					</ul>
-
-					<p>of both the <a href="#manifest-default-language-and-dir">Web Publication</a> and the <a
-							href="#manifest-specific-language-and-dir">natural language properties values</a> of the
-						manifest.</p>
-
-					<p>If a user agent requires the language and one is not available in the authored manifest (either
-						globally or specifically for that property), or the obtained value is invalid, the user agent
-						MAY attempt to determine the language when <a href="#canonical-manifest">generating the
-							canonical manifest</a>. This specification does not mandate how such a language tag is
-						created. The user agent might:</p>
-
-					<ul>
-						<li>use the <a>non-empty</a> language declaration of the manifest;</li>
-						<li>use the first non-empty language declaration found in a resource in the <a>default reading
-								order</a>;</li>
-						<li>calculate the language using its own algorithm.</li>
-					</ul>
-
-					<p>No default values are specified for the <a>language</a> or the default <a>base direction</a>.</p>
-
-					<p class="issue" data-number="354">Proposal for handling localizable texts (writeup of the F2F
-						discussions)</p>
-
-					<section id="manifest-default-language-and-dir">
-						<h6>Global Language and Direction</h6>
-
-						<p>The manifest MAY include global language and base direction declarations for the Web
-							Publication using the following properties.</p>
-
-						<table class="zebra">
-							<thead>
-								<tr>
-									<th>Term</th>
-									<th>Description</th>
-									<th>Required Value</th>
-									<th>[[!schema.org]] Mapping</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>
-										<code data-dfn-for="WebPublicationManifest">
-											<dfn>inLanguage</dfn>
-										</code>
-									</td>
-									<td>Default <a>language</a> for the <a>Web Publication</a> as well as the textual
-										manifest values</td>
-									<td>language code as defined in&#160;[[!bcp47]]</td>
-									<td>
-										<a href="https://schema.org/inLanguage"><code>inLanguage</code></a> (<a
-											href="https://schema.org/Property">Property</a>) </td>
-								</tr>
-							</tbody>
-							<tbody>
-								<tr>
-									<td>
-										<code data-dfn-for="WebPublicationManifest">
-											<dfn>inDirection</dfn>
-										</code>
-									</td>
-									<td>Default <a>base direction</a> for the <a>Web Publication</a> as well as the
-										textual manifest values</td>
-									<td><code>ltr</code>, <code>rtl</code>, or <code>auto</code></td>
-									<td>(None)</td>
-								</tr>
-							</tbody>
-						</table>
-
-						<p>The natural language MUST be a tag that conforms to&#160;[[!bcp47]], while the <dfn
-								data-lt="TextDirection">base language direction</dfn> MUST have one of the following
-							values:</p>
-
-						<ul data-dfn-for="TextDirection">
-							<li><code><dfn>ltr</dfn></code>: indicates that the textual values are explicitly
-								directionally set to left-to-right text;</li>
-							<li><code><dfn>rtl</dfn></code>: indicates that the textual values are explicitly
-								directionally set to right-to-left text;</li>
-							<li><code><dfn>auto</dfn></code>: indicates that the textual values are explicitly
-								directionally set to the direction of the first character with a strong
-								directionality.</li>
-						</ul>
-
-						<p>When specified, these properties are also used as defaults for textual values in the
+						<p>The natural language and base direction can be set for both the <a
+								href="#manifest-default-language-and-dir">publication</a> and the <a
+								href="#manifest-specific-language-and-dir">natural language properties values</a> of the
 							manifest.</p>
 
-						<p class="note">It is important to differentiate the language <em>of the publication</em> from
-							the language and the base direction of the individual resources that compose it. If such
-							resources are, for example, in HTML, the language and direction need to be set in those
-							resources, too. The language and base direction of the publication are not inherited.</p>
+						<p>If a user agent requires the language and one is not available in the authored manifest
+							(either globally or specifically for that property), or the obtained value is invalid, the
+							user agent MAY attempt to determine the language when <a href="#canonical-manifest"
+								>generating the canonical manifest</a>. This specification does not mandate how such a
+							language tag is created. The user agent might:</p>
 
-						<p>The global language information MAY be overridden by <a
-								href="#manifest-specific-language-and-dir">individual values</a>.</p>
+						<ul>
+							<li>use the <a>non-empty</a> language declaration of the manifest;</li>
+							<li>use the first non-empty language declaration found in a resource in the <a>default
+									reading order</a>;</li>
+							<li>calculate the language using its own algorithm.</li>
+						</ul>
 
-						<p>If the manifest is <a href="#manifest-embedding">embedded</a> in the primary entry page via a
-								<code>script</code> element, and the manifest does not set the global language and/or
-							the base direction (see <a href="#manifest-default-language-and-dir"></a>), the
-								<code>lang</code> and the <code>dir</code> attributes of the <code>script</code> element
-							are used as the global <a>language</a> and <a>base direction</a>, respectively (see the
-							details on handling the <a
-								href="https://www.w3.org/TR/html/dom.html#the-lang-and-xmllang-attributes"
-									><code>lang</code></a> and <a
-								href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"><code>dir</code></a>
-							attributes in&#160;[[!html]]).</p>
+						<p>No default values are specified for the <a>language</a> or the default <a>base
+							direction</a>.</p>
 
-						<p class="issue">It is to be discussed whether this last paragraph, i.e., inheriting values from
-								<code>script</code>, should be kept.</p>
+						<p class="issue" data-number="354">Proposal for handling localizable texts (writeup of the F2F
+							discussions)</p>
 
-						<p class="note">If authors intend to use a manifest, or a manifest template, both as embedded
-							manifest and as a separate resource, they are strongly encouraged to set these properties
-							explicitly to avoid interference of the containing <code>script</code> element in case of
-							embedding.</p>
+						<section id="manifest-default-language-and-dir">
+							<h6>Global Language and Direction</h6>
 
-						<pre class="idl">
-partial dictionary WebPublicationManifest {
+							<p>The manifest MAY include global language and base direction declarations for the
+								publication using the following properties.</p>
+
+							<table class="zebra">
+								<thead>
+									<tr>
+										<th>Term</th>
+										<th>Description</th>
+										<th>Required Value</th>
+										<th>[[!schema.org]] Mapping</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>
+											<code data-dfn-for="PublicationManifest">
+												<dfn>inLanguage</dfn>
+											</code>
+										</td>
+										<td>Default <a>language</a> for the publication as well as the textual manifest
+											values</td>
+										<td>language code as defined in&#160;[[!bcp47]]</td>
+										<td>
+											<a href="https://schema.org/inLanguage"><code>inLanguage</code></a> (<a
+												href="https://schema.org/Property">Property</a>) </td>
+									</tr>
+								</tbody>
+								<tbody>
+									<tr>
+										<td>
+											<code data-dfn-for="PublicationManifest">
+												<dfn>inDirection</dfn>
+											</code>
+										</td>
+										<td>Default <a>base direction</a> for the publication as well as the textual
+											manifest values</td>
+										<td><code>ltr</code>, <code>rtl</code>, or <code>auto</code></td>
+										<td>(None)</td>
+									</tr>
+								</tbody>
+							</table>
+
+							<p>The natural language MUST be a tag that conforms to&#160;[[!bcp47]], while the <dfn
+									data-lt="TextDirection">base language direction</dfn> MUST have one of the following
+								values:</p>
+
+							<ul data-dfn-for="TextDirection">
+								<li><code><dfn>ltr</dfn></code>: indicates that the textual values are explicitly
+									directionally set to left-to-right text;</li>
+								<li><code><dfn>rtl</dfn></code>: indicates that the textual values are explicitly
+									directionally set to right-to-left text;</li>
+								<li><code><dfn>auto</dfn></code>: indicates that the textual values are explicitly
+									directionally set to the direction of the first character with a strong
+									directionality.</li>
+							</ul>
+
+							<p>When specified, these properties are also used as defaults for textual values in the
+								manifest.</p>
+
+							<p class="note">It is important to differentiate the language <em>of the publication</em>
+								from the language and the base direction of the individual resources that compose it. If
+								such resources are, for example, in HTML, the language and direction need to be set in
+								those resources, too. The language and base direction of the publication are not
+								inherited.</p>
+
+							<p>The global language information MAY be overridden by <a
+									href="#manifest-specific-language-and-dir">individual values</a>.</p>
+
+							<p>If the manifest is <a href="#manifest-embedding">embedded</a> in the primary entry page
+								via a <code>script</code> element, and the manifest does not set the global language
+								and/or the base direction (see <a href="#manifest-default-language-and-dir"></a>), the
+									<code>lang</code> and the <code>dir</code> attributes of the <code>script</code>
+								element are used as the global <a>language</a> and <a>base direction</a>, respectively
+								(see the details on handling the <a
+									href="https://www.w3.org/TR/html/dom.html#the-lang-and-xmllang-attributes"
+										><code>lang</code></a> and <a
+									href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"><code>dir</code></a>
+								attributes in&#160;[[!html]]).</p>
+
+							<p class="issue">It is to be discussed whether this last paragraph, i.e., inheriting values
+								from <code>script</code>, should be kept.</p>
+
+							<p class="note">If authors intend to use a manifest, or a manifest template, both as
+								embedded manifest and as a separate resource, they are strongly encouraged to set these
+								properties explicitly to avoid interference of the containing <code>script</code>
+								element in case of embedding.</p>
+
+							<pre class="idl">
+partial dictionary PublicationManifest {
     DOMString     inLanguage;
     TextDirection inDirection;
 };
@@ -2090,18 +1653,19 @@ enum TextDirection {
     "auto"
 };</pre>
 
-					</section>
+						</section>
 
-					<section id="manifest-specific-language-and-dir">
-						<h6>Item-specific Language</h6>
+						<section id="manifest-specific-language-and-dir">
+							<h6>Item-specific Language</h6>
 
-						<p>It is possible to set the language for any textual value in the manifest. This information
-							MUST be set as a <dfn data-lt="LocalizableString">localizable string</dfn>, i.e., using the
-								<a href="https://www.w3.org/TR/2014/REC-json-ld-20140116/#string-internationalization"
-									><code>value</code> and <code>language</code> terms</a> (instead of a simple
-							string)&#160;[[!json-ld]]:</p>
+							<p>It is possible to set the language for any textual value in the manifest. This
+								information MUST be set as a <dfn data-lt="LocalizableString">localizable string</dfn>,
+								i.e., using the <a
+									href="https://www.w3.org/TR/2014/REC-json-ld-20140116/#string-internationalization"
+										><code>value</code> and <code>language</code> terms</a> (instead of a simple
+								string)&#160;[[!json-ld]]:</p>
 
-						<pre class="example" title="Setting the author name to French using a localizable string">
+							<pre class="example" title="Setting the author name to French using a localizable string">
 {
     "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"     : "Book",
@@ -2115,16 +1679,17 @@ enum TextDirection {
     }
 }
 </pre>
-						<p>The value of the <code data-dfn-for="LocalizableString"><dfn>language</dfn></code> MUST be
-							set to a language code as defined in [[!bcp47]].</p>
+							<p>The value of the <code data-dfn-for="LocalizableString"><dfn>language</dfn></code> MUST
+								be set to a language code as defined in [[!bcp47]].</p>
 
-						<p>When used in a context of localizable texts, a simple string value is a shorthand for a
-								<a>localizable string</a>, with the <code data-dfn-for="LocalizableString"
-									><dfn>value</dfn></code> set to the string value, and the language set to the value
-							of the <a href="#manifest-default-language-and-dir"><code>inLanguage</code></a> property, if
-							applicable, and unset otherwise. In other words, the previous example is equivalent to:</p>
+							<p>When used in a context of localizable texts, a simple string value is a shorthand for a
+									<a>localizable string</a>, with the <code data-dfn-for="LocalizableString"
+										><dfn>value</dfn></code> set to the string value, and the language set to the
+								value of the <a href="#manifest-default-language-and-dir"><code>inLanguage</code></a>
+								property, if applicable, and unset otherwise. In other words, the previous example is
+								equivalent to:</p>
 
-						<pre class="example" title="Setting the default language of an author name to French">
+							<pre class="example" title="Setting the default language of an author name to French">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"       : "Book",
@@ -2133,78 +1698,74 @@ enum TextDirection {
     "author"     : "Marcel Proust",
 }
 </pre>
-						<p>(See also <a href="#strings-vs-objects"></a>.)</p>
+							<p>(See also <a href="#strings-vs-objects"></a>.)</p>
 
-						<p>It is <em>not</em> possible to set the direction explicitly for a value.</p>
+							<p>It is <em>not</em> possible to set the direction explicitly for a value.</p>
 
-						<p class="note"> Setting the direction for a natural text value is currently not possible in
-							JSON-LD&#160;[[json-ld]]. In case the JSON-LD community, as well as the schema.org
-							community, introduces such a feature, future versions of this specification may extend the
-							ability of Web Publication Manifests to include this.</p>
+							<p class="note"> Setting the direction for a natural text value is currently not possible in
+								JSON-LD&#160;[[json-ld]]. In case the JSON-LD community, as well as the schema.org
+								community, introduces such a feature, future versions of this specification may extend
+								the ability of manifests to include this.</p>
 
-						<p>When using Web Publication manifests with bidirectional text, user agents SHOULD identify the
-							base direction of any given natural language value by scanning the text for the first strong
-							directional character. Once the base direction has been identified, user agents MUST
-							determine the appropriate rendering and display of natural language values according to the
-							Unicode Bidirectional Algorithm&#160;[[!bidi]]. This could require wrapping additional
-							control characters or markup around the string prior to display, in order to apply the base
-							direction. (See <a href="#app-bidi-examples"></a>.)</p>
+							<p>When using manifests with bidirectional text, user agents SHOULD identify the base
+								direction of any given natural language value by scanning the text for the first strong
+								directional character. Once the base direction has been identified, user agents MUST
+								determine the appropriate rendering and display of natural language values according to
+								the Unicode Bidirectional Algorithm&#160;[[!bidi]]. This could require wrapping
+								additional control characters or markup around the string prior to display, in order to
+								apply the base direction. (See <a href="#app-bidi-examples"></a>.)</p>
 
-						<pre class="idl">
+							<pre class="idl">
 dictionary LocalizableString {
     required DOMString value;
              DOMString language;
 };</pre>
+						</section>
 					</section>
-				</section>
 
-				<section id="last-modification-date">
-					<h4>Last Modification Date</h4>
-
-					<p>The <dfn>last modification date</dfn> is the date when the <a>Web Publication</a> was last
-						updated (i.e., whenever changes were last made to any of the resources of the Web Publication,
-						including the <a>manifest</a>). It is expressed using the <code>dateModified</code>
-						property.</p>
-
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th>Term</th>
-								<th>Description</th>
-								<th>Required Value</th>
-								<th>[[!schema.org]] Mapping</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>dateModified</dfn>
-									</code>
-								</td>
-								<td>Last modification date of the publication.</td>
-								<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
-										href="https://schema.org/DateTime"><code>DateTime</code></a>
-									value&#160;[[!schema.org]], both expressed in ISO 8601 Date, or Date Time formats,
-									respectively [[iso8601]].</td>
-								<td>
-									<a href="https://schema.org/dateModified"><code>dateModified</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>The last modification date does not necessarily reflect all changes to the Web Publication (e.g.,
-						third-party content could change without the author being aware). User agents SHOULD check the
-						last modification date of individual resources to determine if they have changed and need
-						updating.</p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
+					<section id="last-modification-date">
+						<h5>Last Modification Date</h5>
+						<p>The <dfn>last modification date</dfn> is the date when the <a>digital publication</a> was
+							last updated (i.e., whenever changes were last made to any of the resources of the
+							publication, including the <a>manifest</a>). It is expressed using the
+								<code>dateModified</code> property.</p>
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th>Term</th>
+									<th>Description</th>
+									<th>Required Value</th>
+									<th>[[!schema.org]] Mapping</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>dateModified</dfn>
+										</code>
+									</td>
+									<td>Last modification date of the publication.</td>
+									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
+											href="https://schema.org/DateTime"><code>DateTime</code></a>
+										value&#160;[[!schema.org]], both expressed in ISO 8601 Date, or Date Time
+										formats, respectively [[iso8601]].</td>
+									<td>
+										<a href="https://schema.org/dateModified"><code>dateModified</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+							</tbody>
+						</table>
+						<p>The last modification date does not necessarily reflect all changes to the publication (e.g.,
+							third-party content could change without the author being aware). User agents SHOULD check
+							the last modification date of individual resources to determine if they have changed and
+							need updating.</p>
+						<pre class="idl">
+partial dictionary PublicationManifest {
     DOMString dateModified;
 };</pre>
 
-					<pre class="example" title="Last modification date of the publication">
+						<pre class="example" title="Last modification date of the publication">
 {
     "@context"     : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"         : "TechArticle",
@@ -2215,54 +1776,53 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 </pre>
+					</section>
 
-				</section>
+					<section id="publication-date">
+						<h5>Publication Date</h5>
 
-				<section id="publication-date">
-					<h4>Publication Date</h4>
+						<p>The <dfn>publication date</dfn> is the date on which the <a>digital publication</a> was
+							originally published. It represents a static event in the lifecycle of a publication and
+							allows subsequent revisions to be identified and compared. It is expressed using the
+								<code>datePublished</code> property.</p>
 
-					<p>The <dfn>publication date</dfn> is the date on which the <a>Web Publication</a> was originally
-						published. It represents a static event in the lifecycle of a Web Publication and allows
-						subsequent revisions to be identified and compared. It is expressed using the
-							<code>datePublished</code> property.</p>
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th>Term</th>
+									<th>Description</th>
+									<th>Required Value</th>
+									<th>[[!schema.org]] Mapping</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>datePublished</dfn>
+										</code>
+									</td>
+									<td>Creation date of the publication.</td>
+									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
+											href="https://schema.org/DateTime"><code>DateTime</code></a>, both expressed
+										in ISO 8601 Date, or Date Time formats, respectively [[!iso8601]].</td>
+									<td>
+										<a href="https://schema.org/datePublished"><code>datePublished</code></a> (<a
+											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
+								</tr>
+							</tbody>
+						</table>
 
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th>Term</th>
-								<th>Description</th>
-								<th>Required Value</th>
-								<th>[[!schema.org]] Mapping</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>datePublished</dfn>
-									</code>
-								</td>
-								<td>Creation date of the publication.</td>
-								<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
-										href="https://schema.org/DateTime"><code>DateTime</code></a>, both expressed in
-									ISO 8601 Date, or Date Time formats, respectively [[!iso8601]].</td>
-								<td>
-									<a href="https://schema.org/datePublished"><code>datePublished</code></a> (<a
-										href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
-							</tr>
-						</tbody>
-					</table>
+						<p>The exact moment of publication is intentionally left open to interpretation: it could be
+							when the publication is first made available online or could be a point in time before
+							publication when the publication is considered final.</p>
 
-					<p>The exact moment of publication is intentionally left open to interpretation: it could be when
-						the Web Publication is first made available online or could be a point in time before
-						publication when the Web Publication is considered final.</p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
+						<pre class="idl">
+partial dictionary PublicationManifest {
     DOMString datePublished;
 };</pre>
 
-					<pre class="example" title="Creation and modification date of the publication">
+						<pre class="example" title="Creation and modification date of the publication">
 {
     "@context"      : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"          : "TechArticle",
@@ -2274,59 +1834,59 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 </pre>
-				</section>
+					</section>
 
-				<section id="reading-progression-direction">
-					<h4>Reading Progression Direction</h4>
+					<section id="reading-progression-direction">
+						<h5>Reading Progression Direction</h5>
 
-					<p>The <dfn data-lt="ProgressionDirection">reading progression</dfn> establishes the reading
-						direction from one resource to the next within a <a>Web Publication</a>. It is expressed using
-						the <code>readingDirection</code> property.</p>
+						<p>The <dfn data-lt="ProgressionDirection">reading progression</dfn> establishes the reading
+							direction from one resource to the next within a <a>digital publication</a>. It is expressed
+							using the <code>readingDirection</code> property.</p>
 
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th>Term</th>
-								<th>Description</th>
-								<th>Required Value</th>
-								<th>[[!schema.org]] Mapping</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>readingProgression</dfn>
-									</code>
-								</td>
-								<td>Reading direction from one resource to the other.</td>
-								<td><code>ltr</code> or <code>rtl</code></td>
-								<td>(None)</td>
-							</tr>
-						</tbody>
-					</table>
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th>Term</th>
+									<th>Description</th>
+									<th>Required Value</th>
+									<th>[[!schema.org]] Mapping</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>readingProgression</dfn>
+										</code>
+									</td>
+									<td>Reading direction from one resource to the other.</td>
+									<td><code>ltr</code> or <code>rtl</code></td>
+									<td>(None)</td>
+								</tr>
+							</tbody>
+						</table>
 
-					<p>The value of this property MUST be either:</p>
+						<p>The value of this property MUST be either:</p>
 
-					<ul data-dfn-for="ProgressionDirection">
-						<li><code><dfn>ltr</dfn></code>: left-to-right;</li>
-						<li><code><dfn>rtl</dfn></code>: right-to-left.</li>
-					</ul>
+						<ul data-dfn-for="ProgressionDirection">
+							<li><code><dfn>ltr</dfn></code>: left-to-right;</li>
+							<li><code><dfn>rtl</dfn></code>: right-to-left.</li>
+						</ul>
 
-					<p>The default value is <code>ltr</code>.</p>
+						<p>The default value is <code>ltr</code>.</p>
 
-					<p>This property has <em>no effect</em> on the rendering of the individual primary resources; it is
-						only relevant for the progression direction from one resource to the other.</p>
+						<p>This property has <em>no effect</em> on the rendering of the individual primary resources; it
+							is only relevant for the progression direction from one resource to the other.</p>
 
-					<p class="note">The reading progression of a <a>Web Publication</a> is used to adapt such
-						publication level interactions as menu position, swap direction, defining tap zones to lead the
-						user to the next and previous pages, touch gestures, etc.</p>
+						<p class="note">The reading progression of a publication is used to adapt such publication level
+							interactions as menu position, swap direction, defining tap zones to lead the user to the
+							next and previous pages, touch gestures, etc.</p>
 
-					<p>If the <code>readingProgression</code> is not set, user agents MUST use the default value
-							<code>ltr</code> when generating the canonical manifest.</p>
+						<p>If the <code>readingProgression</code> is not set, user agents MUST use the default value
+								<code>ltr</code> when generating the canonical manifest.</p>
 
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
+						<pre class="idl">
+partial dictionary PublicationManifest {
     ProgressionDirection readingProgression = "ltr";
 };
 
@@ -2335,7 +1895,7 @@ enum ProgressionDirection {
 	"rtl"
 };</pre>
 
-					<pre class="example" title="Reading progression set explicitl to ltr">
+						<pre class="example" title="Reading progression set explicitl to ltr">
 {
     "@context"           : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"               : "Book",
@@ -2344,70 +1904,54 @@ enum ProgressionDirection {
     "readingProgression" : "ltr"
 }
 </pre>
-				</section>
+					</section>
 
-				<section id="wp-title">
-					<h4>Title</h4>
+					<section id="pub-title">
+						<h5>Title</h5>
 
-					<p>The title provides the human-readable name of the <a>Web Publication</a>. It is expressed using
-						the <code>name</code> property.</p>
+						<p>The title provides the human-readable name of the <a>digital publication</a>. It is expressed
+							using the <code>name</code> property.</p>
 
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th>Term</th>
-								<th>Description</th>
-								<th>Required Value</th>
-								<th>[[!schema.org]] Mapping</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>name</dfn>
-									</code>
-								</td>
-								<td>Human-readable title of the Web Publication.</td>
-								<td>One or more text items for the title.</td>
-								<td>
-									<a href="https://schema.org/name"><code>name</code></a> (<a
-										href="https://schema.org/Thing">Thing</a>) </td>
-							</tr>
-						</tbody>
-					</table>
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th>Term</th>
+									<th>Description</th>
+									<th>Required Value</th>
+									<th>[[!schema.org]] Mapping</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>name</dfn>
+										</code>
+									</td>
+									<td>Human-readable title of the publication.</td>
+									<td>One or more text items for the title.</td>
+									<td>
+										<a href="https://schema.org/name"><code>name</code></a> (<a
+											href="https://schema.org/Thing">Thing</a>) </td>
+								</tr>
+							</tbody>
+						</table>
 
-					<p> The title is specified by the <a href="#wp-title">manifest expression</a>, when present. If not
-						included in the <a>authored manifest</a>, the user agent MUST use the value of the <a
-							data-cite="!html#the-title-element"><code>title</code> element</a>&#160;[[!html]] of the Web
-						Publication’s <a>primary entry page</a>, if present, when generating the <a>canonical
-							manifest</a>. </p>
+						<p id="generate_title">If a title is not included in the <a>authored manifest</a>, and a
+								<a>digital publication</a> does not define alternative rules for obtaining one, the user
+							agent MUST create one. This specification does not specify what heuristics to use to
+							generate such a title.</p>
 
-					<p id="generate_title"> If the title is not available either in the <a>authored manifest</a> or as a
-						non empty <a data-cite="!html#the-title-element"><code>title</code> element</a> in the
-							<a>primary entry page</a>, the user agent MUST create one. This specification does not
-						specify what heuristics the user agent should use; it can, for example, use a language-specific
-						placeholder title, use the <abbr title="Uniform Resource Locator">URL</abbr> of the manifest or
-						the primary entry page, or use the value of the <a href="#address">address</a> in the
-							<a>authored manifest</a>. </p>
+						<p class="note">A user agent is not expected to produce a <a
+								data-cite="WCAG20#navigation-mechanisms-title">meaningful title</a>&#160;[[wcag20]] for
+							a publication when one is not specified. </p>
 
-					<p class="note"> Relying on the <code>title</code> element could be semantically problematic if the
-						Web Publication consists of several HTML resources (e.g., one per chapter of a book), because
-						the <a data-cite="!html#the-title-element">HTML definition</a> defines this element as
-						"metadata" for the enclosing HTML document, not for a collection of resources. Using this
-						element is, on the other hand, preferred in the case of a publication consisting of a single
-						HTML document (e.g., a scholarly journal article). </p>
-
-					<p class="note">A user agent is not expected to produce a <a
-							data-cite="WCAG20#navigation-mechanisms-title">meaningful title</a>&#160;[[wcag20]] for a
-						Web Publication when one is not specified. </p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
+						<pre class="idl">
+partial dictionary PublicationManifest {
     required sequence&lt;LocalizableString> name;
 };</pre>
 
-					<pre class="example" title="Title of the book set explicitly">
+						<pre class="example" title="Title of the book set explicitly">
 {
     "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"     : "Book",
@@ -2416,83 +1960,75 @@ partial dictionary WebPublicationManifest {
     "name"     : "Moby Dick"
 }
 </pre>
+					</section>
 				</section>
-			</section>
 
-			<section id="resource-categorization-properties">
-				<h3>Resource Categorization Properties</h3>
+				<section id="resource-categorization-properties">
+					<h4>Resource Categorization Properties</h4>
 
-				<p><a>Web Publication</a> resources are specified via the <a>default reading order</a>, the <a>resource
-						list</a>, and the <a>links</a>, as defined in this section. These lists contain references to <a
-						href="#informative-properties">informative properties</a> like the <a href="#privacy-policy"
-						>privacy policy</a>, and <a href="#structural-properties">structural properties</a> like the <a
-						href="#table-of-contents">table of contents</a>.</p>
+					<p>Publication resources are specified via the <a>default reading order</a>, the <a>resource
+							list</a>, and the <a>links</a>, as defined in this section. These lists contain references
+						to <a href="#informative-properties">informative properties</a> like the <a
+							href="#privacy-policy">privacy policy</a>, and <a href="#structural-properties">structural
+							properties</a> like the <a href="#table-of-contents">table of contents</a>.</p>
 
-				<p>Note that a particular resource's URL MUST NOT appear in more than one of these lists, and a URL MUST
-					NOT be repeated within a list.</p>
+					<p>Note that a particular resource's URL MUST NOT appear in more than one of these lists, and a URL
+						MUST NOT be repeated within a list.</p>
 
-				<p>The manifest itself MUST NOT include a reference to itself, i.e., the reference to the manifest MUST
-					NOT appear within these lists.</p>
+					<p>The manifest MUST NOT include a reference to itself within any of these lists.</p>
 
-				<section id="default-reading-order">
-					<h4>Default Reading Order</h4>
+					<section id="default-reading-order">
+						<h5>Default Reading Order</h5>
 
-					<p>The <dfn>default reading order</dfn> is a specific progression through a set of <a>Web
-							Publication</a> resources. A user might follow alternative pathways through the content, but
-						in the absence of such interaction the default reading order defines the expected progression
-						from one resource to the next.</p>
+						<p>The <dfn>default reading order</dfn> is a specific progression through a set of <a>digital
+								publication</a> resources. A user might follow alternative pathways through the content,
+							but in the absence of such interaction the default reading order defines the expected
+							progression from one resource to the next.</p>
 
-					<p>The default reading order is expressed using the <code>readingOrder</code> property.</p>
+						<p>The default reading order is expressed using the <code>readingOrder</code> property.</p>
 
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th>Term</th>
-								<th>Description</th>
-								<th>Required Value</th>
-								<th>[[!schema.org]] Mapping</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>readingOrder</dfn>
-									</code>
-								</td>
-								<td></td>
-								<td>
-									<p>An array of:</p>
-									<ul>
-										<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
-										<li>an instance of a <a href="#publication-link-def"
-												><code>LinkedResource</code></a> object</li>
-									</ul>
-									<p>The order in the array is <em>significant</em>. The URLs MUST NOT include
-										fragment identifiers. Non-HTML resources SHOULD be expressed as
-											<code>LinkedResource</code> objects with their <code>encodingFormat</code>
-										values set.</p>
-								</td>
-								<td>(None)</td>
-							</tr>
-						</tbody>
-					</table>
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th>Term</th>
+									<th>Description</th>
+									<th>Required Value</th>
+									<th>[[!schema.org]] Mapping</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>readingOrder</dfn>
+										</code>
+									</td>
+									<td></td>
+									<td>
+										<p>An array of:</p>
+										<ul>
+											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
+											<li>an instance of a <a href="#publication-link-def"
+														><code>LinkedResource</code></a> object</li>
+										</ul>
+										<p>The order in the array is <em>significant</em>. The URLs MUST NOT include
+											fragment identifiers. Non-HTML resources SHOULD be expressed as
+												<code>LinkedResource</code> objects with their
+												<code>encodingFormat</code> values set.</p>
+									</td>
+									<td>(None)</td>
+								</tr>
+							</tbody>
+						</table>
 
-					<p>The default reading order MUST include at least one resource.</p>
+						<p>The default reading order MUST include at least one resource.</p>
 
-					<p>The default reading order is specified directly in the manifest, but MAY be omitted when it only
-						consists of the <a>primary entry page</a>. When the default reading order is absent, user agents
-						MUST include an entry for the primary entry page when compiling the canonical manifest.</p>
-
-					<p>If present in the Web Publication Manifest, this item MUST be mapped on the
-							<code>readingOrder</code> term, defined specifically for Web Publications.</p>
-
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
+						<pre class="idl">
+partial dictionary PublicationManifest {
    required sequence&lt;LinkedResource> readingOrder;
 };</pre>
 
-					<pre class="example" title="Reading order expressed as a simple list of URLs">
+						<pre class="example" title="Reading order expressed as a simple list of URLs">
 {
     "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"     : "Book",
@@ -2509,7 +2045,7 @@ partial dictionary WebPublicationManifest {
     ]
 }
 </pre>
-					<pre class="example" title="Reading order expressed as objects providing more information on items">
+						<pre class="example" title="Reading order expressed as objects providing more information on items">
 {
     "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"     : "Book",
@@ -2531,65 +2067,65 @@ partial dictionary WebPublicationManifest {
     }]
 }
 </pre>
-				</section>
+					</section>
 
-				<section id="resource-list">
-					<h4>Resource List</h4>
+					<section id="resource-list">
+						<h5>Resource List</h5>
 
-					<p>The <dfn>resource list</dfn> enumerates any additional <a href="#wp-resources">resources</a> used
-						in the processing and rendering of a <a>Web Publication</a> that are not already listed in the
-							<a>default reading order</a>. It is expressed using the <code>resources</code> property.</p>
+						<p>The <dfn>resource list</dfn> enumerates any additional <a href="#pub-resources">resources</a>
+							used in the processing and rendering of a <a>digital publication</a> that are not already
+							listed in the <a>default reading order</a>. It is expressed using the <code>resources</code>
+							property.</p>
 
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th>Term</th>
-								<th>Description</th>
-								<th>Required Value</th>
-								<th>[[!schema.org]] Mapping</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>resources</dfn>
-									</code>
-								</td>
-								<td></td>
-								<td>
-									<p>An array of:</p>
-									<ul>
-										<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
-										<li>an instance of a <a href="#publication-link-def"
-												><code>LinkedResource</code></a> object</li>
-									</ul>
-									<p>The order in the array is <em>not significant</em>. The URLs MUST NOT include
-										fragment identifiers. It is RECOMMENDED to use <code>LinkedResource</code>
-										objects with their <code>encodingFormat</code> values set.</p>
-								</td>
-								<td>(None)</td>
-							</tr>
-						</tbody>
-					</table>
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th>Term</th>
+									<th>Description</th>
+									<th>Required Value</th>
+									<th>[[!schema.org]] Mapping</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>resources</dfn>
+										</code>
+									</td>
+									<td></td>
+									<td>
+										<p>An array of:</p>
+										<ul>
+											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
+											<li>an instance of a <a href="#publication-link-def"
+														><code>LinkedResource</code></a> object</li>
+										</ul>
+										<p>The order in the array is <em>not significant</em>. The URLs MUST NOT include
+											fragment identifiers. It is RECOMMENDED to use <code>LinkedResource</code>
+											objects with their <code>encodingFormat</code> values set.</p>
+									</td>
+									<td>(None)</td>
+								</tr>
+							</tbody>
+						</table>
 
-					<p>The completeness of the resource list will affect the usability of the Web Publication in certain
-						reading scenarios (e.g., the ability to read the Web Publication offline). For this reason, it
-						is strongly RECOMMENDED to provide a comprehensive list of all of the Web Publication's
-						constituent resources beyond those listed in the <a>default reading order</a>.</p>
+						<p>The completeness of the resource list can affect the usability of a digital publication in
+							certain reading scenarios (e.g., the ability to read it offline). For this reason, it is
+							strongly RECOMMENDED to provide a comprehensive list of all of the publication's constituent
+							resources beyond those listed in the <a>default reading order</a>.</p>
 
-					<p>In some cases, a comprehensive list of these resources might not be easily achieved (e.g.,
-						third-party scripts that reference resources from deep within their source), but a user agent
-						SHOULD still be able to render a Web Publication even if some of these resources are not
-						identified as belonging to the Web Publication (e.g., when it is taken offline without
-						them).</p>
+						<p>In some cases, a comprehensive list of these resources might not be easily achieved (e.g.,
+							third-party scripts that reference resources from deep within their source), but a user
+							agent SHOULD still be able to render a publication even if some of these resources are not
+							identified as belonging to the publication (e.g., if it is taken offline without them).</p>
 
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
+						<pre class="idl">
+partial dictionary PublicationManifest {
     sequence&lt;LinkedResource> resources = [];
 };</pre>
 
-					<pre class="example" title="Listing resources, some via a simple URL, some with more details">
+						<pre class="example" title="Listing resources, some via a simple URL, some with more details">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"       : "TechArticle",
@@ -2618,120 +2154,115 @@ partial dictionary WebPublicationManifest {
 }
 </pre>
 
-				</section>
+					</section>
 
-				<section id="links">
-					<h4>Links</h4>
+					<section id="links">
+						<h5>Links</h5>
 
-					<p><dfn>Links</dfn> provide a list of <a href="#wp-resources">resources</a> that are <em>not</em>
-						required for the processing and rendering of a Web Publication (i.e., the content of the Web
-						Publication remains unaffected even if these resources are not available). They are expressed
-						using the <code>links</code> property.</p>
+						<p>The <dfn><code>links</code></dfn> property provides a list of <a href="#pub-resources"
+								>resources</a> that are <em>not</em> required for the processing and rendering of a
+								<a>digital publication</a> (i.e., the content of the publication remains unaffected even
+							if these resources are not available).</p>
 
-					<table class="zebra">
-						<thead>
-							<tr>
-								<th>Term</th>
-								<th>Description</th>
-								<th>Required Value</th>
-								<th>[[!schema.org]] Mapping</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code data-dfn-for="WebPublicationManifest">
-										<dfn>links</dfn>
-									</code>
-								</td>
-								<td></td>
-								<td>
-									<p>An array of:</p>
-									<ul>
-										<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
-										<li>an instance of a <a href="#publication-link-def"
-												><code>LinkedResource</code></a> object</li>
-									</ul>
-									<p>The order in the array is <em>not significant</em>. It is RECOMMENDED to use
-											<code>LinkedResource</code> objects with their <code>encodingFormat</code>
-										and <code>rel</code> values set.</p>
-								</td>
-								<td>(None)</td>
-							</tr>
-						</tbody>
-					</table>
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th>Term</th>
+									<th>Description</th>
+									<th>Required Value</th>
+									<th>[[!schema.org]] Mapping</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code data-dfn-for="PublicationManifest">
+											<dfn>links</dfn>
+										</code>
+									</td>
+									<td></td>
+									<td>
+										<p>An array of:</p>
+										<ul>
+											<li>a string, representing the URL&#160;[[url]] of the resource; or</li>
+											<li>an instance of a <a href="#publication-link-def"
+														><code>LinkedResource</code></a> object</li>
+										</ul>
+										<p>The order in the array is <em>not significant</em>. It is RECOMMENDED to use
+												<code>LinkedResource</code> objects with their
+												<code>encodingFormat</code> and <code>rel</code> values set.</p>
+									</td>
+									<td>(None)</td>
+								</tr>
+							</tbody>
+						</table>
 
-					<p>Linked resources are typically made available to user agents to augment or enhance the processing
-						or rendering of it, such as:</p>
+						<p>Linked resources are typically made available to user agents to augment or enhance the
+							processing or rendering, such as:</p>
 
-					<ul>
-						<li>a privacy policy or license that the user agent can offer a link to from a shelf;</li>
-						<li>a metadata record that the user agent can use to discover and display more information about
-							the Web Publication;</li>
-						<li>a dictionary of terms the user agent can process to provide enhanced language help;</li>
-					</ul>
+						<ul>
+							<li>a privacy policy or license that the user agent can offer a link to from a shelf;</li>
+							<li>a metadata record that the user agent can use to discover and display more information
+								about the publication;</li>
+							<li>a dictionary of terms the user agent can process to provide enhanced language help;</li>
+						</ul>
 
-					<p>Links can also be used to identify resources that are used in the online rendering of a Web
-						Publication, but that are not essential to include with it when it is taken offline or packaged
-						(e.g., to minimize the size). These include:</p>
+						<p>Links can also be used to identify resources used in the online rendering of a publication,
+							but that are not essential to include when the publication is taken offline or packaged
+							(e.g., to minimize the size). These include:</p>
 
-					<ul>
-						<li>large font files that enhance the appearance of the Web Publication but are not vital to its
-							display (i.e., a fallback font will suffice);</li>
-						<li>third-party scripts that are not intended for use when a Web Publication is taken offline or
-							packaged (e.g., tracking scripts).</li>
-					</ul>
+						<ul>
+							<li>large font files that enhance the appearance of the publication but are not vital to its
+								display (i.e., a fallback font will suffice);</li>
+							<li>third-party scripts that are not intended for use when a publication is taken offline or
+								packaged (e.g., tracking scripts).</li>
+						</ul>
 
-					<p>The <code>links</code> list SHOULD include resources necessary to render a linked resource (e.g.,
-						scripts, images, style sheets).</p>
+						<p>The <code>links</code> list SHOULD include resources necessary to render a linked resource
+							(e.g., scripts, images, style sheets).</p>
 
-					<p>Resources listed in the <code>links</code> list MUST NOT be listed in the <a
-							href="#default-reading-order">default reading order</a> or <a href="#resource-list">resource
-							list</a>.</p>
+						<p>Resources listed in the <code>links</code> list MUST NOT be listed in the <a
+								href="#default-reading-order">default reading order</a> or <a href="#resource-list"
+								>resource list</a>.</p>
 
-					<p>User agents MAY ignore linked resources, and are not required to take them offline with a Web
-						Publication. These resources SHOULD NOT be included when packaging a Web Publication.</p>
+						<p>User agents MAY ignore linked resources, and are not required to take them offline with a
+							publication. These resources SHOULD NOT be included when packaging a publication.</p>
 
-					<pre class="idl">
-partial dictionary WebPublicationManifest {
+						<pre class="idl">
+partial dictionary PublicationManifest {
     sequence&lt;LinkedResource> links = [];
 };</pre>
 
+					</section>
 				</section>
-			</section>
 
-			<section id="informative-properties">
-				<h3>Informative Properties</h3>
+				<section id="informative-properties">
+					<h4>Informative Properties</h4>
 
-				<section id="accessibility-report">
-					<h4>Accessibility Report</h4>
+					<section id="accessibility-report">
+						<h5>Accessibility Report</h5>
 
-					<p>An accessibility report provides information about the suitability of a <a>Web Publication</a>
-						for consumption by users with varying preferred reading modalities. These reports typically
-						identify the result of an evaluation against established accessibility criteria, such as those
-						provided in [[WCAG21]], and are an important source of information in determining the usability
-						of a Web Publication.</p>
+						<p>An accessibility report provides information about the suitability of a <a>digital
+								publication</a> for consumption by users with varying preferred reading modalities.
+							These reports typically identify the result of an evaluation against established
+							accessibility criteria, such as those provided in [[WCAG21]], and are an important source of
+							information in determining the usability of a publication.</p>
 
-					<p>An accessibility report is identified using the
-							<code>https://www.w3.org/ns/wp#accessibility-report</code> link relationship.</p>
+						<p>An accessibility report is identified using the
+								<code>https://www.w3.org/ns/wp#accessibility-report</code> link relationship.</p>
 
-					<p>The manifest SHOULD include a link to an accessibility report when one is available for a Web
-						Publication. It is RECOMMENDED that the report be included as a resource of the Web
-						Publication.</p>
+						<p>The manifest SHOULD include a link to an accessibility report when one is available for a
+							publication. It is RECOMMENDED that the report be included as a resource of the
+							publication.</p>
 
-					<p>It is also RECOMMENDED that the accessibility report be provided in a human-readable format, such
-						as [[!html]]. Augmenting these reports with machine-processable metadata, such as provided in
-						Schema.org [[!schema.org]], is also RECOMMENDED.</p>
+						<p>It is also RECOMMENDED that the accessibility report be provided in a human-readable format,
+							such as [[!html]]. Augmenting these reports with machine-processable metadata, such as
+							provided in Schema.org [[!schema.org]], is also RECOMMENDED.</p>
 
-					<p>If present in the manifest, the accessibility report MUST be expressed as a <a
-							href="#publication-link-def"><code>LinkedResource</code></a>. The <code>rel</code> value of
-						the <a href="#publication-link-def"><code>LinkedResource</code></a> MUST include the
-							<code>https://www.w3.org/ns/wp#accessibility-report</code> identifier.</p>
+						<p class="ednote">The Working Group will attempt to define the <code>accessibility-report</code>
+							term with IANA, to avoid using a URL.</p>
 
-					<p class="ednote">The Working Group will attempt to define the <code>accessibility-report</code>
-						term with IANA, to avoid using a URL.</p>
-
-					<pre class="example" title="Link to an accessibility report">
+						<pre class="example" title="Link to an accessibility report">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"       : "Book",
@@ -2748,35 +2279,32 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 </pre>
-				</section>
+					</section>
 
-				<section id="privacy-policy">
-					<h4>Privacy Policy</h4>
+					<section id="privacy-policy">
+						<h5>Privacy Policy</h5>
 
-					<p>Users often have the legal right to know and control what information is collected about them,
-						how such information is stored and for how long, whether it is personally identifiable, and how
-						it can be expunged. Including a statement that addresses such privacy concerns is consequently
-						an important part of publishing <a>Web Publications</a>. Even if no information is collected,
-						such a declaration increases the trust users have in the content.</p>
+						<p>Users often have the legal right to know and control what information is collected about
+							them, how such information is stored and for how long, whether it is personally
+							identifiable, and how it can be expunged. Including a statement that addresses such privacy
+							concerns is consequently an important part of publishing <a>digital publications</a>. Even
+							if no information is collected, such a declaration increases the trust users have in the
+							content.</p>
 
-					<p>A privacy policy is identified using the <code>privacy-policy</code> link relationship.</p>
+						<p>A link to a privacy policy can be included in the manifest for this purposes. It is
+							RECOMMENDED that the privacy policy be included as a resource of the publication.</p>
 
-					<p>A link to a privacy policy can be included in the manifest. It is RECOMMENDED that the privacy
-						policy be included as a resource of the Web Publication.</p>
+						<p>The <span data-dfn-for="PublicationManifest"><dfn data-lt="privacyPolicy">privacy
+									policy</dfn></span> is identified using the <code>privacy-policy</code> link
+							relationship&#160;[[!iana-link-relations]].</p>
 
-					<p>It is RECOMMENDED that the privacy policy be provided in a human-readable format, such as <abbr
-							title="Hypertext Markup Language">HTML</abbr>&#160;[[html]].</p>
+						<p>It is RECOMMENDED that the privacy policy be provided in a human-readable format, such as
+								<abbr title="Hypertext Markup Language">HTML</abbr>&#160;[[html]].</p>
 
-					<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in Web
-						Publications.</p>
+						<p>Refer to <a href="#privacy"></a> for more information about privacy considerations in
+							publications.</p>
 
-					<p>If present in the manifest, the <span data-dfn-for="WebPublicationManifest"><dfn
-								data-lt="privacyPolicy">privacy policy</dfn></span> MUST be expressed as a <a
-							href="#publication-link-def"><code>LinkedResource</code></a>. The <code>rel</code> value of
-						the <a href="#publication-link-def"><code>LinkedResource</code></a> MUST include the
-							<code>privacy-policy</code> identifier&#160;[[!iana-link-relations]].</p>
-
-					<pre class="example" title="Privacy policy expressed as an external link">
+						<pre class="example" title="Privacy policy expressed as an external link">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"       : "TechArticle",
@@ -2795,42 +2323,35 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 </pre>
+					</section>
 				</section>
-			</section>
 
-			<section id="structural-properties">
-				<h3>Structural Properties</h3>
+				<section id="structural-properties">
+					<h4>Structural Properties</h4>
 
-				<section id="cover">
-					<h4>Cover</h4>
+					<section id="cover">
+						<h5>Cover</h5>
 
-					<p>The <dfn>cover</dfn> is a resource that user agents can use to present the <a>Web Publication</a>
-						(e.g., in a library or bookshelf, or when initially loading the Web Publication).</p>
+						<p>The <dfn>cover</dfn> is a resource that user agents can use to present the <a>digital
+								publication</a> (e.g., in a library or bookshelf, or when initially loading the
+							publication).</p>
 
-					<p>The cover is identified by the <code>https://www.w3.org/ns/wp#cover</code> link relationship.</p>
+						<p>The cover is identified by the <code>https://www.w3.org/ns/wp#cover</code> link relationship.
+							The URL expressed in the <code>url</code> term MUST NOT include a fragment identifier.</p>
 
-					<p>The manfiest SHOULD include a reference to a cover.</p>
+						<p>If the cover is in an image format, a <code>title</code> and <code>description</code> SHOULD
+							be provided. User agents can use these properties to provide alternative text and
+							descriptions when necessary for accessibility.</p>
 
-					<p>More than one cover MAY be referenced from the manifest (e.g., to provide alternative formats and
-						sizes for different device screens). If multiple covers are specified, each instance MUST define
-						at least one unique property to allow user agents to determine its usability (e.g., a different
-						format, height, width or relationship).</p>
+						<p>More than one cover MAY be referenced from the manifest (e.g., to provide alternative formats
+							and sizes for different device screens). If multiple covers are specified, each instance
+							MUST define at least one unique property to allow user agents to determine its usability
+							(e.g., a different format, height, width or relationship).</p>
 
-					<p>If present in the manifest, the cover MUST be expressed as a <a href="#publication-link-def"
-								><code>LinkedResource</code></a>. The URL expressed in the <code>url</code> term MUST
-						NOT include a fragment identifier.</p>
+						<p class="ednote">The Working Group will attempt to define the <code>cover</code> term by IANA,
+							to avoid using a URL.</p>
 
-					<p>The <code>rel</code> value of the <a href="#publication-link-def"><code>LinkedResource</code></a>
-						MUST include the <code>https://www.w3.org/ns/wp#cover</code> identifier.</p>
-
-					<p>If the cover is in an image format, a <code>title</code> and <code>description</code> SHOULD be
-						provided. User agents can use these properties to provide alternative text and descriptions when
-						necessary for accessibility.</p>
-
-					<p class="ednote">The Working Group will attempt to define the <code>cover</code> term by IANA, to
-						avoid using a URL.</p>
-
-					<pre class="example" title="Cover HTML page">
+						<pre class="example" title="Cover HTML page">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"       : "Book",
@@ -2849,7 +2370,7 @@ partial dictionary WebPublicationManifest {
 }
 </pre>
 
-					<pre class="example" title="Cover image with title and description">
+						<pre class="example" title="Cover image with title and description">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"       : "Book",
@@ -2870,7 +2391,7 @@ partial dictionary WebPublicationManifest {
 }
 </pre>
 
-					<pre class="example" title="Cover image in JPEG and SVG formats">
+						<pre class="example" title="Cover image in JPEG and SVG formats">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"       : "Book",
@@ -2893,57 +2414,25 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 </pre>
-				</section>
+					</section>
 
-				<section id="page-list">
-					<h3>Page List</h3>
+					<section id="page-list">
+						<h5>Page List</h5>
 
-					<p>The <dfn>pagelist</dfn> property identifies the resource that contains the Web Publication's <a
-							href="#wp-pagelist">page list</a>.</p>
+						<p>The page list property identifies the <a>digital publication's</a>
+							<a href="#pagelist">page list</a>. It MAY be used either to embed a page list within the
+							manifest or to identify a resource that contains the list. How the page list has to be
+							represented is determined by the digital publication format.</p>
 
-					<p>The page list is identified by the <code>https://www.w3.org/ns/wp#pagelist</code> link
-						relationship.</p>
+						<p>When the page list is contained in a separate resource, the resource MUST be identified by
+							the <code>https://www.w3.org/ns/wp#pagelist</code> link relationship. The URL expressed in
+							the <code>url</code> term MUST NOT include a fragment identifier.</p>
 
-					<p>User agents MUST compute the <code>pagelist</code> as follows:</p>
+						<p>The link to the page list MAY be specified in either the <a href="#default-reading-order"
+								>default reading order</a> or <a href="#resource-list">resource-list</a>, but MUST NOT
+							be specified in both.</p>
 
-					<ol>
-						<li>Identify the page list resource: <ul>
-								<li> If a resource in either the <a href="#default-reading-order">default reading
-										order</a> or <a href="#resource-list">resource-list</a> is identified with a
-										<code>rel</code> value including <code>https://www.w3.org/ns/wp#pagelist</code>,
-									the corresponding <code>url</code> value identifies the page list resource. If there
-									are several such resources, the first one MUST be used, with the <a
-										href="#default-reading-order">default reading order</a> taking precedence over
-										<a href="#resource-list">resource-list</a>. </li>
-								<li> Otherwise, the <a>primary entry page</a> is the page list resource. </li>
-							</ul>
-						</li>
-						<li> If the page list resource contains an HTML element with the
-							<code>role</code>&#160;[[!html]] value <code>doc-pagelist</code>&#160;[[!dpub-aria-1.0]],
-							the user agent MUST use that element as the page list. If there are several such HTML
-							elements the user agent MUST use the first in <a
-								href="https://dom.spec.whatwg.org/#concept-tree-order">document tree
-							order</a>&#160;[[!dom]]. </li>
-					</ol>
-
-					<p>If this process does not result in a link to the page list, the Web Publication does not have a
-						page list and this property MUST NOT be included in the canonical manifest.</p>
-
-					<p class="ednote">The Working Group will attempt to define the <code>pagelist</code> term by IANA,
-						to avoid using a URL.</p>
-
-					<p>If present in the manifest, the page list MUST be expressed as a <a href="#publication-link-def"
-								><code>LinkedResource</code></a>. The URL expressed in the <code>url</code> term MUST
-						NOT include a fragment identifier.</p>
-
-					<p>The <code>rel</code> value of the <a href="#publication-link-def"><code>LinkedResource</code></a>
-						MUST include the <code>https://www.w3.org/ns/wp#pagelist</code> identifier.</p>
-
-					<p>The link to the page list MAY be specified in either the <a href="#default-reading-order">default
-							reading order</a> or <a href="#resource-list">resource-list</a>, but MUST NOT be specified
-						in both.</p>
-
-					<pre class="example" title="Pagelist identified in another resource of the Web Publication">
+						<pre class="example" title="Pagelist identified in another resource of the publication">
 {
 "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
 "type"       : "Book",
@@ -2960,58 +2449,26 @@ partial dictionary WebPublicationManifest {
 &#8230;
 }
 </pre>
-				</section>
+					</section>
 
-				<section id="table-of-contents">
-					<h4>Table of Contents</h4>
+					<section id="pub-table-of-contents">
+						<h5>Table of Contents</h5>
 
-					<p>The table of contents property identifies the resource that contains the Web Publication's <a
-							href="#wp-table-of-contents">table of contents</a>.</p>
+						<p>The table of contents property identifies the <a>digital publication's</a> table of contents.
+							It MAY be used either to embed a table of contents within the manifest or to identify a
+							resource that contains the table of contents. How the table of contents has to be
+							represented is determined by the digital publication format.</p>
 
-					<p>The table of contents is identified by the <code>contents</code> link relationship.</p>
+						<p>When the <span data-dfn-for="PublicationManifest"><dfn data-lt="toc">table of
+								contents</dfn></span> is contained in a separate resource, the resource MUST be
+							identified by the <code>contents</code> link relationship&#160;[[!iana-link-relations]]. The
+							URL expressed in the <code>url</code> term MUST NOT include a fragment identifier.</p>
 
-					<p>User agents MUST compute the <code>toc</code> as follows:</p>
+						<p>The link to the table of contents MAY be specified in either the <a
+								href="#default-reading-order">default reading order</a> or <a href="#resource-list"
+								>resource-list</a>, but MUST NOT be specified in both.</p>
 
-					<ol>
-						<li>Identify the table of contents resource: <ul>
-								<li> If a resource in either the <a href="#default-reading-order">default reading
-										order</a> or <a href="#resource-list">resource-list</a> is identified with a
-										<code>rel</code> value including
-									<code>contents</code>&#160;[[!iana-link-relations]], the corresponding
-										<code>url</code> value identifies the table of contents resource. If there are
-									several such resources, the first one MUST be used, with the <a
-										href="#default-reading-order">default reading order</a> taking precedence over
-										<a href="#resource-list">resource-list</a>. </li>
-								<li> Otherwise, the <a>primary entry page</a> is the table of contents resource. </li>
-							</ul>
-						</li>
-						<li> If the table of contents resource contains an HTML element with the
-							<code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria-1.0]], the
-							user agent MUST use that element as the table of contents. If there are several such HTML
-							elements the user agent MUST use the first in <a
-								href="https://dom.spec.whatwg.org/#concept-tree-order">document tree
-							order</a>&#160;[[!dom]]. </li>
-					</ol>
-
-					<p>If this process does not result in a link to the table of contents, the Web Publication does not
-						have a table of contents and this property MUST NOT be included in the canonical manifest.</p>
-
-					<p>See the separate section <a href="#app-toc-structure"></a> for the HTML structure that the table
-						of content SHOULD adhere to.</p>
-
-					<p>If present in the manifest, the <span data-dfn-for="WebPublicationManifest"><dfn data-lt="toc"
-								>table of contents</dfn></span> MUST be expressed as a <a href="#publication-link-def"
-								><code>LinkedResource</code></a>. The URL expressed in the <code>url</code> term MUST
-						NOT include a fragment identifier.</p>
-
-					<p>The <code>rel</code> value of the <a href="#publication-link-def"><code>LinkedResource</code></a>
-						MUST include the <code>contents</code> identifier&#160;[[!iana-link-relations]].</p>
-
-					<p>The link to the table of contents MAY be specified in either the <a href="#default-reading-order"
-							>default reading order</a> or <a href="#resource-list">resource-list</a>, but MUST NOT be
-						specified in both.</p>
-
-					<pre class="example" title="Table of content identified in another resource of the Web Publication">
+						<pre class="example" title="Table of content identified in another resource of the publication">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "type"       : "Book",
@@ -3029,7 +2486,7 @@ partial dictionary WebPublicationManifest {
 }
 </pre>
 
-					<pre class="example" title="If the primary entry page includes the TOC, no reference in the manifest is necessary">
+						<pre class="example" title="If the primary entry page includes the TOC, no reference in the manifest is necessary">
 &lt;head&gt;
     &#8230;
     &lt;script type="application/ld+json"&gt;
@@ -3052,47 +2509,49 @@ partial dictionary WebPublicationManifest {
     &#8230;
 &lt;/body&gt;
 </pre>
+					</section>
 				</section>
-			</section>
 
-			<section id="extensibility">
-				<h3>Extensibility</h3>
+				<section id="extensibility">
+					<h4>Extensibility</h4>
 
-				<p>The manifest is designed to provide a basic set of properties for use by user agents in presenting
-					and rendering a <a>Web Publication</a>, but MAY be extended in the following ways:</p>
+					<p>The manifest is designed to provide a basic set of properties for use by user agents in
+						presenting and rendering a <a>digital publication</a>, but MAY be extended in the following
+						ways:</p>
 
-				<ol>
-					<li>by the provision of <a href="#extensibility-linked-records">linked metadata records</a>.</li>
-					<li>through the inclusion of <a href="#extensibility-manifest-properties">additional properties in
-							the manifest</a>;</li>
-				</ol>
+					<ol>
+						<li>by the provision of <a href="#extensibility-linked-records">linked metadata
+							records</a>.</li>
+						<li>through the inclusion of <a href="#extensibility-manifest-properties">additional properties
+								in the manifest</a>;</li>
+					</ol>
 
-				<p>Although both methods are valid, the use of linked records is RECOMMENDED.</p>
+					<p>Although both methods are valid, the use of linked records is RECOMMENDED.</p>
 
-				<p>This specification does not define how such additional properties are compiled, stored or exposed by
-					user agents in their internal representation of the manifest. A user agent MAY ignore some or all
-					extended properties.</p>
+					<p>This specification does not define how such additional properties are compiled, stored or exposed
+						by user agents in their internal representation of the manifest. A user agent MAY ignore some or
+						all extended properties.</p>
 
-				<section id="extensibility-linked-records">
-					<h5>Linked records</h5>
+					<section id="extensibility-linked-records">
+						<h4>Linked records</h4>
 
-					<p>Extending the manifest through links to a record, such as an ONIX&#160;[[onix]] or
-						BibTeX&#160;[[bibtex]] file, MUST be expressed using a <a href="#publication-link-def"
-								><code>LinkedResource</code></a> object, where:</p>
-					<ul>
-						<li> the <code>rel</code> value of the <a href="#publication-link-def"
-									><code>LinkedResource</code></a> SHOULD include a relevant identifier defined by
-							IANA or by other organizations; if the link record contains descriptive metadata it MUST
-							include the <code>describedby</code> (IANA) identifier; </li>
-						<li>the value of the <code>encodingFormat</code> in the link MUST use the MIME media
-							type&#160;[[!rfc2046]] defined for that particular type of record, if applicable.</li>
-					</ul>
+						<p>Extending the manifest through links to a record, such as an ONIX&#160;[[onix]] or
+							BibTeX&#160;[[bibtex]] file, MUST be expressed using a <a href="#publication-link-def"
+									><code>LinkedResource</code></a> object, where:</p>
+						<ul>
+							<li> the <code>rel</code> value of the <a href="#publication-link-def"
+										><code>LinkedResource</code></a> SHOULD include a relevant identifier defined by
+								IANA or by other organizations; if the link record contains descriptive metadata it MUST
+								include the <code>describedby</code> (IANA) identifier; </li>
+							<li>the value of the <code>encodingFormat</code> in the link MUST use the MIME media
+								type&#160;[[!rfc2046]] defined for that particular type of record, if applicable.</li>
+						</ul>
 
-					<p>Linked records MUST be included in the <a href="#resource-list">resource list</a> when they are
-						part of the Web Publication (i.e., are needed for more than just manifest extensibility).
-						Otherwise, they MUST be included in the <a href="#links">links list</a>.</p>
+						<p>Linked records MUST be included in the <a href="#resource-list">resource list</a> when they
+							are part of the publication (i.e., are needed for more than just manifest extensibility).
+							Otherwise, they MUST be included in the <a href="#links">links list</a>.</p>
 
-					<pre class="example" title="Link to external ONIX for Books Metadata file">
+						<pre class="example" title="Link to external ONIX for Books Metadata file">
 {
 "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
 "type"       : "Book",
@@ -3110,21 +2569,22 @@ partial dictionary WebPublicationManifest {
 &#8230;
 }
 </pre>
-					<p class="ednote">The <code>application/onix+xml</code> MIME type has not yet been registered by
-						IANA at the time of writing this document, and is included in the example for illustrative
-						purposes only.</p>
-				</section>
+						<p class="ednote">The <code>application/onix+xml</code> MIME type has not yet been registered by
+							IANA at the time of writing this document, and is included in the example for illustrative
+							purposes only.</p>
+					</section>
 
-				<section id="extensibility-manifest-properties">
-					<h5>Additional Properties in the Manifest</h5>
+					<section id="extensibility-manifest-properties">
+						<h4>Additional Properties in the Manifest</h4>
 
-					<p>Additional properties can be included directly in the manifest. It is RECOMMENDED that these
-						properties be taken from public schemes like [[schema.org]] or [[dcterms]] and use values from
-						controlled vocabularies whenever possible. Proprietary terms MAY be used, but it is RECOMMENDED
-						that such terms be included using <a href="https://www.w3.org/TR/json-ld/#compact-iris">Compact
-							IRIs</a>&#160;[[!json-ld]], with prefixes defined as part of the context.</p>
+						<p>Additional properties can be included directly in the manifest. It is RECOMMENDED that these
+							properties be taken from public schemes like [[schema.org]] or [[dcterms]] and use values
+							from controlled vocabularies whenever possible. Proprietary terms MAY be used, but it is
+							RECOMMENDED that such terms be included using <a
+								href="https://www.w3.org/TR/json-ld/#compact-iris">Compact IRIs</a>&#160;[[!json-ld]],
+							with prefixes defined as part of the context.</p>
 
-					<pre class="example" title="Usage of the schema.org 'copyrightYear' and 'copyrightHolder' terms, as an extension to the basic data">
+						<pre class="example" title="Usage of the schema.org 'copyrightYear' and 'copyrightHolder' terms, as an extension to the basic data">
 {
 "@context"        : ["https://schema.org","https://www.w3.org/ns/wp-context"],
 "type"            : "TechArticle",
@@ -3137,7 +2597,7 @@ partial dictionary WebPublicationManifest {
 }
 </pre>
 
-					<pre class="example" title="Usage of the Dublin Core 'subject' with the 2012 ACM Classification terms, as an extension to the basic data">
+						<pre class="example" title="Usage of the Dublin Core 'subject' with the 2012 ACM Classification terms, as an extension to the basic data">
 {
 "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
 "type"       : "CreativeWork",
@@ -3148,179 +2608,857 @@ partial dictionary WebPublicationManifest {
 &#8230;
 }
 </pre>
-					<p class="note"> A prefix definition <code>dc</code> for [[dcterms]] is included in the context file
-						of [[schema.org]]. This means that it is not necessary to add the prefix explicitly. The same is
-						true for a number of other public vocabularies; see the <a
-							href="https://schema.org/docs/jsonldcontext.json">schema.org context file</a> for further
-						details.</p>
+						<p class="note"> A prefix definition <code>dc</code> for [[dcterms]] is included in the context
+							file of [[schema.org]]. This means that it is not necessary to add the prefix explicitly.
+							The same is true for a number of other public vocabularies; see the <a
+								href="https://schema.org/docs/jsonldcontext.json">schema.org context file</a> for
+							further details.</p>
 
+					</section>
 				</section>
 			</section>
 		</section>
-		<section id="wp-lifecycle">
-			<h2>Web Publication Lifecycle</h2>
+		<section id="webpub" class="part">
+			<h2>PART II: Web Publications</h2>
 
-			<p class="note"> See the <a href="#app-lifecycle-diagrams">diagrams in the appendix</a> for a visual
-				representation of the lifecycle algorithm.</p>
+			<section id="wp-intro" class="informative">
+				<h3>Introduction</h3>
 
-			<section id="obtaining-manifest">
-				<h3>Obtaining a manifest</h3>
+				<p>A <a>Web Publication</a> is a discoverable and identifiable collection of resources. Information
+					about the Web Publication is expressed in its <a>manifest</a>, which is an implementation of the
+					format defined in <a href="#manifest"></a>. The manifest is what enables user agents to understand
+					the bounds of the Web Publication and the connection between its resources.</p>
 
-				<p>The <dfn data-lt="obtaining the manifest|obtaining a manifest|obtains a manifest">steps for obtaining
-						a manifest</dfn>, starting from the <a>primary entry page</a>, are given by the following
-					algorithm. The algorithm, if successful, returns a <a>processed manifest</a>; otherwise, it
-					terminates prematurely and returns nothing. In the case of nothing being returned, the user agent
-					MUST ignore the manifest declaration.</p>
+				<p>The manifest includes metadata that describe the Web Publication, as a publication has an identity
+					and nature beyond its constituent resources. The manifest also provides a list of all the resources
+					that belong to the Web Publication and a default reading order, which is how it connects resources
+					into a single contiguous work.</p>
 
-				<ol>
-					<li> From the <code>Document</code> of the top-level browsing context of the <a>primary entry
-							page</a>, let <var>origin</var> be the <code>Document</code>'s origin, and <var>manifest
-							link</var> be the first <code>link</code> element in tree order in <code>Document</code>
-						whose <code>rel</code> attribute contains the <code>publication</code> token. </li>
+				<p>A Web Publication is discoverable in one of two ways: resources either include a link to the manifest
+					(via an HTTP Link header or an HTML <code>link</code> element&#160;[[html]]), or the manifest can be
+					loaded directly by a compatible user agent.</p>
 
-					<li> If <var>origin</var> is an [[!html]] opaque origin, terminate this algorithm. </li>
+				<p>With the establishment of Web Publications, user agents can build new experiences tailored
+					specifically for their unique reading needs.</p>
 
-					<li> If <var>manifest link</var> is <code>null</code>, terminate this algorithm. </li>
-
-					<li> If <var>manifest link</var>'s <code>href</code> attribute's value is the empty string,
-						terminate this algorithm. </li>
-
-					<li> If <var>manifest link</var>'s <code>href</code> attribute's value is a relative URL, i.e., it
-						points to <var>origin</var> and it has a non-null <a data-cite="!url#concept-url-fragment"
-							>fragment</a> identifying an identifier <var>id</var> in <code>Document</code>: <ol>
-							<li> Let <var>embedded manifest script</var> be the first <code>script</code> element in
-								tree order, whose <code>id</code> attribute is equal to <var>id</var> and whose
-									<code>type</code> attribute is equal to <code>application/ld+json</code>. </li>
-							<li> If <var>embedded manifest script</var> is <code>null</code>, terminate this algorithm. </li>
-							<li> Let <var>text</var> be the <a data-cite="!dom#concept-child-text-content">child text
-									content</a> of <var>embedded manifest script</var>
-							</li>
-							<!-- <li>
-								Let <var>manifest URL</var> be set to <var>origin</var>
-							</li> -->
-							<li> Let <var>base</var> be the value of <a data-cite="!dom/#dom-node-baseuri">baseURI</a>
-								of the <code>script element</code>. </li>
-						</ol>
-						<details>
-							<summary>Explanation</summary>
-							<p>This branch is in use when the manifest is embedded in the primary entry page. The
-								algorithm locates the <code>script</code> element and extract the manifest itself. The
-								document's URL or, if set by the author, the value of a possible <code>base</code>
-								element will be used to turn relative URLs into absolute ones.</p>
-						</details>
-					</li>
-					<li>Otherwise: <ol>
-							<li> Let <var>manifest URL</var> be the result of parsing the value of the <code>href</code>
-								attribute, relative to the element's base URL. If parsing fails, then abort these steps. </li>
-							<li> Let <var>request</var> be a new [[!fetch]] request, whose URL is <var>manifest
-									URL</var>, and whose context is the same as the browsing context of the
-									<code>Document</code>. </li>
-							<li> If the <var>manifest link</var>'s <code>crossOrigin</code> attribute's value is
-									'<code>use-credentials</code>', then set <var>request</var>'s credentials to
-									'<code>include</code>'. </li>
-							<li> Await the result of performing a fetch with <var>request</var>, letting
-									<var>response</var> be the result. </li>
-							<li> If <var>response</var> is a network error, terminate this algorithm. </li>
-							<li> Let <var>text</var> be the result of UTF-8 decoding <var>response</var>'s <a
-									data-cite="!fetch#concept-request-body">body</a>. </li>
-							<li> Let <var>base</var> be the value of <var>manifest URL</var>. </li>
-						</ol>
-						<details>
-							<summary>Explanation</summary>
-							<p>This branch is in use when the manifest is in a separate file. It performs the standard
-								operations to retrieve the manifest from the Web; the URL of the manifest file will be
-								used to turn relative URLs into absolute ones.</p>
-						</details>
-					</li>
-
-					<li> Let <var>json</var> be the result of <a data-cite="!ecmascript#sec-json.parse">parsing</a>
-						<var>text</var>. If <a data-cite="!ecmascript#sec-json.parse">parsing</a> throws an error,
-						terminate this algorithm. </li>
-
-					<li> If Type(<var>json</var>) is not <code>Object</code>, terminate this algorithm. </li>
-
-					<li> Let <var>canonical manifest</var> be the <a>canonical manifest</a> derived from
-						<var>json</var>, using the values of <var>json</var>, <var>base</var>, and <code>Document</code>
-						as input to the algorithm described in <a href="#canonical-manifest"></a>. </li>
-
-					<li> Check whether the <var>canonical manifest</var> fulfills the minimal requirements for a Web
-						Publication Manifest, namely: <ul>
-							<li>The JSON-LD context is set (see <a href="#manifest-context"></a>)</li>
-							<li>The Publication type is set (see <a href="#manifest-pub-types"></a>)</li>
-							<li>The Publication address is set (see <a href="#address"></a>)</li>
-						</ul> If any of these requirements is not fulfilled, terminate the algorithm. </li>
-
-					<li> Let <var>processed manifest</var> be the result of running <a>processing a manifest</a> given
-							<var>canonical manifest</var>. </li>
-
-					<li>Return <var>processed manifest</var>. </li>
-				</ol>
-
-				<p class="note"> The algorithm does not describes how error and warning messages should be reported.
-					This is implementation dependent.</p>
-
+				<figure id="WP-diagram">
+					<object data="images/WP-diagram.svg" type="image/svg+xml" aria-describedby="wp-diagram-alt">
+						<p id="wp-diagram-alt">Flowchart depicts the resources of a Web Publication and their attachment
+							to a manifest.</p>
+					</object>
+					<figcaption>Simplified Diagram of the Structure of Web Publications. <br />A <a
+							href="#WP-diagram-descr">description of the structure diagram</a> is available in the
+						Appendix. Image available in <a href="images/WP-diagram.svg"
+							title="SVG image of the structure of Web Publications">SVG</a> and <a
+							title="PNG image of the structure of Web Publications" href="images/WP-diagram.png">PNG</a>
+						formats.</figcaption>
+				</figure>
 			</section>
 
-			<section id="canonical-manifest">
-				<h4>Generating a Canonical Manifest</h4>
+			<section id="conformance-classes">
+				<h3>Conformance Classes</h3>
 
-				<p>The steps to convert a Web Publication Manifest into a Canonical Manifest are given by the following
-					algorithm. The algorithm takes the following arguments:</p>
+				<p>This specification defines two conformance classes: one for <a>Web Publications</a> and one for user
+					agents that process them.</p>
+
+				<p id="wp-conformance">A Web Publication conforms to this specification if it meets the following
+					criteria:</p>
+
 				<ul>
-					<li>the <var>manifest</var> the JSON object that represent the <a>manifest</a></li>
-					<li>the <var>base</var> URL string, that represents the base URL for the manifest</li>
-					<li> the <var>document</var>
-						<a data-cite="!html#the-document-object">HTML Document (DOM) Node</a>, representing the
-							<a>primary entry page</a>
-					</li>
+					<li>it has a <a>manifest</a> that conforms to <a href="#wp-manifest"></a>;</li>
+					<li>it adheres to the construction requirements defined in <a href="#pub-construction"></a>.</li>
 				</ul>
 
-				<p>The steps of the algorithm are described below. As an abuse of notation, <var>P["term"]</var> refers
-					to the value in the object <var>P</var> for the label <var>"term"</var>, where <var>P</var> is
-					either <var>manifest</var>, or an object appearing within <var>manifest</var> (e.g., a
-						<var>Person</var>). The algorithm replaces or adds some terms to <var>manifest</var>; the
-					replacement terms are expressed in JSON syntax as <code class="json">{"term":"value"}</code>.</p>
-				<ol>
-					<li>let <var>lang</var> string represent the default language, set to: <ul>
-							<li> the value of the <a data-cite="!html#the-lang-and-xml:lang-attributes"
-										><code>lang</code> value</a> for the <code>script</code> element in the
-									<a>primary entry page</a>, in case the manifest is <a href="#manifest-embedding"
-									>embedded</a>; or </li>
-							<li><code>undefined</code> otherwise</li>
+				<p id="ua-conformance">A user agent conforms to this specification if it meets the following
+					criteria:</p>
+
+				<ul>
+					<li>it is capable of <a href="#obtaining-manifest">obtaining a conforming manifest</a> for a Web
+						Publication.</li>
+				</ul>
+			</section>
+
+			<section id="wp-construction">
+				<h3>Web Publication Construction</h3>
+
+				<section id="wp-bounds">
+					<h4>Publication Bounds</h4>
+
+					<p>A Web Publication consists of a finite set of <a href="#wp-resources">resources</a> that
+						represent its content. This extent is known as its bounds and is defined within its manifest —
+						it is obtained from the union of resources listed in the <a href="#default-reading-order"
+							>default reading order</a> and <a href="#resource-list">resource list</a>.</p>
+
+					<p>To determine whether a resource is within the bounds of a Web Publication, user agents MUST
+						compare the absolute URL of a resource to the absolute URLs of the resources obtained from the
+						union. If the resource is identified in the enumeration, it is within the bounds of the Web
+						Publication. All other resources are external to the Web Publication.</p>
+
+					<p>Resources within the bounds of a Web Publication do not have to share the same domain.</p>
+				</section>
+
+				<section id="wp-resources">
+					<h4>Resources</h4>
+
+					<p>A <a>Web Publication</a> MUST include at least one HTML document&#160;[[!html]]—the <a>primary
+							entry page</a>.</p>
+
+					<p>Otherwise, a Web Publication MAY references resources of any media type, both in the <a>default
+							reading order</a> and as dependencies of other resources.</p>
+
+					<p class="note">When adding resources to a Web Publication, consider support in user agents. The use
+						of progressive enhancement techniques and the provision of fallback content, as appropriate,
+						will ensure a more consistent reading experience for users regardless of their preferred user
+						agent.</p>
+				</section>
+
+				<section id="primary-entry-page">
+					<h4>Primary Entry Page</h4>
+
+					<p>The <dfn>primary entry page</dfn> represents the preferred starting <a href="#pub-resources"
+							>resource</a> for a Web Publication and enables discovery of its <a>manifest</a>. It is the
+						resource that is returned when accessing the Web Publication's <a>address</a>, and MUST be
+						included in either the <a>default reading order</a> or the <a>resource list</a>.</p>
+
+					<p>Although any resource can link to the manifest, the primary entry page typically introduces the
+						Web Publication and provides access to the content. It might contain all the content, in the
+						case of a single-page Web Publication, or provide navigational aids to begin reading a
+						multi-document Web Publication. To facilitate the user ease of consumption, the primary entry
+						page SHOULD contain the <a href="#table-of-contents">table of contents</a>.</p>
+
+					<p>It is not required that the primary entry page be included in the <a
+							href="#default-reading-order">default reading order</a>, nor that it be the first document
+						listed when it is included. This specification leaves the exact nature of the document
+						intentionally underspecified to provide flexibility for different approaches. If a default
+						reading order is not provided, however, user agents will <a href="#no-reading-order">create one
+							using the primary entry page</a>.</p>
+
+					<p>The primary entry page is the only resource in which <a href="#manifest-embedding">a manifest can
+							be embedded</a>. To ensure discovery of the manifest, the primary entry page MUST provide a
+							<a href="#manifest-linking">link to the manifest</a>, regardless of whether the manifest is
+						embedded within the page or external to it.</p>
+
+					<p>The address of the primary entry page is also the <a>canonical identifier</a> for the Web
+						Publication (i.e., it serves as its unique identifier).</p>
+
+					<p>In certain cases where information has been omitted from the manifest, user agents will sometimes
+						use the primary entry page as a fallback source of information (see <a href="#language-and-dir"
+							>language and base direction</a> and <a href="#wp-title">title</a>).</p>
+				</section>
+
+				<section id="table-of-contents">
+					<h4>Table of Contents</h4>
+
+					<p>The table of contents provides a hierarchical list of links that reflects the structural outline
+						of the major sections of the Web Publication.</p>
+
+					<p>The table of contents is expressed via an [[!html]]&#160;element (typically a <a
+							href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code>
+						element</a>) in one of the <a href="#pub-resources">resources</a>. This element MUST be
+						identified by the <code>role</code> attribute&#160;[[!html]] value
+						"<code>doc-toc</code>"&#160;[[!dpub-aria-1.0]], and MUST be the first element in the document —
+						in <a href="https://dom.spec.whatwg.org/#concept-tree-order">document tree
+						order</a>&#160;[[!dom]] — with that <code>role</code> value.</p>
+
+					<p>If the table of contents is not located in the <a href="#primary-entry-page">primary entry
+							page</a>, the manifest SHOULD <a href="#table-of-contents">identify the resource</a> that
+						contains the structure.</p>
+
+					<p> When specified, the table of content MUST include a link to at least one <a
+							href="#pub-resources">resource</a>, and all links SHOULD refer to <a href="#pub-resources"
+							>resources</a> within <a href="#pub-bounds">publication bounds</a>. </p>
+
+					<p>Refer to the <a href="#table-of-contents">table of contents property definition</a> for more
+						information on how to identify which resource contains the table of contents.</p>
+
+				</section>
+
+				<section id="pagelist">
+					<h4>Page List</h4>
+
+					<p>The page list is a list of links that provides navigation to static page demarcation points
+						within the content. These locations allow users to coordinate access into the content, but the
+						exact nature of the locations is left to content creators to define. They usually correspond to
+						pages of a print document which is the source of the Web Publication, but might be a purely
+						digital creation added to ease navigation.</p>
+
+					<p>The page list is expressed via an [[!html]] element (typically a <a
+							href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code>
+						element</a>) in one of the <a href="#pub-resources">resources</a>. This element MUST be
+						identified by the <code>role</code> attribute&#160;[[!html]] value
+						"<code>doc-pagelist</code>"&#160;[[!dpub-aria-1.0]], and MUST be the first element in the
+						document — in <a href="https://dom.spec.whatwg.org/#concept-tree-order">document tree
+						order</a>&#160;[[!dom]] — with that <code>role</code> value.</p>
+
+					<p>If the page list is not located in the <a href="#primary-entry-page">primary entry page</a>, the
+						manifest SHOULD <a href="#page-list">identify the resource</a> that contains the structure.</p>
+
+					<p>There are no requirements on the page list itself, except that, when specified, it MUST include a
+						link to at least one <a href="#pub-resources">resource</a>.</p>
+
+					<p>Refer to the <a href="#page-list"><code>pagelist</code> property definition</a> for more
+						information on how to identify which resource contains the page list.</p>
+				</section>
+			</section>
+
+			<section id="wp-manifest">
+				<h3>Manifest</h3>
+
+				<section id="wp-properties">
+					<h4>Properties</h4>
+
+					<section id="wp-requirements">
+						<h5>Requirements</h5>
+
+						<p>The expression of properties in a Web Publication manifest includes a combination of those <a
+								href="#manifest-properties">defined generally for digital publications</a> as well as
+							two specific to Web Publications: the publication's <a href="#address">address</a> and <a
+								href="#canonical-identifier">canonical identifier</a>.</p>
+
+						<p>The requirements for the expression of these properties are as follows:</p>
+
+						<dl>
+							<dt>REQUIRED:</dt>
+							<dd>
+								<ul>
+									<li>
+										<a href="#address">address</a>
+									</li>
+									<li>
+										<a href="#wp-reading-order">default reading order</a>
+									</li>
+									<li>
+										<a href="#wp-title">title</a>
+									</li>
+								</ul>
+							</dd>
+							<dt>RECOMMENDED:</dt>
+							<dd>
+								<ul>
+									<li>
+										<a href="#accessibility">accessibility</a>
+									</li>
+									<li>
+										<a href="#accessibility-report">accessibility report</a>
+									</li>
+									<li>
+										<a href="#language-and-dir">base direction</a>
+									</li>
+									<li>
+										<a href="#canonical-identifier">canonical identifier</a>
+									</li>
+									<li>
+										<a href="#cover">cover</a>
+									</li>
+									<li>
+										<a href="#creators">creators</a>
+									</li>
+									<li>
+										<a href="#language-and-dir">language and base direction</a>
+									</li>
+									<li>
+										<a href="#links">links</a>
+									</li>
+									<li>
+										<a href="#last-modification-date">last modification date</a>
+									</li>
+									<li>
+										<a href="#publication-date">publication date</a>
+									</li>
+									<li>
+										<a href="#privacy-policy">privacy policy</a>
+									</li>
+									<li>
+										<a href="#reading-progression-direction">reading progression direction</a>
+									</li>
+									<li>
+										<a href="#resource-list">resource list</a>
+									</li>
+									<li>
+										<a href="#table-of-contents">table of contents</a>
+									</li>
+									<li>
+										<a href="#page-list">page list</a>
+									</li>
+								</ul>
+							</dd>
+						</dl>
+
+						<p>These properties do not all have to be serialized in the <a>authored manifest</a>. Refer to
+							each property's definition to determine whether it is required in the manifest or can be
+							compiled into the <a>canonical manifest</a> from other information.</p>
+					</section>
+
+					<section id="address">
+						<h4>Address</h4>
+
+						<p>A Web Publication's <dfn>address</dfn> is a <abbr title="Uniform Resource Locator"
+							>URL</abbr>&#160;[[!url]] that represents the <a>primary entry page</a> for the Web
+							Publication. It is expressed using the <code>url</code> property.</p>
+
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th>Term</th>
+									<th>Description</th>
+									<th>Required Value</th>
+									<th>[[!schema.org]] Mapping</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code>url</code>
+									</td>
+									<td>URL of the primary entry page.</td>
+									<td>A URL [[!url]].</td>
+									<td>
+										<a href="https://schema.org/url"><code>url</code></a> (<a
+											href="https://schema.org/Thing">Thing</a>) </td>
+								</tr>
+							</tbody>
+						</table>
+
+						<p>If the address does not resolve to an <abbr title="Hypertext Markup Language">HTML</abbr>
+							document&#160;[[!html]], user agents SHOULD NOT provide access to the resource to users. A
+							Web Publication MAY have more than one address, but all the addresses MUST resolve to the
+							same document.</p>
+
+						<p>The referenced document SHOULD be a resource of the Web Publication. It can be any resource,
+							including one that is not listed in the <a>default reading order</a>. This document MUST
+							include a <a href="#manifest-linking">link to the manifest</a> to ensure a bidirectional
+							linking relationship (i.e., that user agents can also locate the manifest from the document
+							at the address).</p>
+
+						<p>If the document is not a publication resource, user agents SHOULD load the first document in
+							the <a>default reading order</a> when initiating the publication.</p>
+
+						<p class="note"> To improve the usability of publications, particularly in user agents that do
+							not support them, authors are encouraged to include navigation aids in the referenced
+							document that facilitate consumption of the content, (e.g., provide a table of contents or a
+							link to one).</p>
+
+						<div class="note">The publication's address can also be used as value for an identifier link
+							relation&#160;[[link-relation]].</div>
+
+						<pre class="example" title="Setting the address of the main entry page">
+{
+    "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
+    "type"     : "Book",
+    &#8230;
+    "url"      : "https://publisher.example.org/mobydick",
+    &#8230;
+}
+</pre>
+					</section>
+
+					<section id="canonical-identifier">
+						<h5>Canonical Identifier</h5>
+
+						<p>A Web Publication's <dfn>canonical identifier</dfn> is a unique identifier that resolves to
+							the preferred version of the Web Publication. It is expressed using the <code>id</code>
+							property.</p>
+
+						<table class="zebra">
+							<thead>
+								<tr>
+									<th>Term</th>
+									<th>Description</th>
+									<th>Required Value</th>
+									<th>[[!schema.org]] Mapping</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code>id</code>
+									</td>
+									<td>Preferred version of the publication.</td>
+									<td>A URL [[!url]].</td>
+									<td>(None)</td>
+								</tr>
+							</tbody>
+						</table>
+
+						<p class="note">Ensuring uniqueness of canonical identifiers is outside the scope of this
+							specification. The actual achievable uniqueness depends on such factors as the conventions
+							of the identifier scheme used and the degree of control over assignment of identifiers.</p>
+
+						<p>The canonical identifier is intended to provide a measure of permanence above and beyond the
+							Web Publication's <a href="#address">address(es)</a>. If a Web Publication is permanently
+							relocated to a new URL, for example, the canonical identifier provides a way of discovering
+							the new location (e.g., a <abbr title="Digital Object Identifier">DOI</abbr> registry could
+							be updated with the new <abbr title="Uniform Resource Locator">URL</abbr>, or a redirect
+							could be added to the <abbr title="Uniform Resource Locator">URL</abbr> of the canonical
+							identifier). It is also intended to provide a means of identifying instances of the same Web
+							Publication hosted at different URLs.</p>
+
+						<p>If a URL is not provided in the manifest, or the value is an invalid URL, the Web Publication
+							does not have a canonical identifier. User agents MUST NOT attempt to construct a canonical
+							identifier from any other identifiers provided in the manifest for the canonical
+							manifest.</p>
+
+						<p>The specification of the canonical identifier MAY be complemented by the inclusion of
+							additional types of identifiers for the Web Publication using the <a
+								href="https://schema.org/identifier"><code>identifier</code>
+							property</a>&#160;[[!schema.org]] and/or its subtypes.</p>
+
+						<pre class="example" title="Example for setting both the canonical identifier as URL and the address of the same document">
+{
+    "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
+    "type"     : "TechArticle",
+    &#8230;
+    "id"       : "http://www.w3.org/TR/tabular-data-model/",
+    "url"      : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
+    &#8230;
+}
+</pre>
+
+						<pre class="example" title="Example for setting both the ISBN and the address of the same document">
+{
+    "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
+    "type"     : "Book",
+    &#8230;
+    "isbn"     : "9780123456789",
+    "url"      : "https://publisher.example.org/mobydick",
+    &#8230;
+}
+</pre>
+
+					</section>
+
+					<section id="wp-reading-order">
+						<h5>Default Reading Order</h5>
+
+						<p>The Web Publication <code>readingOrder</code> property extends the <a
+								href="#default-reading-order">Publication Manifest <code>readingOrder</code>
+								property</a> in the following ways:</p>
+
+						<ul>
+							<li>The <a href="reading-order">default reading order</a> MAY be omitted when it only
+								consists of the <a>primary entry page</a>. When the default reading order is absent,
+								user agents MUST include an entry for the primary entry page when compiling the
+								canonical manifest.</li>
 						</ul>
-						<details>
-							<summary> Explanation </summary>
-							<p>This value is used in <a href="#can-set-lang">the step on language</a> below.</p>
-						</details>
-					</li>
-					<li> let <var>dir</var> string represents the base direction, set to: <ul>
-							<li> the value of the <a data-cite="!html#the-dir-attribute"><code>dir</code> value</a> for
-								the <code>script</code> element in the <a>primary entry page</a>, in case the manifest
-								is <a href="#manifest-embedding">embedded</a>; or </li>
-							<li><code>undefined</code> otherwise</li>
-						</ul>
-						<details>
-							<summary> Explanation </summary>
-							<p>This value is used in <a href="#can-set-dir">the step on base direction</a> below.</p>
-						</details>
-					</li>
-					<li> (<a href="#wp-title"></a>) if <var>manifest["name"]</var> is <code>undefined</code>, then
-						locate the <a data-cite="!html#the-title-element"><code>title</code></a> HTML element using
-							<var>document</var>. If that element exists and is non-empty, let <var>t</var> be its text
-						content, and add to <var>manifest</var>: <ul>
-							<li> if the language of <code>title</code> is explicitly <a
-									data-cite="!html#the-lang-and-xml:lang-attributes">set</a> to the value of
-									<var>l</var>, then add <br />
-								<code class="json">"name": [{"value": t, "language": l}]</code>
+					</section>
+
+					<section id="wp-page-list">
+						<h5>Page List</h5>
+
+						<p>The Web Publication <code>pagelist</code> property extends the <a href="#page-list"
+								>Publication Manifest <code>pagelist</code> property</a> as described in this
+							section.</p>
+
+						<p>The <code>pagelist</code> property MUST identify a resource that contains the page list for
+							the Web Publication. It MUST NOT be used to embed a page list in the manifest.</p>
+
+						<p>User agents MUST compute the <code>pagelist</code> as follows:</p>
+
+						<ol>
+							<li>Identify the page list resource: <ul>
+									<li> If a resource in either the <a href="#default-reading-order">default reading
+											order</a> or <a href="#resource-list">resource-list</a> is identified with a
+											<code>rel</code> value including
+											<code>https://www.w3.org/ns/wp#pagelist</code>, the corresponding
+											<code>url</code> value identifies the page list resource. If there are
+										several such resources, the first one MUST be used, with the <a
+											href="#default-reading-order">default reading order</a> taking precedence
+										over <a href="#resource-list">resource-list</a>. </li>
+									<li> Otherwise, the <a>primary entry page</a> is the page list resource. </li>
+								</ul>
 							</li>
-							<li>or <br />
-								<code class="json">"name": [t]</code><br /> otherwise </li>
+							<li> If the page list resource contains an HTML element with the
+								<code>role</code>&#160;[[!html]] value
+								<code>doc-pagelist</code>&#160;[[!dpub-aria-1.0]], the user agent MUST use that element
+								as the page list. If there are several such HTML elements the user agent MUST use the
+								first in <a href="https://dom.spec.whatwg.org/#concept-tree-order">document tree
+									order</a>&#160;[[!dom]]. </li>
+						</ol>
+
+						<p>If this process does not result in a link to the page list, the publication does not have a
+							page list and this property MUST NOT be included in the canonical manifest.</p>
+
+						<p class="ednote">The Working Group will attempt to define the <code>pagelist</code> term by
+							IANA, to avoid using a URL.</p>
+
+						<pre class="example" title="Pagelist identified in another resource of the publication">
+{
+"@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
+"type"       : "Book",
+&#8230;
+"url"        : "https://publisher.example.org/mobydick",
+"name"       : "Moby Dick",
+"resources"  : [{
+	"type"       : "LinkedResource",
+	"url"        : "toc_file.html",
+	"rel"        : "https://www.w3.org/ns/wp#pagelist"
+},{
+	&#8230;
+}],
+&#8230;
+}
+</pre>
+					</section>
+
+					<section id="wp-title">
+						<h5>Title</h5>
+
+						<p>The Web Publication <code>title</code> property extends the <a href="#pub-title">Publication
+								Manifest <code>title</code> property</a> in the following ways:</p>
+
+						<ul>
+							<li>If a <a href="pub-title">title</a> is not included in the <a>authored manifest</a>, the
+								user agent MUST use the value of the <a data-cite="!html#the-title-element"
+										><code>title</code> element</a>&#160;[[!html]] of the Web Publication's
+									<a>primary entry page</a>, if present, when generating the <a>canonical
+								manifest</a>.</li>
 						</ul>
-						<details>
-							<summary>Explanation</summary>
-							<p>This step ensures that the <code>title</code> element's content in the primary entry page
-								can be used, as a default, as the title of the publication. For example,</p>
-							<pre class="example">
+
+						<p class="note">Relying on the <code>title</code> element could be semantically problematic if
+							the Web Publication consists of several HTML resources (e.g., one per chapter of a book),
+							because the <a data-cite="!html#the-title-element">HTML definition</a> defines this element
+							as "metadata" for the enclosing HTML document, not for a collection of resources. Using this
+							element is, on the other hand, preferred in the case of a Web Publication consisting of a
+							single HTML document (e.g., a scholarly journal article).</p>
+					</section>
+
+					<section id="wp-table-of-contents">
+						<h5>Table of Contents</h5>
+
+						<p>The Web Publication <code>contents</code> property extends the <a
+								href="#pub-table-of-contents">Publication Manifest <code>contents</code> property</a> as
+							described in this section.</p>
+
+						<p>The <code>contents</code> property MUST identify a resource that contains the page list for
+							the Web Publication. It MUST NOT be used to embed a page list in the manifest.</p>
+
+						<p>User agents MUST compute the <code>toc</code> as follows:</p>
+
+						<ol>
+							<li>Identify the table of contents resource: <ul>
+									<li> If a resource in either the <a href="#default-reading-order">default reading
+											order</a> or <a href="#resource-list">resource-list</a> is identified with a
+											<code>rel</code> value including
+										<code>contents</code>&#160;[[!iana-link-relations]], the corresponding
+											<code>url</code> value identifies the table of contents resource. If there
+										are several such resources, the first one MUST be used, with the <a
+											href="#default-reading-order">default reading order</a> taking precedence
+										over <a href="#resource-list">resource-list</a>. </li>
+									<li> Otherwise, the <a>primary entry page</a> is the table of contents resource.
+									</li>
+								</ul>
+							</li>
+							<li> If the table of contents resource contains an HTML element with the
+								<code>role</code>&#160;[[!html]] value <code>doc-toc</code>&#160;[[!dpub-aria-1.0]], the
+								user agent MUST use that element as the table of contents. If there are several such
+								HTML elements the user agent MUST use the first in <a
+									href="https://dom.spec.whatwg.org/#concept-tree-order">document tree
+								order</a>&#160;[[!dom]]. </li>
+						</ol>
+
+						<p>If this process does not result in a link to the table of contents, the publication does not
+							have a table of contents and this property MUST NOT be included in the canonical
+							manifest.</p>
+
+						<p>See the separate section <a href="#app-toc-structure"></a> for the HTML structure that the
+							table of content SHOULD adhere to.</p>
+
+						<pre class="example" title="Table of content identified in another resource of the publication">
+{
+    "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
+    "type"       : "Book",
+    &#8230;
+    "url"        : "https://publisher.example.org/mobydick",
+    "name"       : "Moby Dick",
+    "resources"  : [{
+        "type"       : "LinkedResource",
+        "url"        : "toc_file.html",
+        "rel"        : "contents"
+    },{
+        &#8230;
+    }],
+    &#8230;
+}
+</pre>
+
+						<pre class="example" title="If the primary entry page includes the TOC, no reference in the manifest is necessary">
+&lt;head&gt;
+    &#8230;
+    &lt;script type="application/ld+json"&gt;
+    {
+        "@context"        : ["https://schema.org","https://www.w3.org/ns/wp-context"],
+        "type"            : "TechArticle",
+        &#8230;
+        "id"              : "http://www.w3.org/TR/tabular-data-model/",
+        "url"             : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
+        &#8230;
+    }
+    &lt;/script&gt;
+    &#8230;
+&lt;/head&gt;
+&lt;body&gt;
+    &#8230;
+    &lt;section role="doc-toc"&gt;
+        &#8230;
+    &lt;/section&gt;
+    &#8230;
+&lt;/body&gt;
+</pre>
+					</section>
+				</section>
+
+				<section id="wp-manifest-assoc">
+					<h3>Association</h3>
+
+					<section id="wp-manifest-embedding">
+						<h4>Embedding</h4>
+
+						<p>A manifest MAY be embedded only in the <a href="#primary-entry-page">primary entry page</a>.
+							In this case, the manifest MUST be included in a <a
+								href="https://www.w3.org/TR/html5/semantics-scripting.html#the-script-element"
+									><code>script</code> element</a>&#160;[[!html]] whose <code>type</code> attribute is
+							set to <code>application/ld+json</code>.</p>
+
+						<p>Additionally, the <code>script</code> element MUST include a unique identifier in an
+								<code>id</code> attribute&#160;[[!html]]. This identifier ensures that the manifest <a
+								href="#manifest-linking">can be referenced</a>.</p>
+
+						<pre class="example" title="A Web Publication Manifest included in an HTML document">
+&lt;script id="example_manifest" type="application/ld+json"&gt;
+   {
+      &#8230;
+   }
+&lt;/script&gt;
+</pre>
+					</section>
+
+					<section id="wp-manifest-linking">
+						<h4>Linking</h4>
+
+						<p>With the exception of the <a>primary entry page</a>, linking a resource to its manifest is
+							OPTIONAL. Including a link is encouraged whenever possible, however, as it allows user
+							agents to immediately ascertain that a resource belongs to a Web Publication regardless of
+							how the user reaches the resource.</p>
+
+						<p>Links to a Web Publication Manifest MUST take one or both of the following forms:</p>
+
+						<ul>
+							<li>
+								<p>An HTTP <code>Link</code> header field&#160;[[!rfc5988]] with its <code>rel</code>
+									parameter set to the value "<code>publication</code>".</p>
+								<pre class="example">Link: &lt;https://example.com/webpub/manifest>; rel=publication</pre>
+							</li>
+							<li>
+								<p>A <code>link</code> element&#160;[[!html]] with its <code>rel</code> attribute set to
+									the value "<code>publication</code>".</p>
+								<pre class="example">&lt;link href="https://example.com/webpub/manifest" rel="publication"/></pre>
+							</li>
+						</ul>
+
+						<p>When a manifest is embedded within an HTML document, the link MUST include a fragment
+							identifier that references the <code>script</code> element that contains the manifest (see
+								<a href="#manifest-embedding"></a>).</p>
+
+						<pre class="example" title="Link to a manifest within the same HTML resource">
+	&lt;link href="#example_manifest" rel="publication"&gt;
+	&#8230;
+	&lt;script id="example_manifest" type="application/ld+json"&gt;
+	{
+        "@context" : ["https://schema.org", "https://www.w3.org/ns/wp-context"],
+        &#8230;
+	}
+	&lt;/script&gt;
+</pre>
+
+						<p class="issue" data-number="132">The exact value of <code>rel</code> is still to be agreed
+							upon and should be registered by IANA.</p>
+
+						<p class="ednote">The following details might be moved to the lifecycle section in a future
+							draft.</p>
+
+						<p>When a resource links to multiple manifests, a user agent MAY choose to present one or more
+							alternatives to the end user, or choose a single alternative on its own. The user agent MAY
+							choose to present any manifest based upon information that it possesses, even one that is
+							not explicitly listed as a parent (e.g., based upon information it calculates or acquires
+							out of band). In the absence of a preference by user agent implementers, selection of the
+							first manifest listed is suggested as a default.</p>
+
+					</section>
+				</section>
+			</section>
+
+			<section id="wp-lifecycle">
+				<h3>Web Publication Lifecycle</h3>
+
+				<p class="note"> See the <a href="#app-lifecycle-diagrams">diagrams in the appendix</a> for a visual
+					representation of the lifecycle algorithm.</p>
+
+				<section id="obtaining-manifest">
+					<h4>Obtaining a manifest</h4>
+
+					<p>The <dfn data-lt="obtaining the manifest|obtaining a manifest|obtains a manifest">steps for
+							obtaining a manifest</dfn>, starting from the <a>primary entry page</a>, are given by the
+						following algorithm. The algorithm, if successful, returns a <a>processed manifest</a>;
+						otherwise, it terminates prematurely and returns nothing. In the case of nothing being returned,
+						the user agent MUST ignore the manifest declaration.</p>
+
+					<ol>
+						<li> From the <code>Document</code> of the top-level browsing context of the <a>primary entry
+								page</a>, let <var>origin</var> be the <code>Document</code>'s origin, and <var>manifest
+								link</var> be the first <code>link</code> element in tree order in <code>Document</code>
+							whose <code>rel</code> attribute contains the <code>publication</code> token. </li>
+
+						<li> If <var>origin</var> is an [[!html]] opaque origin, terminate this algorithm. </li>
+
+						<li> If <var>manifest link</var> is <code>null</code>, terminate this algorithm. </li>
+
+						<li> If <var>manifest link</var>'s <code>href</code> attribute's value is the empty string,
+							terminate this algorithm. </li>
+
+						<li> If <var>manifest link</var>'s <code>href</code> attribute's value is a relative URL, i.e.,
+							it points to <var>origin</var> and it has a non-null <a
+								data-cite="!url#concept-url-fragment">fragment</a> identifying an identifier
+								<var>id</var> in <code>Document</code>: <ol>
+								<li> Let <var>embedded manifest script</var> be the first <code>script</code> element in
+									tree order, whose <code>id</code> attribute is equal to <var>id</var> and whose
+										<code>type</code> attribute is equal to <code>application/ld+json</code>. </li>
+								<li> If <var>embedded manifest script</var> is <code>null</code>, terminate this
+									algorithm. </li>
+								<li> Let <var>text</var> be the <a data-cite="!dom#concept-child-text-content">child
+										text content</a> of <var>embedded manifest script</var>
+								</li>
+								<!-- <li>
+								Let <var>manifest URL</var> be set to <var>origin</var>
+							</li> -->
+								<li> Let <var>base</var> be the value of <a data-cite="!dom/#dom-node-baseuri"
+										>baseURI</a> of the <code>script element</code>. </li>
+							</ol>
+							<details>
+								<summary>Explanation</summary>
+								<p>This branch is in use when the manifest is embedded in the primary entry page. The
+									algorithm locates the <code>script</code> element and extract the manifest itself.
+									The document's URL or, if set by the author, the value of a possible
+										<code>base</code> element will be used to turn relative URLs into absolute
+									ones.</p>
+							</details>
+						</li>
+						<li>Otherwise: <ol>
+								<li> Let <var>manifest URL</var> be the result of parsing the value of the
+										<code>href</code> attribute, relative to the element's base URL. If parsing
+									fails, then abort these steps. </li>
+								<li> Let <var>request</var> be a new [[!fetch]] request, whose URL is <var>manifest
+										URL</var>, and whose context is the same as the browsing context of the
+										<code>Document</code>. </li>
+								<li> If the <var>manifest link</var>'s <code>crossOrigin</code> attribute's value is
+										'<code>use-credentials</code>', then set <var>request</var>'s credentials to
+										'<code>include</code>'. </li>
+								<li> Await the result of performing a fetch with <var>request</var>, letting
+										<var>response</var> be the result. </li>
+								<li> If <var>response</var> is a network error, terminate this algorithm. </li>
+								<li> Let <var>text</var> be the result of UTF-8 decoding <var>response</var>'s <a
+										data-cite="!fetch#concept-request-body">body</a>. </li>
+								<li> Let <var>base</var> be the value of <var>manifest URL</var>. </li>
+							</ol>
+							<details>
+								<summary>Explanation</summary>
+								<p>This branch is in use when the manifest is in a separate file. It performs the
+									standard operations to retrieve the manifest from the Web; the URL of the manifest
+									file will be used to turn relative URLs into absolute ones.</p>
+							</details>
+						</li>
+
+						<li> Let <var>json</var> be the result of <a data-cite="!ecmascript#sec-json.parse">parsing</a>
+							<var>text</var>. If <a data-cite="!ecmascript#sec-json.parse">parsing</a> throws an error,
+							terminate this algorithm. </li>
+
+						<li> If Type(<var>json</var>) is not <code>Object</code>, terminate this algorithm. </li>
+
+						<li> Let <var>canonical manifest</var> be the <a>canonical manifest</a> derived from
+								<var>json</var>, using the values of <var>json</var>, <var>base</var>, and
+								<code>Document</code> as input to the algorithm described in <a
+								href="#canonical-manifest"></a>. </li>
+
+						<li> Check whether the <var>canonical manifest</var> fulfills the minimal requirements for a Web
+							Publication Manifest, namely: <ul>
+								<li>The JSON-LD context is set (see <a href="#manifest-context"></a>)</li>
+								<li>The Publication type is set (see <a href="#publication-types"></a>)</li>
+								<li>The Publication address is set (see <a href="#address"></a>)</li>
+							</ul> If any of these requirements is not fulfilled, terminate the algorithm. </li>
+
+						<li> Let <var>processed manifest</var> be the result of running <a>processing a manifest</a>
+							given <var>canonical manifest</var>. </li>
+
+						<li>Return <var>processed manifest</var>. </li>
+					</ol>
+
+					<p class="note"> The algorithm does not describes how error and warning messages should be reported.
+						This is implementation dependent.</p>
+
+				</section>
+
+				<section id="canonical-manifest">
+					<h4>Generating a Canonical Manifest</h4>
+
+					<p>The steps to convert a Web Publication Manifest into a Canonical Manifest are given by the
+						following algorithm. The algorithm takes the following arguments:</p>
+					<ul>
+						<li>the <var>manifest</var> the JSON object that represent the <a>manifest</a></li>
+						<li>the <var>base</var> URL string, that represents the base URL for the manifest</li>
+						<li> the <var>document</var>
+							<a data-cite="!html#the-document-object">HTML Document (DOM) Node</a>, representing the
+								<a>primary entry page</a>
+						</li>
+					</ul>
+
+					<p>The steps of the algorithm are described below. As an abuse of notation, <var>P["term"]</var>
+						refers to the value in the object <var>P</var> for the label <var>"term"</var>, where
+							<var>P</var> is either <var>manifest</var>, or an object appearing within
+							<var>manifest</var> (e.g., a <var>Person</var>). The algorithm replaces or adds some terms
+						to <var>manifest</var>; the replacement terms are expressed in JSON syntax as <code class="json"
+							>{"term":"value"}</code>.</p>
+					<ol>
+						<li>let <var>lang</var> string represent the default language, set to: <ul>
+								<li> the value of the <a data-cite="!html#the-lang-and-xml:lang-attributes"
+											><code>lang</code> value</a> for the <code>script</code> element in the
+										<a>primary entry page</a>, in case the manifest is <a href="#manifest-embedding"
+										>embedded</a>; or </li>
+								<li><code>undefined</code> otherwise</li>
+							</ul>
+							<details>
+								<summary> Explanation </summary>
+								<p>This value is used in <a href="#can-set-lang">the step on language</a> below.</p>
+							</details>
+						</li>
+						<li> let <var>dir</var> string represents the base direction, set to: <ul>
+								<li> the value of the <a data-cite="!html#the-dir-attribute"><code>dir</code> value</a>
+									for the <code>script</code> element in the <a>primary entry page</a>, in case the
+									manifest is <a href="#manifest-embedding">embedded</a>; or </li>
+								<li><code>undefined</code> otherwise</li>
+							</ul>
+							<details>
+								<summary> Explanation </summary>
+								<p>This value is used in <a href="#can-set-dir">the step on base direction</a>
+									below.</p>
+							</details>
+						</li>
+						<li> (<a href="#pub-title"></a>) if <var>manifest["name"]</var> is <code>undefined</code>, then
+							locate the <a data-cite="!html#the-title-element"><code>title</code></a> HTML element using
+								<var>document</var>. If that element exists and is non-empty, let <var>t</var> be its
+							text content, and add to <var>manifest</var>: <ul>
+								<li> if the language of <code>title</code> is explicitly <a
+										data-cite="!html#the-lang-and-xml:lang-attributes">set</a> to the value of
+										<var>l</var>, then add <br />
+									<code class="json">"name": [{"value": t, "language": l}]</code>
+								</li>
+								<li>or <br />
+									<code class="json">"name": [t]</code><br /> otherwise </li>
+							</ul>
+							<details>
+								<summary>Explanation</summary>
+								<p>This step ensures that the <code>title</code> element's content in the primary entry
+									page can be used, as a default, as the title of the Web Publication. For
+									example,</p>
+								<pre class="example">
 &lt;html&gt;
 &lt;head&gt;
     &lt;title&gt;Moby Dick&lt;/title&gt;
@@ -3332,25 +3470,25 @@ partial dictionary WebPublicationManifest {
     }
     &lt;/script&gt;
 			                    </pre>
-							<p>yields (unless the <code>name</code> is set explicitly in the manifest):</p>
-							<pre class="example">
+								<p>yields (unless the <code>name</code> is set explicitly in the manifest):</p>
+								<pre class="example">
 {
     "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "name"     : ["Moby Dick"],
     &#8230;
 }
 			                    </pre>
-						</details>
-					</li>
-					<li id="can-set-lang"> (<a href="#language-and-dir"></a>) if <var>manifest["inLanguage"]</var> is
-							<code>undefined</code> and the value of <var>lang</var> is <em>not</em>
-						<code>undefined</code>, add<br />
-						<code class="json">"inLanguage": lang</code><br /> to <var>manifest</var>
-						<details>
-							<summary>Explanation</summary>
-							<p>This step ensures that the language explicitly set in the primary entry page is valid for
-								an embedded manifest content. For example,</p>
-							<pre class="example">
+							</details>
+						</li>
+						<li id="can-set-lang"> (<a href="#language-and-dir"></a>) if <var>manifest["inLanguage"]</var>
+							is <code>undefined</code> and the value of <var>lang</var> is <em>not</em>
+							<code>undefined</code>, add<br />
+							<code class="json">"inLanguage": lang</code><br /> to <var>manifest</var>
+							<details>
+								<summary>Explanation</summary>
+								<p>This step ensures that the language explicitly set in the primary entry page is valid
+									for an embedded manifest content. For example,</p>
+								<pre class="example">
 &lt;html&gt;
 &lt;head&gt;
     &#8230;
@@ -3361,25 +3499,26 @@ partial dictionary WebPublicationManifest {
     }
     &lt;/script&gt;
 			                </pre>
-							<p>yields (unless the language and the direction are set explicitly in the manifest):</p>
-							<pre class="example">
+								<p>yields (unless the language and the direction are set explicitly in the
+									manifest):</p>
+								<pre class="example">
 {
     "@context"    : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "inLanguage"  : "ur",
     &#8230;
 }
 			                </pre>
-						</details>
-					</li>
-					<li id="can-set-dir"> (<a href="#language-and-dir"></a>) if <var>manifest["inDirection"]</var> is
-							<code>undefined</code> and the value of <var>dir</var> is <em>not</em>
-						<code>undefined</code>, add<br />
-						<code class="json">"inDirection": dir</code><br /> to <var>manifest</var>
-						<details>
-							<summary>Explanation</summary>
-							<p>This step ensures that the base direction explicitly set in the primary entry page is
-								valid for an embedded manifest content. For example,</p>
-							<pre class="example">
+							</details>
+						</li>
+						<li id="can-set-dir"> (<a href="#language-and-dir"></a>) if <var>manifest["inDirection"]</var>
+							is <code>undefined</code> and the value of <var>dir</var> is <em>not</em>
+							<code>undefined</code>, add<br />
+							<code class="json">"inDirection": dir</code><br /> to <var>manifest</var>
+							<details>
+								<summary>Explanation</summary>
+								<p>This step ensures that the base direction explicitly set in the primary entry page is
+									valid for an embedded manifest content. For example,</p>
+								<pre class="example">
 &lt;html&gt;
 &lt;head&gt;
     &#8230;
@@ -3391,8 +3530,9 @@ partial dictionary WebPublicationManifest {
     }
     &lt;/script&gt;
 			                </pre>
-							<p>yields (unless the language and the direction are set explicitly in the manifest):</p>
-							<pre class="example">
+								<p>yields (unless the language and the direction are set explicitly in the
+									manifest):</p>
+								<pre class="example">
 {
     "@context"    : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "inLanguage"  : "ur",
@@ -3400,38 +3540,39 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 			                </pre>
-						</details>
-					</li>
-					<li id="no-reading-order"> (<a href="#default-reading-order"></a>) if
-							<var>manifest["readingOrder"]</var> is <code>undefined</code>, let <var>u</var> be the value
-						of <a data-cite="!dom#concept-document-url">document.URL</a>, and add<br />
-						<code class="json">"readingOrder": [{"type": ["LinkedResource"], "url": u}]</code><br /> to the
-							<var>manifest</var>
-						<details>
-							<summary>Explanation</summary>
-							<p> If the publication consists only of the primary entry page, the default reading order
-								can be omitted; it will consist, automatically, of that single resource. </p>
-						</details>
-					</li>
-					<li> (<a href="#arrays-and-single-values"></a>) consider <var>P["term"]</var>, where <var>P</var> is
-						any object in <var>manifest</var> (including itself) and <var>term</var> is <ul>
-							<li><code>type</code>; or</li>
-							<li>one of the <a href="#accessibility">accessibility</a> terms except for
-									<code>accessibilitySummary</code>; or</li>
-							<li>one of the <a href="#creators">creator</a> terms; or</li>
-							<li><code>name</code>; or</li>
-							<li>one of the <a href="#resource-categorization-properties">resource categorization
-									properties</a>; or</li>
-							<li><code>rel</code>.</li>
-						</ul> If <var>P["term"]</var> is a single string or object <code>v</code>, then change the
-						relevant term/value to<br />
-						<code class="json">"term": [v]</code>
-						<br />Repeat this step for all possible values of <var>P["term"]</var>. <details>
-							<summary>Explanation</summary>
-							<p>A number of terms require their values to be arrays but, for the sake of convenience,
-								authors are allowed to use a single value instead of a one element array. For
-								example,</p>
-							<pre class="example">
+							</details>
+						</li>
+						<li id="no-reading-order"> (<a href="#default-reading-order"></a>) if
+								<var>manifest["readingOrder"]</var> is <code>undefined</code>, let <var>u</var> be the
+							value of <a data-cite="!dom#concept-document-url">document.URL</a>, and add<br />
+							<code class="json">"readingOrder": [{"type": ["LinkedResource"], "url": u}]</code><br /> to
+							the <var>manifest</var>
+							<details>
+								<summary>Explanation</summary>
+								<p> If the Web Publication consists only of the primary entry page, the default reading
+									order can be omitted; it will consist, automatically, of that single resource. </p>
+							</details>
+						</li>
+						<li> (<a href="#arrays-and-single-values"></a>) consider <var>P["term"]</var>, where
+								<var>P</var> is any object in <var>manifest</var> (including itself) and <var>term</var>
+							is <ul>
+								<li><code>type</code>; or</li>
+								<li>one of the <a href="#accessibility">accessibility</a> terms except for
+										<code>accessibilitySummary</code>; or</li>
+								<li>one of the <a href="#creators">creator</a> terms; or</li>
+								<li><code>name</code>; or</li>
+								<li>one of the <a href="#resource-categorization-properties">resource categorization
+										properties</a>; or</li>
+								<li><code>rel</code>.</li>
+							</ul> If <var>P["term"]</var> is a single string or object <code>v</code>, then change the
+							relevant term/value to<br />
+							<code class="json">"term": [v]</code>
+							<br />Repeat this step for all possible values of <var>P["term"]</var>. <details>
+								<summary>Explanation</summary>
+								<p>A number of terms require their values to be arrays but, for the sake of convenience,
+									authors are allowed to use a single value instead of a one element array. For
+									example,</p>
+								<pre class="example">
 {
     "@context"  : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "name"      : "Moby Dick",
@@ -3447,8 +3588,8 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 			                </pre>
-							<p>yields:</p>
-							<pre class="example">
+								<p>yields:</p>
+								<pre class="example">
 {
     "@context"  : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "name"      : ["Moby Dick"],
@@ -3464,18 +3605,18 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 			                    </pre>
-						</details>
-					</li>
-					<li> (<a href="#creators"></a>) if the value <var>v</var> in a <var>manifest["term"]</var> array,
-						where <var>term</var> is one of the <a href="#creators">creator</a> terms, is a simple string or
-							<a>localizable string</a>, exchange that element in the array to<br />
-						<code class="json">{"type": ["Person"], "name": [v]}</code>
-						<br />Repeat this step for all possible values of <var>v</var>. <details>
-							<summary>Explanation</summary>
-							<p>An author, editor, etc., should be explicitly designed as an object of type
-									<code>Person</code> but, for the sake of convenience, authors are allowed to just
-								give their name. For example,</p>
-							<pre class="example">
+							</details>
+						</li>
+						<li> (<a href="#creators"></a>) if the value <var>v</var> in a <var>manifest["term"]</var>
+							array, where <var>term</var> is one of the <a href="#creators">creator</a> terms, is a
+							simple string or <a>localizable string</a>, exchange that element in the array to<br />
+							<code class="json">{"type": ["Person"], "name": [v]}</code>
+							<br />Repeat this step for all possible values of <var>v</var>. <details>
+								<summary>Explanation</summary>
+								<p>An author, editor, etc., should be explicitly designed as an object of type
+										<code>Person</code> but, for the sake of convenience, authors are allowed to
+									just give their name. For example,</p>
+								<pre class="example">
 {
     "@context"  : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "name"      : ["Moby Dick"],
@@ -3483,8 +3624,8 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 			                </pre>
-							<p>yields:</p>
-							<pre class="example">
+								<p>yields:</p>
+								<pre class="example">
 {
     "@context"  : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "name"      : ["Moby Dick"],
@@ -3495,18 +3636,19 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 			                </pre>
-						</details>
-					</li>
-					<li> (<a href="#link-values"></a>) if the value <var>v</var> in a <var>manifest["term"]</var> array,
-						where <var>term</var> is one of the <a href="#resource-categorization-properties">resource
-							categorization properties</a>, is a simple string, exchange that element in the array to<br />
-						<code class="json">{"type": ["LinkedResource"], "url": v}</code>
-						<br />Repeat this step for all possible values of <var>v</var>. <details>
-							<summary>Explanation</summary>
-							<p>Resource links should be explicitly designed as an object of type
-									<code>LinkedResource</code> but, for the sake of convenience, authors are allowed to
-								just give their absolute or relative URL. For example,</p>
-							<pre class="example">
+							</details>
+						</li>
+						<li> (<a href="#link-values"></a>) if the value <var>v</var> in a <var>manifest["term"]</var>
+							array, where <var>term</var> is one of the <a href="#resource-categorization-properties"
+								>resource categorization properties</a>, is a simple string, exchange that element in
+							the array to<br />
+							<code class="json">{"type": ["LinkedResource"], "url": v}</code>
+							<br />Repeat this step for all possible values of <var>v</var>. <details>
+								<summary>Explanation</summary>
+								<p>Resource links should be explicitly designed as an object of type
+										<code>LinkedResource</code> but, for the sake of convenience, authors are
+									allowed to just give their absolute or relative URL. For example,</p>
+								<pre class="example">
 {
     "@context"  : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     &#8230;
@@ -3517,8 +3659,8 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 			                </pre>
-							<p>yields:</p>
-							<pre class="example">
+								<p>yields:</p>
+								<pre class="example">
 {
     "@context"  : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     &#8230;
@@ -3531,27 +3673,27 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 			                </pre>
-						</details>
-					</li>
-					<li> (<a href="#strings-vs-objects"></a>) let <var>v</var> be the value, or one of the values in
-						case of an array, of <var>P["term"]</var>, where <var>P</var> is any object in
-							<var>manifest</var> (including itself) and <var>term</var> is: <ul>
-							<li><code>accessibilitySummary</code>; or</li>
-							<li><code>name</code>; or</li>
-							<li><code>description</code>.</li>
-						</ul> If <var>v</var> is a single string, then change the relevant term/value to: <ul>
-							<li>if <var>manifest[inLanguage]</var> is set to the value of <var>l</var> then<br />
-								<code class="json">"term": {"value": v,"language": l}</code>
-							</li>
-							<li>otherwise<br />
-								<code class="json">"term": {"value": v}</code></li>
-						</ul> Repeat this step for all possible values of <var>v</var>. <details>
-							<summary>Explanation</summary>
-							<p>Natural language text values should be explicitly designed as localizable string objects
-								but, for the sake of convenience, authors are allowed to just use a simple string. I.e.,
-								if no language information has been provided (via <code>inLanguage</code>) in the
-								manifest then, for example,</p>
-							<pre class="example">
+							</details>
+						</li>
+						<li> (<a href="#strings-vs-objects"></a>) let <var>v</var> be the value, or one of the values in
+							case of an array, of <var>P["term"]</var>, where <var>P</var> is any object in
+								<var>manifest</var> (including itself) and <var>term</var> is: <ul>
+								<li><code>accessibilitySummary</code>; or</li>
+								<li><code>name</code>; or</li>
+								<li><code>description</code>.</li>
+							</ul> If <var>v</var> is a single string, then change the relevant term/value to: <ul>
+								<li>if <var>manifest[inLanguage]</var> is set to the value of <var>l</var> then<br />
+									<code class="json">"term": {"value": v,"language": l}</code>
+								</li>
+								<li>otherwise<br />
+									<code class="json">"term": {"value": v}</code></li>
+							</ul> Repeat this step for all possible values of <var>v</var>. <details>
+								<summary>Explanation</summary>
+								<p>Natural language text values should be explicitly designed as localizable string
+									objects but, for the sake of convenience, authors are allowed to just use a simple
+									string. I.e., if no language information has been provided (via
+										<code>inLanguage</code>) in the manifest then, for example,</p>
+								<pre class="example">
 {
     "@context"  : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "name"      : ["Moby Dick"],
@@ -3559,8 +3701,8 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 			                </pre>
-							<p>yields:</p>
-							<pre class="example">
+								<p>yields:</p>
+								<pre class="example">
 {
     "@context"  : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "name"      : [{
@@ -3572,9 +3714,9 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 			                </pre>
-							<p>If an explicit language has also been provided in the manifest, that language is also
-								added to the localizable string object. For example,</p>
-							<pre class="example">
+								<p>If an explicit language has also been provided in the manifest, that language is also
+									added to the localizable string object. For example,</p>
+								<pre class="example">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "inLanguage" : "en",
@@ -3583,8 +3725,8 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 			                </pre>
-							<p>yields:</p>
-							<pre class="example">
+								<p>yields:</p>
+								<pre class="example">
 {
     "@context"  : ["https://schema.org","https://www.w3.org/ns/wp-context"],
     "inLanguage": "en",
@@ -3599,94 +3741,119 @@ partial dictionary WebPublicationManifest {
     &#8230;
 }
 			                </pre>
-						</details>
-					</li>
+							</details>
+						</li>
 
-					<li> (<a href="#manifest-relative-urls"></a>) if the value of <var>P["term"]</var>, where
-							<var>P</var> is any object in <var>manifest</var> (including itself) and <var>term</var> is: <ul>
-							<li><code>url</code>; or</li>
-							<li><code>id</code></li>
-						</ul> is a single string <var>u</var> which is <em>not</em> an <a
-							data-cite="!url/#absolute-url-string">absolute URL string</a>, then resolve this value
-						(considered to be a relative URL) using the value of <var>base</var>, yielding the value of
-							<var>au</var>, and replace the term/value pair by<br />
-						<code class="json">"term": au</code>
-						<details>
-							<summary>Explanation</summary>
-							<p>All relative URLs in the publication manifest must be resolved against the base value to
-								yield absolute URLs.</p>
-						</details>
-					</li>
-					<li> Return the (transformed) <code>manifest</code>. </li>
-				</ol>
-				<p class="note"> See the <a href="#canonicalize-manifest-diagram">diagram in the appendix</a> for a
-					visual representation of the algorithm. Also, to help understanding the result of the algorithm,
-					there is a link to the corresponding canonical manifests for all the examples in <a
-						href="#app-manifest-examples"></a>.</p>
+						<li> (<a href="#manifest-relative-urls"></a>) if the value of <var>P["term"]</var>, where
+								<var>P</var> is any object in <var>manifest</var> (including itself) and <var>term</var>
+							is: <ul>
+								<li><code>url</code>; or</li>
+								<li><code>id</code></li>
+							</ul> is a single string <var>u</var> which is <em>not</em> an <a
+								data-cite="!url/#absolute-url-string">absolute URL string</a>, then resolve this value
+							(considered to be a relative URL) using the value of <var>base</var>, yielding the value of
+								<var>au</var>, and replace the term/value pair by<br />
+							<code class="json">"term": au</code>
+							<details>
+								<summary>Explanation</summary>
+								<p>All relative URLs in the Web Publication manifest must be resolved against the base
+									value to yield absolute URLs.</p>
+							</details>
+						</li>
+						<li> Return the (transformed) <code>manifest</code>. </li>
+					</ol>
+					<p class="note"> See the <a href="#canonicalize-manifest-diagram">diagram in the appendix</a> for a
+						visual representation of the algorithm. Also, to help understanding the result of the algorithm,
+						there is a link to the corresponding canonical manifests for all the examples in <a
+							href="#app-manifest-examples"></a>.</p>
+				</section>
+
+				<section id="processing-manifest">
+					<h4>Processing the manifest</h4>
+
+					<p>The <dfn data-lt="processing the manifest|processing a manifest">steps for processing a
+							manifest</dfn> are given by the following algorithm. The algorithm takes a <var>json</var>
+						object representing a <a>canonical manifest</a>. The output from inputting a JSON object into
+						this algorithm is a <dfn>processed manifest</dfn>. The goal of the algorithm is to ensure that
+						the data represented in <var>json</var> abides to the minimal requirements on the data,
+						removing, if applicable, non-conformant data.</p>
+
+					<ol>
+						<li> Let <var>manifest object</var> be the result of <a data-cite="!webidl-1/#es-dictionary"
+								>converting</a>
+							<var>json</var> to a <a>PublicationManifest</a> dictionary. </li>
+						<li> Extension point: process any proprietary and/or other supported members at this point in
+							the algorithm. </li>
+						<li> Perform data cleanup operations on <var>manifest object</var>, possibly removing data, as
+							well as raising warnings. <ol>
+								<li>Check whether the value of <var>manifest object["url"]</var> is a valid
+									URL&#160;[[!url]]. If not, issue a warning.</li>
+								<li>For all the terms defined in <a href="#accessibility"></a>, except for
+										<code>accessModeSufficient</code> and <code>accessibilitySummary</code>, check
+									whether all tokens listed in <var>manifest[term]</var> are defined in the preferred
+									vocabulary (see the <a
+										href="https://www.w3.org/wiki/WebSchemas/Accessibility#property-table">list of
+										expected values</a> for each). Issue a warning for each unrecognized value.</li>
+								<li>For all values in <var>manifest object["accessModeSufficient"]</var>, check whether
+									each token in each <a href="https://schema.org/ItemList">ItemList</a>
+									[[!schema.org]] is defined in the preferred vocabulary (see the <a
+										href="https://www.w3.org/wiki/WebSchemas/Accessibility#property-table">list of
+										expected values</a>). Issue a warning for each unrecognized value.</li>
+								<li> For all the terms defined in <a href="#creators"></a>, check whether every object
+										<var>Obj</var> in <var>manifest object[term]</var> has <var>Obj["name"]</var>
+									set. If not, remove <var>Obj</var> from <var>manifest object[term]</var> array and
+									issue a warning. </li>
+								<li> Check whether the value of <var>manifest object["name"]</var> is not empty. If it
+									is, generate a value (see the <a href="#generate_title">separate note for
+										details</a>) and issue a warning. </li>
+								<li> For all the terms defined in <a href="#resource-categorization-properties"></a>,
+									check whether every object <var>Obj</var> in <var>manifest object[term]</var> has
+										<var>Obj["url"]</var> set. If not, remove <var>Obj</var> from <var>manifest
+										object[term]</var> array and issue a warning. If yes, check whether
+										<var>Obj["url"]</var> is a valid URL&#160;[[!url]] and, if not, issue a warning. </li>
+								<li> Check whether <var>manifest object["datePublished"]</var> is a valid date or
+									date-time, per&#160;[[iso8601]]. If the check fails, issue a warning. </li>
+								<li> Check whether <var>manifest object["dateModified"]</var> is a valid date or
+									date-time, per&#160;[[iso8601]]. If the check fails, issue a warning. </li>
+							</ol>
+						</li>
+						<li> Return <var>manifest object</var>. </li>
+					</ol>
+				</section>
 			</section>
 
-			<section id="processing-manifest">
-				<h3>Processing the manifest</h3>
+			<section id="security">
+				<h3>Security</h3>
 
-				<p>The <dfn data-lt="processing the manifest|processing a manifest">steps for processing a
-						manifest</dfn> are given by the following algorithm. The algorithm takes a <var>json</var>
-					object representing a <a>canonical manifest</a>. The output from inputting a JSON object into this
-					algorithm is a <dfn>processed manifest</dfn>. The goal of the algorithm is to ensure that the data
-					represented in <var>json</var> abides to the minimal requirements on the data, removing, if
-					applicable, non-conformant data.</p>
+				<div class="ednote">Placeholder for security issues.</div>
+			</section>
 
-				<ol>
-					<li> Let <var>manifest object</var> be the result of <a data-cite="!webidl-1/#es-dictionary"
-							>converting</a>
-						<var>json</var> to a <a>WebPublicationManifest</a> dictionary. </li>
-					<li> Extension point: process any proprietary and/or other supported members at this point in the
-						algorithm. </li>
-					<li> Perform data cleanup operations on <var>manifest object</var>, possibly removing data, as well
-						as raising warnings. <ol>
-							<li>Check whether the value of <var>manifest object["url"]</var> is a valid
-								URL&#160;[[!url]]. If not, issue a warning.</li>
-							<li>For all the terms defined in <a href="#accessibility"></a>, except for
-									<code>accessModeSufficient</code> and <code>accessibilitySummary</code>, check
-								whether all tokens listed in <var>manifest[term]</var> are defined in the preferred
-								vocabulary (see the <a
-									href="https://www.w3.org/wiki/WebSchemas/Accessibility#property-table">list of
-									expected values</a> for each). Issue a warning for each unrecognized value.</li>
-							<li>For all values in <var>manifest object["accessModeSufficient"]</var>, check whether each
-								token in each <a href="https://schema.org/ItemList">ItemList</a> [[!schema.org]] is
-								defined in the preferred vocabulary (see the <a
-									href="https://www.w3.org/wiki/WebSchemas/Accessibility#property-table">list of
-									expected values</a>). Issue a warning for each unrecognized value.</li>
-							<li> For all the terms defined in <a href="#creators"></a>, check whether every object
-									<var>Obj</var> in <var>manifest object[term]</var> has <var>Obj["name"]</var> set.
-								If not, remove <var>Obj</var> from <var>manifest object[term]</var> array and issue a
-								warning. </li>
-							<li> Check whether the value of <var>manifest object["name"]</var> is not empty. If it is,
-								generate a value (see the <a href="#generate_title">separate note for details</a>) and
-								issue a warning. </li>
-							<li> For all the terms defined in <a href="#resource-categorization-properties"></a>, check
-								whether every object <var>Obj</var> in <var>manifest object[term]</var> has
-									<var>Obj["url"]</var> set. If not, remove <var>Obj</var> from <var>manifest
-									object[term]</var> array and issue a warning. If yes, check whether
-									<var>Obj["url"]</var> is a valid URL&#160;[[!url]] and, if not, issue a warning. </li>
-							<li> Check whether <var>manifest object["datePublished"]</var> is a valid date or date-time,
-								per&#160;[[iso8601]]. If the check fails, issue a warning. </li>
-							<li> Check whether <var>manifest object["dateModified"]</var> is a valid date or date-time,
-								per&#160;[[iso8601]]. If the check fails, issue a warning. </li>
-						</ol>
-					</li>
-					<li> Return <var>manifest object</var>. </li>
-				</ol>
+			<section id="privacy">
+				<h3>Privacy</h3>
+
+				<div class="ednote">Placeholder for privacy issues.</div>
 			</section>
 		</section>
-		<section id="security">
-			<h2>Security</h2>
+		<section id="extensions" class="part">
+			<h2>PART III: Modular Extensions</h2>
 
-			<div class="ednote">Placeholder for security issues.</div>
-		</section>
-		<section id="privacy">
-			<h2>Privacy</h2>
+			<section id="mod-intro">
+				<h3>Introduction</h3>
 
-			<div class="ednote">Placeholder for privacy issues.</div>
+				<p>The first two parts of this specification define the cornerstones for developing additional
+						<a>digital publication</a> formats that can be deployed to the Web.</p>
+			</section>
+
+			<section id="mod-compat">
+				<h3>Compatibility Requirements</h3>
+
+				<p>In order for a <a>digital publication</a> format to be compatible with this specification, following
+					conditions MUST be met:</p>
+
+				<ul>
+					<li>It MUST adhere to the manifest format requirements defined in <a href="#manifest"></a>.</li>
+				</ul>
+			</section>
 		</section>
 		<section id="app-toc-structure" class="appendix">
 			<h2>Machine-Processable Table of Contents</h2>
@@ -3700,15 +3867,15 @@ partial dictionary WebPublicationManifest {
 						<code>nav</code> element can be more specifically identified by use of the <a
 						href="https://www.w3.org/TR/html/dom.html#aria-role-attribute"><code>role</code> attribute</a>
 					[[html]]. In particular, the <code>doc-toc</code> role from the [[dpub-aria-1.0]] vocabulary
-					identifies the <code>nav</code> element as the Web Publications’s <a href="#wp-table-of-contents"
-						>table of contents</a>.</p>
+					identifies the <code>nav</code> element as the Web Publications's <a href="#table-of-contents">table
+						of contents</a>.</p>
 
-				<p>Including an identifiable table of contents is an accessible way to produce any publication, but due
-					to the flexibility of HTML markup, it also presents challenges for user agents trying to extract a
-					meaningful hierarchy of links (e.g., to provide a custom view available from any page). To avoid
-					duplicating the tables of contents for different uses, this section defines a syntax that is both
-					human friendly and commonly used while still providing enough structure for user agent
-					extraction.</p>
+				<p>Including an identifiable table of contents is an accessible way to produce any <a>digital
+						publication</a>, but due to the flexibility of HTML markup, it also presents challenges for user
+					agents trying to extract a meaningful hierarchy of links (e.g., to provide a custom view available
+					from any page). To avoid duplicating the tables of contents for different uses, this section defines
+					a syntax that is both human friendly and commonly used while still providing enough structure for
+					user agent extraction.</p>
 
 				<p>Authors have a choice of lists (ordered or unordered) to construct their table of contents. By
 					tagging each link within these lists in anchor tags (<a
@@ -3726,7 +3893,7 @@ partial dictionary WebPublicationManifest {
 
 				<p>The machine-readable table of contents is defined within an [[html]] <a
 						href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code> element</a>. As
-					described in <a href="#wp-table-of-contents"></a>, this <code>nav</code> element has to be both the
+					described in <a href="#table-of-contents"></a>, this <code>nav</code> element has to be both the
 					first element in the document and identifiable by a <code>role</code> attribute with the value
 						<code>doc-toc</code>.</p>
 
@@ -3759,7 +3926,7 @@ partial dictionary WebPublicationManifest {
 							processing. The list cannot occur inside of any <a href="#toc-skipped-elements">skipped
 								elements</a>, however, since their internal contents are not evaluated.</p>
 						<p>If the <code>nav</code> element does not contain one of these elements, then user agents will
-							not register the Web Publication as containing a usable table of contents (e.g., a
+							not register the digital publication as containing a usable table of contents (e.g., a
 							machine-rendered option will not be available).</p>
 					</dd>
 					<dt id="toc-branches">Branches</dt>
@@ -3820,7 +3987,7 @@ partial dictionary WebPublicationManifest {
 
    &lt;ol>
       &lt;li>
-        &lt;a href="discourses.html">ZARATHUSTRA’S DISCOURSES.&lt;/a>
+        &lt;a href="discourses.html">ZARATHUSTRA'S DISCOURSES.&lt;/a>
          &lt;ul>
             &lt;li>&lt;a href="discourses.html#s01">THE THREE METAMORPHOSES.&lt;/a>&lt;/li>
             &lt;li>&lt;a href="discourses.html#s02">THE ACADEMIC CHAIRS OF VIRTUE.&lt;/a>&lt;/li>
@@ -4249,11 +4416,11 @@ partial dictionary WebPublicationManifest {
 										element is terminated (i.e., to avoid processing multiple links for a single
 										branch).</p>
 									<p>In addition to having an <code>href</code> attribute specified, it is necessary
-										that it resolve to a resource that belongs to the publication to meet the
-										requirements of this specification. If not, the branch is retained but the entry
-										will not be linkable.</p>
-									<p>Additional information about the target of the link &#8212; the type of resource
-										and its relationship &#8212; is also retained.</p>
+										that it resolve to a resource that belongs to the digital publication to meet
+										the requirements of this specification. If not, the branch is retained but the
+										entry will not be linkable.</p>
+									<p>Additional information about the target of the link — the type of resource and
+										its relationship — is also retained.</p>
 									<aside class="example" title="Visualization of a link to an SVG image">
 										<pre>{
    "name": "In the Beginning",
@@ -4302,8 +4469,8 @@ partial dictionary WebPublicationManifest {
 					<li>
 						<p>After completing the DOM walk, if the <em>entries</em> property of <em>toc</em> contains a
 							non-empty array, <em>toc</em> represents the machine-processed table of contents.</p>
-						<p>Otherwise, the Web Publication does not have a table of contents that can be used for machine
-							rendering purposes.</p>
+						<p>Otherwise, the digital publication does not have a table of contents that can be used for
+							machine rendering purposes.</p>
 						<details>
 							<summary>Explanation</summary>
 							<p>If the <code>entries</code> array in the root <em>toc</em> object does not contain any
@@ -4318,7 +4485,7 @@ partial dictionary WebPublicationManifest {
 		<section id="app-manifest-examples" class="appendix informative">
 			<h2>Manifest Examples</h2>
 
-			<section id="simple-book-example">
+			<section>
 				<h3>Simple Book</h3>
 				<p>A manifest for a simple book. The <a
 						href="https://w3c.github.io/wpub/experiments/separate_manifest/mobydick.jsonld">canonical
@@ -4326,7 +4493,7 @@ partial dictionary WebPublicationManifest {
 				<pre class="example" data-include="experiments/separate_manifest/mobydick-simple.jsonld" data-include-format="text"></pre>
 			</section>
 
-			<section id="single-document-publication-example">
+			<section>
 				<h3>Single-Document Publication</h3>
 				<p>Example for an embedded manifest example. The <a
 						href="https://w3c.github.io/wpub/experiments/w3c_rec/simple-canonical.jsonld">canonical
@@ -4336,7 +4503,7 @@ partial dictionary WebPublicationManifest {
 				<pre class="example" data-include="experiments/w3c_rec/simple_version.html" data-include-format="text"></pre>
 			</section>
 
-			<section id="audiobook-example">
+			<section>
 				<h3>Audiobook</h3>
 				<p>A manifest for an audiobook. The <a
 						href="https://w3c.github.io/wpub/experiments/audiobook/flatland-canonical.json">canonical

--- a/index.html
+++ b/index.html
@@ -2632,9 +2632,11 @@ partial dictionary PublicationManifest {
 					that belong to the Web Publication and a default reading order, which is how it connects resources
 					into a single contiguous work.</p>
 
-				<p>A Web Publication is discoverable in one of two ways: resources either include a link to the manifest
-					(via an HTTP Link header or an HTML <code>link</code> element&#160;[[html]]), or the manifest can be
-					loaded directly by a compatible user agent.</p>
+				<p>A Web Publication is discoverable via the presence of a link to the manifest in any of its resources
+					(i.e., by the use of an HTTP Link header or an HTML <code>link</code> element&#160;[[html]]). The
+					linked manifest is contained either directly within the resource containing the link (in a special
+					case called the <a href="#primary-entry-page">primary entry page</a>) or in a separate JSON-LD
+					document.</p>
 
 				<p>With the establishment of Web Publications, user agents can build new experiences tailored
 					specifically for their unique reading needs.</p>

--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@
 					<dd>
 						<p>The Authored Publication Manifest is the serialization of the manifest that the author
 							provides with the digital publication (i.e., prior to be digital publication being processed
-							by a user agent. Note that the author does not have to be human; a machine could
+							by a user agent). Note that the author does not have to be human; a machine could
 							automatically produce authored manifests for digital publications.</p>
 					</dd>
 

--- a/index.html
+++ b/index.html
@@ -1605,9 +1605,9 @@ dictionary CreatorInfo {
 									directionally set to left-to-right text;</li>
 								<li><code><dfn>rtl</dfn></code>: indicates that the textual values are explicitly
 									directionally set to right-to-left text;</li>
-								<li><code><dfn>auto</dfn></code>: indicates that the textual values are explicitly
-									directionally set to the direction of the first character with a strong
-									directionality.</li>
+								<li><code>auto</code> indicates that the textual values are explicitly directionally set
+									to the direction of the first character with a strong directionality, following the
+									rules of the Unicode Bidirectional Algorithm [[!bidi]].</li>
 							</ul>
 
 							<p>When specified, these properties are also used as defaults for textual values in the

--- a/index.html
+++ b/index.html
@@ -995,11 +995,11 @@ dictionary LinkedResource {
 						<p>The base URL for relative URLs is determined as follows:</p>
 
 						<ul>
-							<li>In the case of an <a href="#manifest-embedding">embedded manifest</a>, the base URL is
-								the <a data-cite="!html#the-base-element">document base URL</a>&#160;[[!html]] of the
+							<li>In the case of an <a href="#wp-manifest-embedding">embedded manifest</a>, the base URL
+								is the <a data-cite="!html#the-base-element">document base URL</a>&#160;[[!html]] of the
 									<a>primary entry page</a> of the publication;</li>
-							<li>In the case of a <a href="#manifest-linking">linked manifest</a>, the base URL is URL of
-								the manifest resource.</li>
+							<li>In the case of a <a href="#wp-manifest-linking">linked manifest</a>, the base URL is URL
+								of the manifest resource.</li>
 						</ul>
 
 						<p>By consequence, relative URLs in embedded manifests are resolved against the URL of the
@@ -1622,12 +1622,12 @@ dictionary CreatorInfo {
 							<p>The global language information MAY be overridden by <a
 									href="#manifest-specific-language-and-dir">individual values</a>.</p>
 
-							<p>If the manifest is <a href="#manifest-embedding">embedded</a> in the primary entry page
-								via a <code>script</code> element, and the manifest does not set the global language
-								and/or the base direction (see <a href="#manifest-default-language-and-dir"></a>), the
-									<code>lang</code> and the <code>dir</code> attributes of the <code>script</code>
-								element are used as the global <a>language</a> and <a>base direction</a>, respectively
-								(see the details on handling the <a
+							<p>If the manifest is <a href="#wp-manifest-embedding">embedded</a> in the primary entry
+								page via a <code>script</code> element, and the manifest does not set the global
+								language and/or the base direction (see <a href="#manifest-default-language-and-dir"
+								></a>), the <code>lang</code> and the <code>dir</code> attributes of the
+									<code>script</code> element are used as the global <a>language</a> and <a>base
+									direction</a>, respectively (see the details on handling the <a
 									href="https://www.w3.org/TR/html/dom.html#the-lang-and-xmllang-attributes"
 										><code>lang</code></a> and <a
 									href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"><code>dir</code></a>
@@ -2072,10 +2072,9 @@ partial dictionary PublicationManifest {
 					<section id="resource-list">
 						<h5>Resource List</h5>
 
-						<p>The <dfn>resource list</dfn> enumerates any additional <a href="#pub-resources">resources</a>
-							used in the processing and rendering of a <a>digital publication</a> that are not already
-							listed in the <a>default reading order</a>. It is expressed using the <code>resources</code>
-							property.</p>
+						<p>The <dfn>resource list</dfn> enumerates any additional resources used in the processing and
+							rendering of a <a>digital publication</a> that are not already listed in the <a>default
+								reading order</a>. It is expressed using the <code>resources</code> property.</p>
 
 						<table class="zebra">
 							<thead>
@@ -2159,10 +2158,9 @@ partial dictionary PublicationManifest {
 					<section id="links">
 						<h5>Links</h5>
 
-						<p>The <dfn><code>links</code></dfn> property provides a list of <a href="#pub-resources"
-								>resources</a> that are <em>not</em> required for the processing and rendering of a
-								<a>digital publication</a> (i.e., the content of the publication remains unaffected even
-							if these resources are not available).</p>
+						<p>The <dfn><code>links</code></dfn> property provides a list of resources that are <em>not</em>
+							required for the processing and rendering of a <a>digital publication</a> (i.e., the content
+							of the publication remains unaffected even if these resources are not available).</p>
 
 						<table class="zebra">
 							<thead>
@@ -2666,7 +2664,7 @@ partial dictionary PublicationManifest {
 
 				<ul>
 					<li>it has a <a>manifest</a> that conforms to <a href="#wp-manifest"></a>;</li>
-					<li>it adheres to the construction requirements defined in <a href="#pub-construction"></a>.</li>
+					<li>it adheres to the construction requirements defined in <a href="#wp-construction"></a>.</li>
 				</ul>
 
 				<p id="ua-conformance">A user agent conforms to this specification if it meets the following
@@ -2715,7 +2713,7 @@ partial dictionary PublicationManifest {
 				<section id="primary-entry-page">
 					<h4>Primary Entry Page</h4>
 
-					<p>The <dfn>primary entry page</dfn> represents the preferred starting <a href="#pub-resources"
+					<p>The <dfn>primary entry page</dfn> represents the preferred starting <a href="#wp-resources"
 							>resource</a> for a Web Publication and enables discovery of its <a>manifest</a>. It is the
 						resource that is returned when accessing the Web Publication's <a>address</a>, and MUST be
 						included in either the <a>default reading order</a> or the <a>resource list</a>.</p>
@@ -2733,10 +2731,10 @@ partial dictionary PublicationManifest {
 						reading order is not provided, however, user agents will <a href="#no-reading-order">create one
 							using the primary entry page</a>.</p>
 
-					<p>The primary entry page is the only resource in which <a href="#manifest-embedding">a manifest can
-							be embedded</a>. To ensure discovery of the manifest, the primary entry page MUST provide a
-							<a href="#manifest-linking">link to the manifest</a>, regardless of whether the manifest is
-						embedded within the page or external to it.</p>
+					<p>The primary entry page is the only resource in which <a href="#wp-manifest-embedding">a manifest
+							can be embedded</a>. To ensure discovery of the manifest, the primary entry page MUST
+						provide a <a href="#wp-manifest-linking">link to the manifest</a>, regardless of whether the
+						manifest is embedded within the page or external to it.</p>
 
 					<p>The address of the primary entry page is also the <a>canonical identifier</a> for the Web
 						Publication (i.e., it serves as its unique identifier).</p>
@@ -2754,7 +2752,7 @@ partial dictionary PublicationManifest {
 
 					<p>The table of contents is expressed via an [[!html]]&#160;element (typically a <a
 							href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code>
-						element</a>) in one of the <a href="#pub-resources">resources</a>. This element MUST be
+						element</a>) in one of the <a href="#wp-resources">resources</a>. This element MUST be
 						identified by the <code>role</code> attribute&#160;[[!html]] value
 						"<code>doc-toc</code>"&#160;[[!dpub-aria-1.0]], and MUST be the first element in the document —
 						in <a href="https://dom.spec.whatwg.org/#concept-tree-order">document tree
@@ -2764,9 +2762,9 @@ partial dictionary PublicationManifest {
 							page</a>, the manifest SHOULD <a href="#table-of-contents">identify the resource</a> that
 						contains the structure.</p>
 
-					<p> When specified, the table of content MUST include a link to at least one <a
-							href="#pub-resources">resource</a>, and all links SHOULD refer to <a href="#pub-resources"
-							>resources</a> within <a href="#pub-bounds">publication bounds</a>. </p>
+					<p> When specified, the table of content MUST include a link to at least one <a href="#wp-resources"
+							>resource</a>, and all links SHOULD refer to <a href="#wp-resources">resources</a> within <a
+							href="#wp-bounds">publication bounds</a>. </p>
 
 					<p>Refer to the <a href="#table-of-contents">table of contents property definition</a> for more
 						information on how to identify which resource contains the table of contents.</p>
@@ -2784,7 +2782,7 @@ partial dictionary PublicationManifest {
 
 					<p>The page list is expressed via an [[!html]] element (typically a <a
 							href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code>
-						element</a>) in one of the <a href="#pub-resources">resources</a>. This element MUST be
+						element</a>) in one of the <a href="#wp-resources">resources</a>. This element MUST be
 						identified by the <code>role</code> attribute&#160;[[!html]] value
 						"<code>doc-pagelist</code>"&#160;[[!dpub-aria-1.0]], and MUST be the first element in the
 						document — in <a href="https://dom.spec.whatwg.org/#concept-tree-order">document tree
@@ -2794,7 +2792,7 @@ partial dictionary PublicationManifest {
 						manifest SHOULD <a href="#page-list">identify the resource</a> that contains the structure.</p>
 
 					<p>There are no requirements on the page list itself, except that, when specified, it MUST include a
-						link to at least one <a href="#pub-resources">resource</a>.</p>
+						link to at least one <a href="#wp-resources">resource</a>.</p>
 
 					<p>Refer to the <a href="#page-list"><code>pagelist</code> property definition</a> for more
 						information on how to identify which resource contains the page list.</p>
@@ -2926,7 +2924,7 @@ partial dictionary PublicationManifest {
 
 						<p>The referenced document SHOULD be a resource of the Web Publication. It can be any resource,
 							including one that is not listed in the <a>default reading order</a>. This document MUST
-							include a <a href="#manifest-linking">link to the manifest</a> to ensure a bidirectional
+							include a <a href="#wp-manifest-linking">link to the manifest</a> to ensure a bidirectional
 							linking relationship (i.e., that user agents can also locate the manifest from the document
 							at the address).</p>
 
@@ -3221,7 +3219,7 @@ partial dictionary PublicationManifest {
 
 						<p>Additionally, the <code>script</code> element MUST include a unique identifier in an
 								<code>id</code> attribute&#160;[[!html]]. This identifier ensures that the manifest <a
-								href="#manifest-linking">can be referenced</a>.</p>
+								href="#wp-manifest-linking">can be referenced</a>.</p>
 
 						<pre class="example" title="A Web Publication Manifest included in an HTML document">
 &lt;script id="example_manifest" type="application/ld+json"&gt;
@@ -3257,7 +3255,7 @@ partial dictionary PublicationManifest {
 
 						<p>When a manifest is embedded within an HTML document, the link MUST include a fragment
 							identifier that references the <code>script</code> element that contains the manifest (see
-								<a href="#manifest-embedding"></a>).</p>
+								<a href="#wp-manifest-embedding"></a>).</p>
 
 						<pre class="example" title="Link to a manifest within the same HTML resource">
 	&lt;link href="#example_manifest" rel="publication"&gt;
@@ -3420,8 +3418,8 @@ partial dictionary PublicationManifest {
 						<li>let <var>lang</var> string represent the default language, set to: <ul>
 								<li> the value of the <a data-cite="!html#the-lang-and-xml:lang-attributes"
 											><code>lang</code> value</a> for the <code>script</code> element in the
-										<a>primary entry page</a>, in case the manifest is <a href="#manifest-embedding"
-										>embedded</a>; or </li>
+										<a>primary entry page</a>, in case the manifest is <a
+										href="#wp-manifest-embedding">embedded</a>; or </li>
 								<li><code>undefined</code> otherwise</li>
 							</ul>
 							<details>
@@ -3432,7 +3430,7 @@ partial dictionary PublicationManifest {
 						<li> let <var>dir</var> string represents the base direction, set to: <ul>
 								<li> the value of the <a data-cite="!html#the-dir-attribute"><code>dir</code> value</a>
 									for the <code>script</code> element in the <a>primary entry page</a>, in case the
-									manifest is <a href="#manifest-embedding">embedded</a>; or </li>
+									manifest is <a href="#wp-manifest-embedding">embedded</a>; or </li>
 								<li><code>undefined</code> otherwise</li>
 							</ul>
 							<details>


### PR DESCRIPTION
Opening the PR for general review and commenting, as I've gone as far as I'm likely to on my own in terms of splitting the document up.

There are now three parts to the specification:

- Part I defines the manifest in general terms for any "digital publication" (I had to introduce this term to avoid confusion, but maybe there's something better)
- Part II is the more familiar concrete implementation of web publications
- Part III will be where we define any requirements for extending

One place where I really noticed my attempts to generalize the manifest failing was with the table of contents and page lists, which depend entirely on there being a primary entry page. I did my best to allow flexibility for now, but as we've defined relationships for these I'm not sure what their actual property names would be. Will need revision in the future.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/407.html" title="Last updated on Mar 7, 2019, 7:07 PM UTC (eb5e46d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/407/dcd922c...eb5e46d.html" title="Last updated on Mar 7, 2019, 7:07 PM UTC (eb5e46d)">Diff</a>