### PR TITLE
Remove duplicate instance of datePublished

### DIFF
--- a/index.html
+++ b/index.html
@@ -4945,15 +4945,6 @@ dictionary LinkedResource {
 					</tr>
 					<tr>
 						<td>
-							<code>datePublished</code>
-						</td>
-						<td>
-							<a href="#publication-date"></a>
-						</td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>
 							<code>duration</code>
 						</td>
 						<td>


### PR DESCRIPTION
This PR fixes #437 by removing the duplicate instance of datePublished from the property index.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/447.html" title="Last updated on May 21, 2019, 4:27 PM UTC (0b01351)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/447/a2f2254...0b01351.html" title="Last updated on May 21, 2019, 4:27 PM UTC (0b01351)">Diff</a>