### PR TITLE
Have a <dfn> for TextDirection's auto value so it's linked correctly.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1605,7 +1605,7 @@ dictionary CreatorInfo {
 									directionally set to left-to-right text;</li>
 								<li><code><dfn>rtl</dfn></code>: indicates that the textual values are explicitly
 									directionally set to right-to-left text;</li>
-								<li><code>auto</code> indicates that the textual values are explicitly directionally set
+								<li><code><dfn>auto</dfn></code> indicates that the textual values are explicitly directionally set
 									to the direction of the first character with a strong directionality, following the
 									rules of the Unicode Bidirectional Algorithm [[!bidi]].</li>
 							</ul>


### PR DESCRIPTION
This fixes the single warning that ReSpec currently issues.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dbaron/wpub/pull/411.html" title="Last updated on Mar 18, 2019, 9:58 PM UTC (ebb96ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/411/26af644...dbaron:ebb96ec.html" title="Last updated on Mar 18, 2019, 9:58 PM UTC (ebb96ec)">Diff</a>