### PR TITLE
Fix a reference to "base direction" that should be "base URL".

### DIFF
--- a/index.html
+++ b/index.html
@@ -1004,7 +1004,7 @@ dictionary LinkedResource {
 						</ul>
 
 						<p>By consequence, relative URLs in embedded manifests are resolved against the URL of the
-							primary entry page <em>unless</em> the page declares a base direction (i.e., in a <a
+							primary entry page <em>unless</em> the page declares a base URL (i.e., in a <a
 								data-cite="!html#the-base-element"><code>&lt;base&gt;</code> element</a> in its
 							header).</p>
 


### PR DESCRIPTION
I think this is an obvious typo (or search-replace error, or similar).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dbaron/wpub/pull/416.html" title="Last updated on Mar 21, 2019, 10:09 PM UTC (0c6287a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/416/e3948f0...dbaron:0c6287a.html" title="Last updated on Mar 21, 2019, 10:09 PM UTC (0c6287a)">Diff</a>