### PR TITLE
Correct required "value" property

### DIFF
--- a/schema/localizable.schema.json
+++ b/schema/localizable.schema.json
@@ -17,7 +17,7 @@
           "pattern": "^((?:(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?:([A-Za-z]{2,3}(-(?:[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-(?:[A-Za-z]{4}))?(-(?:[A-Za-z]{2}|[0-9]{3}))?(-(?:[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-(?:[0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(?:x(-[A-Za-z0-9]{1,8})+))?)|(?:x(-[A-Za-z0-9]{1,8})+))$"
         }
       },
-      "required": ["@value"]
+      "required": ["value"]
     },
     {
       "type": "array",
@@ -33,7 +33,7 @@
           }
         },
         "uniqueItems": true,
-        "required": ["@value"]
+        "required": ["value"]
       }
     }
   ]


### PR DESCRIPTION
I noticed for localizable strings that we define "value" but require "@value". This PR assumes the former is correct.