### PR TITLE
Minor modification on the language and base direction section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1284,6 +1284,12 @@ partial dictionary PublicationManifest {
 							table of contents on the right hand side for publications whose natural base direction is
 							right-to-left).</p>
 
+						<p class="note">It is important to differentiate the language <em>of the publication</em>
+							from the language and the base direction of the individual resources that compose it. If
+							such resources are, for example, in HTML, the language and direction need to be set in
+							those resources, too. The language and base direction of the publication are not
+							inherited.</p>
+
 						<p>Similarly, each natural language property value in the manifest (e.g., <a href="#pub-title"
 								>title</a>, <a href="#creators">creators</a>) is a <a href="#value-localizable-string"
 								>localizable string</a>.</p>
@@ -1383,12 +1389,6 @@ partial dictionary PublicationManifest {
 							<p>When specified, these properties are also used as defaults for textual values in the
 								manifest.</p>
 
-							<p class="note">It is important to differentiate the language <em>of the publication</em>
-								from the language and the base direction of the individual resources that compose it. If
-								such resources are, for example, in HTML, the language and direction need to be set in
-								those resources, too. The language and base direction of the publication are not
-								inherited.</p>
-
 							<p>The global language information MAY be overridden by <a
 									href="#manifest-specific-language-and-dir">individual values</a>.</p>
 
@@ -1403,8 +1403,7 @@ partial dictionary PublicationManifest {
 									href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"><code>dir</code></a>
 								attributes in&#160;[[!html]]).</p>
 
-							<p class="issue">It is to be discussed whether this last paragraph, i.e., inheriting values
-								from <code>script</code>, should be kept.</p>
+							<p class="issue" data-number=438></p>
 
 							<p class="note">If authors intend to use a manifest, or a manifest template, both as
 								embedded manifest and as a separate resource, they are strongly encouraged to set these


### PR DESCRIPTION
@dbaron had a comment in https://github.com/w3ctag/design-reviews/issues/344#issuecomment-485034489:

> The description of default language and base direction seems a bit confusing. It seems to imply it's a default for the manifest and the publication, but then there's a note that says it only applies to the manifest and not to the resources that comprise the publication.

I agree it was not clear. I have moved the relevant note to the beginning of the section to make the distinction between the language/direction of the publication and the language/direction of the individual resources. I hope this change is enough.

I have also added an explicit reference to the issue on whether lang/dir is inherited when the manifest is embedded.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/439.html" title="Last updated on May 9, 2019, 6:37 PM UTC (6d535a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/439/91abe8d...6d535a3.html" title="Last updated on May 9, 2019, 6:37 PM UTC (6d535a3)">Diff</a>