### PR TITLE
Change expected a11y property values to an informative note

### DIFF
--- a/common/js/biblio.js
+++ b/common/js/biblio.js
@@ -128,5 +128,9 @@ var biblio = {
     "bibtex": {
          "title": "BibTeX Format Description",
          "href" : "http://www.bibtex.org/Format/"
+    },
+    "webschemas-a11y": {
+    	"title": "WebSchemas Accessibility",
+    	"href": "http://www.w3.org/wiki/WebSchemas/Accessibility"
     }
 }

--- a/index.html
+++ b/index.html
@@ -735,9 +735,7 @@ enum ProgressionDirection {
 									</td>
 									<td> The human sensory perceptual system or cognitive faculty through which a person
 										may process or perceive information. </td>
-									<td> One or more text(s). <a
-											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-											>Expected values</a>. </td>
+									<td>One or more text(s).</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
 									</td>
@@ -753,9 +751,7 @@ enum ProgressionDirection {
 									</td>
 									<td> A list of single or combined accessModes that are sufficient to understand all
 										the intellectual content of a resource. </td>
-									<td> One or more <a href="https://schema.org/ItemList">ItemList</a>. <a
-											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-											>Expected values</a>. </td>
+									<td> One or more <a href="https://schema.org/ItemList">ItemList</a>.</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
 									</td>
@@ -772,9 +768,7 @@ enum ProgressionDirection {
 									</td>
 									<td>Indicates that the resource is compatible with the referenced accessibility
 										APIs. </td>
-									<td>One or more text(s).<a
-											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-											>Expected values</a>. </td>
+									<td>One or more text(s).</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
 									</td>
@@ -790,9 +784,7 @@ enum ProgressionDirection {
 									</td>
 									<td>Identifies input methods that are sufficient to fully control the described
 										resource. </td>
-									<td> One or more text(s). <a
-											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-											>Expected values</a>. </td>
+									<td> One or more text(s).</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
 									</td>
@@ -809,9 +801,7 @@ enum ProgressionDirection {
 									</td>
 									<td> Content features of the resource, such as accessible media, alternatives and
 										supported enhancements for accessibility. </td>
-									<td> One or more text(s). <a
-											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-											>Expected values</a>. </td>
+									<td> One or more text(s).</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
 									</td>
@@ -828,9 +818,7 @@ enum ProgressionDirection {
 									</td>
 									<td> A characteristic of the described resource that is physiologically dangerous to
 										some users. </td>
-									<td> One or more text(s).<a
-											href="https://www.w3.org/wiki/WebSchemas/Accessibility#accessibilityFeature_in_detail"
-											>Expected values</a>. </td>
+									<td> One or more text(s).</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
 									</td>
@@ -862,8 +850,8 @@ enum ProgressionDirection {
 							</tbody>
 						</table>
 
-						<p>Detailed descriptions of these properties are available on the <a
-								href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas Wiki site</a>.</p>
+						<p class="note">Detailed descriptions of these properties, including the expected values to use
+							with them, are available at [[webschemas-a11y]].</p>
 
 						<p>Values SHOULD be drawn from the <a
 								href="https://www.w3.org/wiki/WebSchemas/Accessibility#property-table">preferred
@@ -2932,17 +2920,6 @@ enum ProgressionDirection {
 						<li><p>Perform data cleanup operations on <var>manifest</var>, possibly removing data, as well
 								as raising warnings.</p>
 							<ol>
-								<!--<li>For all the terms defined in <a href="#accessibility"></a>, except for
-										<code>accessModeSufficient</code> and <code>accessibilitySummary</code>, check
-									whether all tokens listed in <var>manifest[term]</var> are defined in the preferred
-									vocabulary (see the <a
-										href="https://www.w3.org/wiki/WebSchemas/Accessibility#property-table">list of
-										expected values</a> for each). Issue a warning for each unrecognized value. </li>
-								<li>For all values in <var>manifest["accessModeSufficient"]</var>, check whether each
-									token in each <a href="https://schema.org/ItemList">ItemList</a> [[!schema.org]] is
-									defined in the preferred vocabulary (see the <a
-										href="https://www.w3.org/wiki/WebSchemas/Accessibility#property-table">list of
-										expected values</a>). Issue a warning for all unrecognized values. </li> -->
 								<li>For all <var>term</var> that expect <a href="#value-object-entity">entities</a>,
 									check whether the value object <var>P</var> in <var>manifest[term]</var> has
 										<var>P["name"]</var> set. If not, remove <var>P</var> from

--- a/index.html
+++ b/index.html
@@ -1306,9 +1306,6 @@ enum ProgressionDirection {
 						<p>No default values are specified for the <a>language</a> or the default <a>base
 							direction</a>.</p>
 
-						<p class="issue" data-number="354">Proposal for handling localizable texts (writeup of the F2F
-							discussions)</p>
-
 						<section id="manifest-default-language-and-dir">
 							<h6>Global Language and Direction</h6>
 

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -120,55 +120,43 @@
     "accessMode": {
       "type": ["string", "array"],
       "items": {
-        "type": "string",
-        "enum": ["auditory", "tactile", "textual", "visual", "colorDependent", "chartOnVisual", "chemOnVisual", "diagramOnVisual", "mathOnVisual", "musicOnVisual", "textOnVisual"]
+        "type": "string"
       },
-      "enum": ["auditory", "tactile", "textual", "visual", "colorDependent", "chartOnVisual", "chemOnVisual", "diagramOnVisual", "mathOnVisual", "musicOnVisual", "textOnVisual"],
       "uniqueItems": true
     },
     "accessModeSufficient": {
       "type": ["string", "array"],
       "items": {
-        "type": "string",
-        "enum": ["auditory", "tactile", "textual", "visual"]
+        "type": "string"
       },
-      "enum": ["auditory", "tactile", "textual", "visual"],
       "uniqueItems": true
     },
     "accessibilityAPI": {
       "type": ["string", "array"],
       "items": {
-        "type": "string",
-        "enum": ["AndroidAccessibility", "ARIA", "ATK", "AT-SPI", "BlackberryAccessibility", "iAccessible2", "iOSAccessibility", "JavaAccessibility", "MacOSXAccessibility", "MSAA", "UIAutomation"]
+        "type": "string"
       },
-      "uniqueItems": true,
-      "enum": ["AndroidAccessibility", "ARIA", "ATK", "AT-SPI", "BlackberryAccessibility", "iAccessible2", "iOSAccessibility", "JavaAccessibility", "MacOSXAccessibility", "MSAA", "UIAutomation"]
+      "uniqueItems": true
     },
     "accessibilityControl": {
       "type": ["string", "array"],
       "items": {
-        "type": "string",
-        "enum": ["fullKeyboardControl", "fullMouseControl", "fullSwitchControl", "fullTouchControl", "fullVideoControl", "fullVoiceControl"]
+        "type": "string"
       },
-      "enum": ["fullKeyboardControl", "fullMouseControl", "fullSwitchControl", "fullTouchControl", "fullVideoControl", "fullVoiceControl"],
       "uniqueItems": true
     },
     "accessibilityFeature": {
       "type": ["string", "array"],
       "items": {
-        "type": "string",
-        "enum": ["alternativeText", "annotations", "audioDescription", "bookmarks", "braille", "captions", "ChemML", "describedMath", "displayTransformability", "highContrastAudio", "highContrastDisplay", "index", "largePrint", "latex", "longDescription", "MathML", "none", "printPageNumbers", "readingOrder", "rubyAnnotations", "signLanguage", "structuralNavigation", "synchronizedAudioText", "tableOfContents", "taggedPDF", "tactileGraphic", "tactileObject", "timingControl", "transcript", "ttsMarkup", "unlocked"]
+        "type": "string"
       },
-      "enum": ["alternativeText", "annotations", "audioDescription", "bookmarks", "braille", "captions", "ChemML", "describedMath", "displayTransformability", "highContrastAudio", "highContrastDisplay", "index", "largePrint", "latex", "longDescription", "MathML", "none", "printPageNumbers", "readingOrder", "rubyAnnotations", "signLanguage", "structuralNavigation", "synchronizedAudioText", "tableOfContents", "taggedPDF", "tactileGraphic", "tactileObject", "timingControl", "transcript", "ttsMarkup", "unlocked"],
       "uniqueItems": true
     },
     "accessibilityHazard": {
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": ["flashing", "noFlashingHazard", "motionSimulation", "noMotionSimulationHazard", "sound", "noSoundHazard", "unknown", "none"]
+        "type": "string"
       },
-      "enum": ["flashing", "noFlashingHazard", "motionSimulation", "noMotionSimulationHazard", "sound", "noSoundHazard", "unknown", "none"],
       "uniqueItems": true
     },
     "accessibilitySummary": {


### PR DESCRIPTION
This PR removes the "Expected Value" links for the accessibility properties from the definition table, since these were never meant as a restrictive set.

I've instead changed the paragraph after the definition table that directed people to the Web Schemas wiki to a note, and indicate in it that the expected values are listed there. The reference is now informative, as a result, and listed in the biblio file.

I've also fully removed the paragraphs about issuing warnings for unknown values from the manifest post-processing step. It's not invalid to use values other than those listed in the wiki; those are just the formally recognized values. Validating the values, and how best to inform about unknown values, shouldn't be in the user agent space.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/pull/449.html" title="Last updated on May 23, 2019, 1:01 PM UTC (fc5ea8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wpub/449/a5149c7...fc5ea8c.html" title="Last updated on May 23, 2019, 1:01 PM UTC (fc5ea8c)">Diff</a>