### PR TITLE
Added a script to clean up the WebIDL index

### DIFF
--- a/common/js/clean_idl_index.js
+++ b/common/js/clean_idl_index.js
@@ -1,0 +1,28 @@
+function clean_idl_index() {
+    // 1. Get all the (partial) definitions for the publication manifest IDL
+    const all_defs = Array.from(document.querySelectorAll('section#idl-index pre.idl span[data-title=PublicationManifest'));
+
+    // 2. Collect all the definition into one HTML text. Note that the first entry is empty, should be
+    // kept for the final display.
+    // The HTML that must be found is what is between the `{` and the `}` characters.
+    const all_defs_essential = all_defs.slice(1).map((def) => def.innerHTML.split('{')[1].split('}')[0]).join('');
+
+    // 3. The partial definitions, as well as the preceding empty line, should be removed
+    all_defs.slice(1).forEach((def) => {
+        const previous = def.previousSibling;
+        previous.remove();
+        def.remove()
+    });
+
+    // 4. Add the definition to the first definition which is still around
+    // 4.1 looking for object title
+    const object_title = all_defs[0].querySelector('.idlID');
+    // 4.2 remove the next sibling, which is a text node with the empty definition
+    object_title.nextSibling.remove();
+    // 4.3 create a new span with the html content and add this to the definition
+    const new_span = document.createElement('span');
+    new_span.innerHTML = ` {${all_defs_essential}};`
+    object_title.parentNode.append(new_span);
+}
+
+

--- a/index.html
+++ b/index.html
@@ -8,11 +8,12 @@
 		<script src="common/js/orcid.js" class="remove"></script>
 		<script src="common/js/wp.js" class="remove"></script>
 		<script src="common/js/parts.js" class="remove"></script>
+		<script src="common/js/clean_idl_index.js" class="remove"></script>
 		<link href="common/css/common.css" rel="stylesheet" type="text/css" />
 		<script class="remove">
 		  // <![CDATA[
           var respecConfig = {
-			  postProcess: [show_orcid, create_wp, denumber_parts],
+			  postProcess: [show_orcid, create_wp, denumber_parts, clean_idl_index],
 			  wg: "Publishing Working Group",
               specStatus: "ED",
               shortName: "wpub",
@@ -975,11 +976,11 @@ partial dictionary PublicationManifest {
 
 							<pre class="idl">
 dictionary LinkedResource {
-    DOMString           url;
-    DOMString           encodingFormat;
-    sequence&lt;LocalizableString>   name;
-    LocalizableString   description;
-    sequence&lt;DOMString> rel;
+    DOMString			url;
+    DOMString			encodingFormat;
+    sequence&lt;LocalizableString>	name;
+    LocalizableString		description;
+    sequence&lt;DOMString>		rel;
 };</pre>
 						</section>
 					</section>
@@ -1176,7 +1177,7 @@ partial dictionary PublicationManifest {
     sequence&lt;DOMString> accessibilityControl;
     sequence&lt;DOMString> accessibilityFeature;
     sequence&lt;DOMString> accessibilityHazard;
-    LocalizableString      accessibilitySummary;
+    LocalizableString   accessibilitySummary;
 };</pre>
 
 						<pre class="example" title="Example accessiblity metadata for a document with text and images. The publication provides alternative text and long descriptions appropriate for each image, so can also be read in purely textual form.">
@@ -1457,8 +1458,8 @@ partial dictionary PublicationManifest {
 dictionary CreatorInfo {
              sequence&lt;DOMString>         type;
     required sequence&lt;LocalizableString> name;
-             DOMString                      id;
-             DOMString                      url;
+             DOMString                   id;
+             DOMString                   url;
 };</pre>
 
 						<pre class="example" title="Author of a book">


### PR DESCRIPTION
@mattgarrish 

I have created a script that rearranges the [IDL index](https://w3c.github.io/wpub/#idl-index) content so that all the 'partial' definitions are collected into one.

It is not a general solution for a similar index page (that should be done for and in respec) but just a hack for our own specification.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/415.html" title="Last updated on Mar 21, 2019, 2:56 PM UTC (55c5cf2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/415/db67738...55c5cf2.html" title="Last updated on Mar 21, 2019, 2:56 PM UTC (55c5cf2)">Diff</a>